### PR TITLE
order of fields is incorrect

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -70,8 +70,8 @@ pub fn parse_compact_data(data: &[CompactData]) -> Vec<MarketEvent> {
                         let mut j = 0;
                         while j + 5 < values.len() {
                             if let (
-                                Some(symbol),
                                 Some(_), // event_type
+                                Some(symbol),
                                 Some(bid_price),
                                 Some(ask_price),
                                 Some(bid_size),
@@ -101,8 +101,8 @@ pub fn parse_compact_data(data: &[CompactData]) -> Vec<MarketEvent> {
                         let mut j = 0;
                         while j + 4 < values.len() {
                             if let (
-                                Some(symbol),
                                 Some(_), // event_type
+                                Some(symbol),
                                 Some(price),
                                 Some(size),
                                 Some(day_volume),
@@ -128,8 +128,8 @@ pub fn parse_compact_data(data: &[CompactData]) -> Vec<MarketEvent> {
                         let mut j = 0;
                         while j + 7 < values.len() {
                             if let (
-                                Some(symbol),
                                 Some(_), // event_type
+                                Some(symbol),
                                 Some(delta),
                                 Some(gamma),
                                 Some(theta),


### PR DESCRIPTION
The order of deserializing is incorrect, so the MarketEvent's deserialized always have symbol as "Quote", "Trade" and "Greeks".  This make `DXLinkClient::on_event` not work because the symbol will never matched.