### PR TITLE
Skip WebSocket control frames instead of failing the connection (#4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dxlink"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 license = "MIT"
 description = "Library for trading through tastytrade's API"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ include = [
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tokio-tungstenite = { version = "0.28", features = ["native-tls"] }
-tokio = { version = "1.49", features = ["full"] }
+tokio-tungstenite = { version = "0.30", features = ["native-tls"] }
+tokio = { version = "1.53", features = ["full"] }
 futures-util = "0.3"
 tracing = "0.1"
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -541,9 +541,15 @@ impl DXLinkClient {
                             }
                         }
                     }
+                    // The connection is gone: reading the same dead socket again
+                    // can only fail, so stop instead of spinning forever.
+                    Err(e) if e.is_terminal() => {
+                        error!("Connection lost, stopping message processing: {}", e);
+                        break;
+                    }
                     Err(e) => {
                         error!("Error receiving message: {}", e);
-                        // Una pequeña pausa para no saturar logs en caso de errores repetidos
+                        // A short pause so repeated errors do not flood the logs
                         tokio::time::sleep(Duration::from_millis(100)).await;
                     }
                 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1206,6 +1206,57 @@ mod tests {
         }
     }
 
+    /// The message task must stop once the connection is gone, instead of
+    /// re-reading a dead socket every 100ms forever (issue #4).
+    #[tokio::test]
+    async fn test_message_task_stops_when_server_closes() {
+        use tokio::net::TcpListener;
+        use tokio_tungstenite::accept_async;
+
+        // A bare WebSocket server that accepts the handshake and immediately
+        // hangs up. No DXLink handshake is needed: start_message_processing only
+        // requires a live connection.
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("failed to bind test server");
+        let addr = listener.local_addr().expect("failed to read local addr");
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("failed to accept");
+            let ws = accept_async(stream).await.expect("failed to handshake");
+            drop(ws);
+        });
+
+        let mut client = DXLinkClient::new(&format!("ws://{}", addr), "test_token");
+        client.connection = Some(
+            crate::connection::WebSocketConnection::connect(&format!("ws://{}", addr))
+                .await
+                .expect("failed to connect"),
+        );
+
+        client
+            .start_message_processing()
+            .expect("failed to start message processing");
+
+        let handle = client
+            .message_handle
+            .as_ref()
+            .expect("message task should have been spawned");
+
+        // Generous bound: the point is that it terminates at all, not how fast.
+        let stopped = tokio::time::timeout(Duration::from_secs(5), async {
+            while !handle.is_finished() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+
+        assert!(
+            stopped.is_ok(),
+            "message task kept running after the server closed the connection"
+        );
+    }
+
     // Test error cases for connection
     #[test]
     fn test_connection_errors() {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1240,21 +1240,17 @@ mod tests {
 
         let handle = client
             .message_handle
-            .as_ref()
+            .take()
             .expect("message task should have been spawned");
 
-        // Generous bound: the point is that it terminates at all, not how fast.
-        let stopped = tokio::time::timeout(Duration::from_secs(5), async {
-            while !handle.is_finished() {
-                tokio::time::sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await;
+        // Awaiting the handle rather than polling is_finished() also fails the
+        // test if the task panicked on its way out. Generous bound: the point is
+        // that it terminates at all, not how fast.
+        let joined = tokio::time::timeout(Duration::from_secs(5), handle)
+            .await
+            .expect("message task kept running after the server closed the connection");
 
-        assert!(
-            stopped.is_ok(),
-            "message task kept running after the server closed the connection"
-        );
+        joined.expect("message task panicked instead of stopping cleanly");
     }
 
     // Test error cases for connection

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -20,6 +20,39 @@ use tracing::{debug, error};
 /// Placeholder written in place of credential values when logging outbound messages.
 const REDACTED_PLACEHOLDER: &str = "<redacted>";
 
+/// Maximum number of characters kept from a server-supplied close reason.
+const MAX_CLOSE_REASON_LEN: usize = 120;
+
+/// Longest unbroken run kept verbatim in a close reason. Real reasons are made
+/// of short words; anything longer has the shape of a credential.
+const MAX_CLOSE_REASON_WORD_LEN: usize = 32;
+
+/// Returns a close reason that is safe to log and to embed in an error.
+///
+/// The reason is free text chosen by the server, and it reaches both the logs
+/// and [`DXLinkError::Connection`]. The close path is also the authentication
+/// failure path, so a server that echoed the auth token back would turn our own
+/// error reporting into a credential leak. Control characters are dropped, runs
+/// too long to be a word are masked with [`REDACTED_PLACEHOLDER`], and the
+/// result is truncated. The close code is a protocol enum and is always kept.
+fn sanitize_close_reason(reason: &str) -> String {
+    let printable: String = reason.chars().filter(|c| !c.is_control()).collect();
+
+    let masked = printable
+        .split_whitespace()
+        .map(|word| {
+            if word.chars().count() > MAX_CLOSE_REASON_WORD_LEN {
+                REDACTED_PLACEHOLDER
+            } else {
+                word
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+
+    masked.chars().take(MAX_CLOSE_REASON_LEN).collect()
+}
+
 /// Returns a copy of a serialized message that is safe to log.
 ///
 /// Credential-bearing fields (any field named `token`, at any nesting level)
@@ -184,11 +217,27 @@ impl WebSocketConnection {
                     debug!("Skipping WebSocket control frame: {:?}", message);
                 }
                 Some(Ok(Message::Close(frame))) => {
+                    // The code is a protocol enum and is trusted; the reason is
+                    // free text from the server and is not.
                     let detail = match frame {
-                        Some(frame) => format!("code {}, reason: {}", frame.code, frame.reason),
+                        Some(frame) => format!(
+                            "code {}, reason: {}",
+                            frame.code,
+                            sanitize_close_reason(&frame.reason)
+                        ),
                         None => "no close frame".to_string(),
                     };
                     error!("Server closed the connection: {}", detail);
+
+                    // Closing is a handshake. tungstenite queues the reply when
+                    // this frame is yielded, but on a split stream it only
+                    // reaches the peer once the write half is driven, so do that
+                    // before giving up on the socket. Failing here changes
+                    // nothing for the caller: the connection is gone either way.
+                    if let Err(e) = self.write.lock().await.close().await {
+                        debug!("Could not complete the close handshake: {}", e);
+                    }
+
                     return Err(DXLinkError::Connection(format!(
                         "server closed the connection ({})",
                         detail
@@ -409,6 +458,33 @@ mod frame_tests {
         }
     }
 
+    /// The close path is the authentication failure path, so a server that
+    /// echoes the token back must not get it into our error text or our logs.
+    #[tokio::test]
+    async fn test_close_reason_cannot_leak_a_credential() {
+        let token = "tastytrade-live-bearer-token-that-is-long-enough-to-be-a-secret";
+        let url = serve_frames(vec![Message::Close(Some(CloseFrame {
+            code: CloseCode::Policy,
+            reason: format!("rejected token {token}").into(),
+        }))])
+        .await;
+
+        let connection = WebSocketConnection::connect(&url)
+            .await
+            .expect("failed to connect");
+
+        let err = connection
+            .receive()
+            .await
+            .expect_err("a close frame must not be reported as success");
+
+        let text = err.to_string();
+        assert!(!text.contains(token), "token leaked into the error: {text}");
+        assert!(text.contains(REDACTED_PLACEHOLDER));
+        // The close code still has to survive, it is the actionable part.
+        assert!(text.contains("code"), "close code lost: {text}");
+    }
+
     #[tokio::test]
     async fn test_close_error_is_terminal() {
         let url = serve_frames(vec![Message::Close(None)]).await;
@@ -423,6 +499,49 @@ mod frame_tests {
             .expect_err("a close frame must not be reported as success");
         // This is what stops the message task instead of letting it spin.
         assert!(err.is_terminal(), "close should be terminal, got: {err:?}");
+    }
+
+    /// Closing is a handshake: when the peer sends Close we must send one back
+    /// before giving up on the socket, or the connection is left half closed.
+    #[tokio::test]
+    async fn test_receive_completes_the_close_handshake() {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("failed to bind test server");
+        let addr = listener.local_addr().expect("failed to read local addr");
+
+        let echoed = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("failed to accept");
+            let mut ws = accept_async(stream).await.expect("failed to handshake");
+
+            ws.send(Message::Close(Some(CloseFrame {
+                code: CloseCode::Normal,
+                reason: "bye".into(),
+            })))
+            .await
+            .expect("failed to send close");
+
+            // Wait for the client's half of the close handshake.
+            loop {
+                match ws.next().await {
+                    Some(Ok(Message::Close(_))) | None => return true,
+                    Some(Ok(_)) => continue,
+                    Some(Err(_)) => return false,
+                }
+            }
+        });
+
+        let connection = WebSocketConnection::connect(&format!("ws://{}", addr))
+            .await
+            .expect("failed to connect");
+
+        let _ = connection.receive().await;
+
+        let replied = tokio::time::timeout(Duration::from_secs(3), echoed)
+            .await
+            .expect("server never saw the client's close reply")
+            .expect("server task panicked");
+        assert!(replied, "client did not complete the close handshake");
     }
 
     #[tokio::test]
@@ -558,6 +677,52 @@ mod redaction_tests {
     #[test]
     fn test_redact_sensitive_withholds_unparseable_payloads() {
         assert_eq!(redact_sensitive("not json"), REDACTED_PLACEHOLDER);
+    }
+
+    #[test]
+    fn test_sanitize_close_reason_keeps_ordinary_text() {
+        // The diagnostic value of a close reason is the whole point of keeping
+        // it, so normal wording must survive untouched.
+        assert_eq!(
+            sanitize_close_reason("invalid token, please re-authenticate"),
+            "invalid token, please re-authenticate"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_close_reason_masks_credential_shaped_runs() {
+        let token = "a".repeat(64);
+        let sanitized = sanitize_close_reason(&format!("rejected token {token} for user bob"));
+
+        assert!(!sanitized.contains(&token), "token survived: {sanitized}");
+        assert!(sanitized.contains(REDACTED_PLACEHOLDER));
+        // Everything that is not credential-shaped is still readable.
+        assert!(sanitized.contains("rejected token"));
+        assert!(sanitized.contains("for user bob"));
+    }
+
+    #[test]
+    fn test_sanitize_close_reason_drops_control_characters() {
+        let sanitized = sanitize_close_reason("bad\u{0}token\nsecond line\u{7}");
+
+        assert!(!sanitized.contains('\u{0}'));
+        assert!(!sanitized.contains('\u{7}'));
+        assert!(!sanitized.contains('\n'));
+    }
+
+    #[test]
+    fn test_sanitize_close_reason_is_bounded() {
+        // Many short words: nothing is credential-shaped, so only the overall
+        // length limit applies.
+        let long = "word ".repeat(200);
+        let sanitized = sanitize_close_reason(&long);
+
+        assert_eq!(sanitized.chars().count(), MAX_CLOSE_REASON_LEN);
+    }
+
+    #[test]
+    fn test_sanitize_close_reason_handles_empty_input() {
+        assert_eq!(sanitize_close_reason(""), "");
     }
 
     /// A `MakeWriter` that captures log output into a shared buffer so tests

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -150,10 +150,16 @@ impl WebSocketConnection {
 
     /// Receives a text message from the WebSocket connection.
     ///
-    /// This function attempts to read the next message from the WebSocket stream.
-    /// It expects the message to be a text message. If a non-text message or an error
-    /// is encountered, an appropriate error is returned.  If the connection is closed
-    /// unexpectedly, an error is also returned.
+    /// DXLink is a text-JSON protocol, so only `Text` frames carry payloads.
+    /// WebSocket control frames (`Ping`, `Pong`) are ordinary transport traffic —
+    /// the underlying library answers Pings on its own but still surfaces them
+    /// here — so they are skipped and reading continues until a payload arrives.
+    ///
+    /// A `Close` frame is reported as [`DXLinkError::Connection`] rather than as
+    /// an unexpected message: a server that closes is usually saying something
+    /// specific (bad token, unsupported version) and that belongs in the error
+    /// text. A `Binary` frame is a genuine protocol anomaly for DXLink and is
+    /// rejected as [`DXLinkError::UnexpectedMessage`].
     ///
     /// # Returns
     ///
@@ -164,26 +170,47 @@ impl WebSocketConnection {
     pub async fn receive(&self) -> DXLinkResult<String> {
         let mut read = self.read.lock().await;
 
-        match read.next().await {
-            Some(Ok(Message::Text(text))) => {
-                debug!("Received message: {}", text);
-                Ok(text.to_string())
-            }
-            Some(Ok(message)) => {
-                debug!("Received non-text message: {:?}", message);
-                Err(DXLinkError::UnexpectedMessage(
-                    "Expected text message".to_string(),
-                ))
-            }
-            Some(Err(e)) => {
-                error!("WebSocket error: {}", e);
-                Err(DXLinkError::WebSocket(Box::new(e)))
-            }
-            None => {
-                error!("WebSocket connection closed unexpectedly");
-                Err(DXLinkError::Connection(
-                    "Connection closed unexpectedly".to_string(),
-                ))
+        loop {
+            match read.next().await {
+                Some(Ok(Message::Text(text))) => {
+                    debug!("Received message: {}", text);
+                    return Ok(text.to_string());
+                }
+                // Control frames are normal protocol traffic, not a protocol error.
+                // `Frame` is documented by tungstenite as never yielded while
+                // reading; the arm is defensive so a future change cannot make it
+                // fatal by accident.
+                Some(Ok(message @ (Message::Ping(_) | Message::Pong(_) | Message::Frame(_)))) => {
+                    debug!("Skipping WebSocket control frame: {:?}", message);
+                }
+                Some(Ok(Message::Close(frame))) => {
+                    let detail = match frame {
+                        Some(frame) => format!("code {}, reason: {}", frame.code, frame.reason),
+                        None => "no close frame".to_string(),
+                    };
+                    error!("Server closed the connection: {}", detail);
+                    return Err(DXLinkError::Connection(format!(
+                        "server closed the connection ({})",
+                        detail
+                    )));
+                }
+                Some(Ok(Message::Binary(bytes))) => {
+                    debug!("Received binary frame of {} bytes", bytes.len());
+                    return Err(DXLinkError::UnexpectedMessage(format!(
+                        "Expected text message, got a binary frame of {} bytes",
+                        bytes.len()
+                    )));
+                }
+                Some(Err(e)) => {
+                    error!("WebSocket error: {}", e);
+                    return Err(DXLinkError::WebSocket(Box::new(e)));
+                }
+                None => {
+                    error!("WebSocket connection closed unexpectedly");
+                    return Err(DXLinkError::Connection(
+                        "Connection closed unexpectedly".to_string(),
+                    ));
+                }
             }
         }
     }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -315,6 +315,192 @@ impl KeepAliveSender {
 }
 
 #[cfg(test)]
+mod frame_tests {
+    //! Frame-level tests for [`WebSocketConnection::receive`].
+    //!
+    //! These drive the server side with `tokio_tungstenite::accept_async` rather
+    //! than warp, because the whole point is emitting specific frame kinds — a
+    //! Ping, or a Close with a chosen code — which warp does not expose cleanly.
+    //! Every server binds an ephemeral port so the suite stays parallel-safe.
+
+    use super::*;
+    use futures_util::SinkExt;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::accept_async;
+    use tokio_tungstenite::tungstenite::protocol::frame::CloseFrame;
+    use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+
+    /// Starts a server that sends `frames` to the first client that connects and
+    /// then keeps the socket open. Returns the URL to connect to.
+    async fn serve_frames(frames: Vec<Message>) -> String {
+        serve_frames_after(frames, Duration::ZERO).await
+    }
+
+    /// As [`serve_frames`], but waits `delay` before sending anything.
+    async fn serve_frames_after(frames: Vec<Message>, delay: Duration) -> String {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("failed to bind test server");
+        let addr = listener.local_addr().expect("failed to read local addr");
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("failed to accept");
+            let mut ws = accept_async(stream).await.expect("failed to handshake");
+
+            if !delay.is_zero() {
+                tokio::time::sleep(delay).await;
+            }
+
+            for frame in frames {
+                let is_close = matches!(frame, Message::Close(_));
+                ws.send(frame).await.expect("failed to send frame");
+                if is_close {
+                    return;
+                }
+            }
+
+            // Hold the connection open so a timeout test observes silence rather
+            // than a close.
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        });
+
+        format!("ws://{}", addr)
+    }
+
+    #[tokio::test]
+    async fn test_receive_skips_control_frames_and_returns_following_text() {
+        let url = serve_frames(vec![
+            Message::Ping(vec![1, 2, 3].into()),
+            Message::Pong(Vec::new().into()),
+            Message::Text("{\"type\":\"SETUP\"}".into()),
+        ])
+        .await;
+
+        let connection = WebSocketConnection::connect(&url)
+            .await
+            .expect("failed to connect");
+
+        let received = connection
+            .receive()
+            .await
+            .expect("control frames should be skipped, not fatal");
+        assert_eq!(received, "{\"type\":\"SETUP\"}");
+    }
+
+    #[tokio::test]
+    async fn test_receive_reports_close_as_connection_error() {
+        let url = serve_frames(vec![Message::Close(Some(CloseFrame {
+            code: CloseCode::Policy,
+            reason: "invalid token".into(),
+        }))])
+        .await;
+
+        let connection = WebSocketConnection::connect(&url)
+            .await
+            .expect("failed to connect");
+
+        match connection.receive().await {
+            Err(DXLinkError::Connection(msg)) => {
+                // The reason is what tells an operator why the server hung up,
+                // so it has to survive into the error text.
+                assert!(msg.contains("invalid token"), "close reason lost: {msg}");
+            }
+            other => panic!("expected Connection error, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_close_error_is_terminal() {
+        let url = serve_frames(vec![Message::Close(None)]).await;
+
+        let connection = WebSocketConnection::connect(&url)
+            .await
+            .expect("failed to connect");
+
+        let err = connection
+            .receive()
+            .await
+            .expect_err("a close frame must not be reported as success");
+        // This is what stops the message task instead of letting it spin.
+        assert!(err.is_terminal(), "close should be terminal, got: {err:?}");
+    }
+
+    #[tokio::test]
+    async fn test_receive_rejects_binary_frames() {
+        let url = serve_frames(vec![Message::Binary(vec![1, 2, 3].into())]).await;
+
+        let connection = WebSocketConnection::connect(&url)
+            .await
+            .expect("failed to connect");
+
+        match connection.receive().await {
+            Err(DXLinkError::UnexpectedMessage(msg)) => {
+                assert!(msg.contains("binary"), "unhelpful error text: {msg}");
+            }
+            other => panic!("expected UnexpectedMessage error, got: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_binary_error_is_not_terminal() {
+        let url = serve_frames(vec![Message::Binary(vec![0xff].into())]).await;
+
+        let connection = WebSocketConnection::connect(&url)
+            .await
+            .expect("failed to connect");
+
+        let err = connection
+            .receive()
+            .await
+            .expect_err("a binary frame must be rejected");
+        // One bad frame does not mean the connection is gone.
+        assert!(
+            !err.is_terminal(),
+            "binary frame should not kill the connection: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_receive_with_timeout_is_not_woken_by_control_frames() {
+        // Ping first, payload only after a delay: a control frame must not make
+        // the call return early with nothing useful.
+        let url = serve_frames_after(
+            vec![
+                Message::Ping(Vec::new().into()),
+                Message::Text("payload".into()),
+            ],
+            Duration::from_millis(50),
+        )
+        .await;
+
+        let connection = WebSocketConnection::connect(&url)
+            .await
+            .expect("failed to connect");
+
+        let received = connection
+            .receive_with_timeout(Duration::from_secs(5))
+            .await
+            .expect("receive_with_timeout failed");
+        assert_eq!(received, Some("payload".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_receive_with_timeout_returns_none_on_silence() {
+        let url = serve_frames(Vec::new()).await;
+
+        let connection = WebSocketConnection::connect(&url)
+            .await
+            .expect("failed to connect");
+
+        let received = connection
+            .receive_with_timeout(Duration::from_millis(100))
+            .await
+            .expect("receive_with_timeout failed");
+        assert_eq!(received, None);
+    }
+}
+
+#[cfg(test)]
 mod redaction_tests {
     use super::*;
     use crate::messages::{AuthMessage, KeepaliveMessage};

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,11 +34,12 @@ pub enum DXLinkError {
 }
 
 impl DXLinkError {
-    /// Reports whether this error leaves the connection unusable.
+    /// Reports whether this error requires a connection to be (re)established
+    /// before anything can proceed.
     ///
-    /// A terminal error means the WebSocket cannot carry further traffic and the
-    /// caller must establish a new connection to continue; retrying the same
-    /// socket will never succeed. A non-terminal error describes a single bad
+    /// A terminal error means retrying as-is can never succeed: the transport
+    /// failed, the peer went away, the credentials were rejected, or there was no
+    /// live connection to begin with. A non-terminal error describes a single bad
     /// message — the frame was rejected, the connection was not.
     ///
     /// This is what tells a read loop whether to stop or to skip the offending

--- a/src/error.rs
+++ b/src/error.rs
@@ -226,6 +226,30 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_is_terminal_for_connection_level_failures() {
+        // The transport is gone or the credentials were rejected: reading the
+        // same socket again cannot succeed.
+        assert!(DXLinkError::Connection("closed".to_string()).is_terminal());
+        assert!(DXLinkError::Authentication("bad token".to_string()).is_terminal());
+        assert!(
+            DXLinkError::WebSocket(Box::new(tungstenite::Error::ConnectionClosed)).is_terminal()
+        );
+    }
+
+    #[test]
+    fn test_is_terminal_for_message_level_failures() {
+        // These describe one bad message; the connection is still usable, so a
+        // read loop must skip and keep going rather than tear down.
+        let ser_error = serde_json::from_str::<serde_json::Value>("invalid json").unwrap_err();
+        assert!(!DXLinkError::Serialization(ser_error).is_terminal());
+        assert!(!DXLinkError::Channel("no such channel".to_string()).is_terminal());
+        assert!(!DXLinkError::Protocol("unexpected state".to_string()).is_terminal());
+        assert!(!DXLinkError::Timeout("no CHANNEL_OPENED".to_string()).is_terminal());
+        assert!(!DXLinkError::UnexpectedMessage("binary frame".to_string()).is_terminal());
+        assert!(!DXLinkError::Unknown("something".to_string()).is_terminal());
+    }
+
     // Test error conversion and propagation with ?
     #[test]
     fn test_error_propagation() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,45 @@ pub enum DXLinkError {
     Unknown(String),
 }
 
+impl DXLinkError {
+    /// Reports whether this error leaves the connection unusable.
+    ///
+    /// A terminal error means the WebSocket cannot carry further traffic and the
+    /// caller must establish a new connection to continue; retrying the same
+    /// socket will never succeed. A non-terminal error describes a single bad
+    /// message — the frame was rejected, the connection was not.
+    ///
+    /// This is what tells a read loop whether to stop or to skip the offending
+    /// message and keep going.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use dxlink::DXLinkError;
+    ///
+    /// // The peer hung up: nothing more can be read from this socket.
+    /// assert!(DXLinkError::Connection("server closed the connection".to_string()).is_terminal());
+    ///
+    /// // One malformed frame; the connection is still healthy.
+    /// assert!(!DXLinkError::UnexpectedMessage("Expected text message".to_string()).is_terminal());
+    /// ```
+    pub fn is_terminal(&self) -> bool {
+        match self {
+            // The transport itself failed or the peer went away.
+            DXLinkError::WebSocket(_) | DXLinkError::Connection(_) => true,
+            // Retrying with the same rejected credentials cannot succeed.
+            DXLinkError::Authentication(_) => true,
+            // These describe one message, not the state of the connection.
+            DXLinkError::Serialization(_)
+            | DXLinkError::Channel(_)
+            | DXLinkError::Protocol(_)
+            | DXLinkError::Timeout(_)
+            | DXLinkError::UnexpectedMessage(_)
+            | DXLinkError::Unknown(_) => false,
+        }
+    }
+}
+
 impl Display for DXLinkError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -301,7 +301,11 @@ async fn run_full_session(behaviour: Behaviour) {
     assert_eq!(trade.day_volume, 10_000_000.0);
 
     // The callback path is separate from the stream path; both must fire.
-    let delivered = callback_events.lock().expect("callback lock poisoned");
+    // Copy out of the lock in its own scope so no guard reaches the await below.
+    let delivered: Vec<MarketEvent> = {
+        let events = callback_events.lock().expect("callback lock poisoned");
+        events.clone()
+    };
     assert_eq!(
         delivered.len(),
         2,
@@ -380,14 +384,17 @@ async fn test_callback_is_scoped_to_its_symbol() {
     assert!(symbols.contains(&"AAPL"), "AAPL missing from {symbols:?}");
     assert!(symbols.contains(&"MSFT"), "MSFT missing from {symbols:?}");
 
-    let delivered = msft_events.lock().expect("lock poisoned");
+    // Copy out of the lock in its own scope so no guard reaches the await below.
+    let delivered: Vec<MarketEvent> = {
+        let events = msft_events.lock().expect("lock poisoned");
+        events.clone()
+    };
     assert_eq!(delivered.len(), 1, "MSFT callback should fire exactly once");
     match &delivered[0] {
         MarketEvent::Quote(q) => assert_eq!(q.event_symbol, "MSFT"),
         other => panic!("MSFT callback received the wrong event: {other:?}"),
     }
 
-    drop(delivered);
     client.disconnect().await.expect("failed to disconnect");
 }
 

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -1,0 +1,522 @@
+//! End-to-end tests that drive the public API exactly as `examples/miscellaneous/src/bin/basic.rs`
+//! does: connect, open a feed channel, configure it, register a callback, take
+//! the event stream, subscribe, and consume market events.
+//!
+//! Unlike the older suites these assert the *values* that reach the consumer, so
+//! they fail if the COMPACT column order in `setup_feed` and the stride in
+//! `parse_compact_data` ever drift apart — the one defect in this codebase that
+//! produces wrong numbers instead of an error.
+//!
+//! `control_frames` mode interleaves WebSocket Pings with the protocol traffic,
+//! which is the end-to-end regression test for issue #4: before the fix, the
+//! first Ping aborted the handshake and no session was ever established.
+
+use dxlink::{DXLinkClient, EventType, FeedSubscription, MarketEvent};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+/// A DXLink server that speaks enough of the protocol to run a full session,
+/// and can interleave WebSocket control frames with every response.
+mod flow_server {
+    use futures_util::{SinkExt, StreamExt};
+    use serde_json::{Value, json};
+    use std::net::SocketAddr;
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::tungstenite::Message;
+
+    pub struct FlowServer {
+        pub address: SocketAddr,
+        received: Arc<Mutex<Vec<Value>>>,
+    }
+
+    impl FlowServer {
+        /// Every message the client sent, in order.
+        pub fn received(&self) -> Vec<Value> {
+            self.received
+                .lock()
+                .expect("received lock poisoned")
+                .clone()
+        }
+
+        pub fn url(&self) -> String {
+            format!("ws://{}", self.address)
+        }
+    }
+
+    /// What the server does besides answering the protocol.
+    #[derive(Clone, Copy, PartialEq)]
+    pub enum Behaviour {
+        /// Plain text responses only.
+        Plain,
+        /// Send a Ping before, and a Pong after, every response. Control frames
+        /// are ordinary traffic and must never break a session.
+        ControlFrames,
+        /// Complete the handshake, then hang up once the feed is subscribed.
+        CloseAfterSubscribe,
+    }
+
+    /// Column order for COMPACT rows. This MUST match the field list that
+    /// `setup_feed` requests for each event type — the server echoes back the
+    /// fields in the order they were asked for.
+    fn quote_row(symbol: &str) -> Value {
+        // eventType, eventSymbol, bidPrice, askPrice, bidSize, askSize
+        json!(["Quote", symbol, 150.25, 150.5, 100.0, 150.0])
+    }
+
+    fn trade_row(symbol: &str) -> Value {
+        // eventType, eventSymbol, price, size, dayVolume
+        json!(["Trade", symbol, 151.25, 75.0, 10_000_000.0])
+    }
+
+    pub async fn start(behaviour: Behaviour) -> FlowServer {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind flow server");
+        let address = listener.local_addr().expect("failed to read local addr");
+
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let received_task = received.clone();
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("failed to accept");
+            let mut ws = tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("failed to handshake");
+
+            // One task owns the whole socket, so requests and responses stay
+            // ordered and there is no sink to share.
+            while let Some(Ok(message)) = ws.next().await {
+                let Message::Text(text) = message else {
+                    continue;
+                };
+                let Ok(value) = serde_json::from_str::<Value>(&text) else {
+                    continue;
+                };
+
+                received_task
+                    .lock()
+                    .expect("received lock poisoned")
+                    .push(value.clone());
+
+                let channel = value["channel"].as_u64().unwrap_or(0);
+                let mut responses: Vec<Value> = Vec::new();
+                let mut close_after = false;
+
+                match value["type"].as_str().unwrap_or("") {
+                    "SETUP" => {
+                        responses.push(json!({
+                            "channel": channel,
+                            "type": "SETUP",
+                            "version": "1.0.0",
+                            "keepaliveTimeout": 60,
+                            "acceptKeepaliveTimeout": 60
+                        }));
+                        responses.push(json!({
+                            "channel": 0,
+                            "type": "AUTH_STATE",
+                            "state": "UNAUTHORIZED"
+                        }));
+                    }
+                    "AUTH" => responses.push(json!({
+                        "channel": 0,
+                        "type": "AUTH_STATE",
+                        "state": "AUTHORIZED",
+                        "userId": "test-user"
+                    })),
+                    "CHANNEL_REQUEST" => responses.push(json!({
+                        "channel": channel,
+                        "type": "CHANNEL_OPENED",
+                        "service": "FEED",
+                        "parameters": {}
+                    })),
+                    "FEED_SETUP" => responses.push(json!({
+                        "channel": channel,
+                        "type": "FEED_CONFIG",
+                        "aggregationPeriod": 0.1,
+                        "dataFormat": "COMPACT"
+                    })),
+                    "FEED_SUBSCRIPTION" => {
+                        if let Some(add) = value.get("add").and_then(|a| a.as_array()) {
+                            for sub in add {
+                                let symbol = sub["symbol"].as_str().unwrap_or("");
+                                let row = match sub["type"].as_str().unwrap_or("") {
+                                    "Quote" => quote_row(symbol),
+                                    "Trade" => trade_row(symbol),
+                                    _ => continue,
+                                };
+                                let event_type = sub["type"].as_str().unwrap_or("");
+                                responses.push(json!({
+                                    "channel": channel,
+                                    "type": "FEED_DATA",
+                                    "data": [event_type, row]
+                                }));
+                            }
+                        }
+                        close_after = behaviour == Behaviour::CloseAfterSubscribe;
+                    }
+                    // KEEPALIVE and anything else needs no reply.
+                    _ => {}
+                }
+
+                for response in responses {
+                    if behaviour == Behaviour::ControlFrames {
+                        ws.send(Message::Ping(vec![7].into()))
+                            .await
+                            .expect("failed to send ping");
+                    }
+
+                    ws.send(Message::Text(response.to_string().into()))
+                        .await
+                        .expect("failed to send response");
+
+                    if behaviour == Behaviour::ControlFrames {
+                        ws.send(Message::Pong(Vec::new().into()))
+                            .await
+                            .expect("failed to send pong");
+                    }
+                }
+
+                if close_after {
+                    let _ = ws.send(Message::Close(None)).await;
+                    return;
+                }
+            }
+        });
+
+        FlowServer { address, received }
+    }
+}
+
+use flow_server::Behaviour;
+
+/// Collects events off the stream until `wanted` have arrived or time runs out.
+async fn collect_events(
+    stream: &mut tokio::sync::mpsc::Receiver<MarketEvent>,
+    wanted: usize,
+) -> Vec<MarketEvent> {
+    let mut events = Vec::new();
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+
+    while events.len() < wanted {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match tokio::time::timeout(remaining, stream.recv()).await {
+            Ok(Some(event)) => events.push(event),
+            // Channel closed or deadline hit; return what we have and let the
+            // caller's assertion report the shortfall.
+            Ok(None) | Err(_) => break,
+        }
+    }
+
+    events
+}
+
+/// Runs the same sequence as the `basic` example and checks the market data that
+/// comes out the other end, field by field.
+async fn run_full_session(behaviour: Behaviour) {
+    let server = flow_server::start(behaviour).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+
+    client
+        .setup_feed(channel_id, &[EventType::Quote, EventType::Trade])
+        .await
+        .expect("failed to set up feed");
+
+    // A callback scoped to one symbol, exactly as the example registers it.
+    let callback_events = Arc::new(Mutex::new(Vec::new()));
+    let callback_sink = callback_events.clone();
+    client.on_event("AAPL", move |event| {
+        callback_sink
+            .lock()
+            .expect("callback lock poisoned")
+            .push(event);
+    });
+
+    client
+        .subscribe(
+            channel_id,
+            vec![
+                FeedSubscription {
+                    event_type: "Quote".to_string(),
+                    symbol: "AAPL".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+                FeedSubscription {
+                    event_type: "Trade".to_string(),
+                    symbol: "AAPL".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+            ],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    let events = collect_events(&mut event_stream, 2).await;
+    assert_eq!(
+        events.len(),
+        2,
+        "expected a Quote and a Trade to reach the stream, got {events:?}"
+    );
+
+    let quote = events
+        .iter()
+        .find_map(|e| match e {
+            MarketEvent::Quote(q) => Some(q),
+            _ => None,
+        })
+        .expect("no Quote event reached the consumer");
+
+    // The symbol is the assertion that catches a COMPACT column-order drift: if
+    // eventType and eventSymbol swap, this reads "Quote" instead of "AAPL".
+    assert_eq!(quote.event_symbol, "AAPL");
+    assert_eq!(quote.event_type, "Quote");
+    assert_eq!(quote.bid_price, 150.25);
+    assert_eq!(quote.ask_price, 150.5);
+    assert_eq!(quote.bid_size, 100.0);
+    assert_eq!(quote.ask_size, 150.0);
+
+    let trade = events
+        .iter()
+        .find_map(|e| match e {
+            MarketEvent::Trade(t) => Some(t),
+            _ => None,
+        })
+        .expect("no Trade event reached the consumer");
+
+    assert_eq!(trade.event_symbol, "AAPL");
+    assert_eq!(trade.price, 151.25);
+    assert_eq!(trade.size, 75.0);
+    assert_eq!(trade.day_volume, 10_000_000.0);
+
+    // The callback path is separate from the stream path; both must fire.
+    let delivered = callback_events.lock().expect("callback lock poisoned");
+    assert_eq!(
+        delivered.len(),
+        2,
+        "callback for AAPL should have received both events, got {delivered:?}"
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+#[tokio::test]
+async fn test_full_session_delivers_market_data() {
+    run_full_session(Behaviour::Plain).await;
+}
+
+/// End-to-end regression for issue #4. Before the fix the first Ping aborted the
+/// handshake, so this never got as far as a quote.
+#[tokio::test]
+async fn test_full_session_survives_interleaved_control_frames() {
+    run_full_session(Behaviour::ControlFrames).await;
+}
+
+/// A callback registered for one symbol must not see another symbol's events.
+#[tokio::test]
+async fn test_callback_is_scoped_to_its_symbol() {
+    let server = flow_server::start(Behaviour::Plain).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+
+    let msft_events = Arc::new(Mutex::new(Vec::new()));
+    let msft_sink = msft_events.clone();
+    client.on_event("MSFT", move |event| {
+        msft_sink.lock().expect("lock poisoned").push(event);
+    });
+
+    client
+        .subscribe(
+            channel_id,
+            vec![
+                FeedSubscription {
+                    event_type: "Quote".to_string(),
+                    symbol: "AAPL".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+                FeedSubscription {
+                    event_type: "Quote".to_string(),
+                    symbol: "MSFT".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+            ],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    let events = collect_events(&mut event_stream, 2).await;
+    assert_eq!(events.len(), 2, "both symbols should reach the stream");
+
+    let symbols: Vec<&str> = events
+        .iter()
+        .filter_map(|e| match e {
+            MarketEvent::Quote(q) => Some(q.event_symbol.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(symbols.contains(&"AAPL"), "AAPL missing from {symbols:?}");
+    assert!(symbols.contains(&"MSFT"), "MSFT missing from {symbols:?}");
+
+    let delivered = msft_events.lock().expect("lock poisoned");
+    assert_eq!(delivered.len(), 1, "MSFT callback should fire exactly once");
+    match &delivered[0] {
+        MarketEvent::Quote(q) => assert_eq!(q.event_symbol, "MSFT"),
+        other => panic!("MSFT callback received the wrong event: {other:?}"),
+    }
+
+    drop(delivered);
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// The client must survive the server hanging up mid-session: no panic, no hang,
+/// and `disconnect` still succeeds.
+#[tokio::test]
+async fn test_session_survives_server_close() {
+    let server = flow_server::start(Behaviour::CloseAfterSubscribe).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+
+    client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Quote".to_string(),
+                symbol: "AAPL".to_string(),
+                from_time: None,
+                source: None,
+            }],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    // The quote is sent before the close, so it must still arrive.
+    let events = collect_events(&mut event_stream, 1).await;
+    assert_eq!(
+        events.len(),
+        1,
+        "the event sent before the close should still be delivered"
+    );
+
+    // The server hung up; tearing down must not hang or panic.
+    tokio::time::timeout(Duration::from_secs(5), client.disconnect())
+        .await
+        .expect("disconnect hung after the server closed the connection")
+        .expect("disconnect failed after the server closed the connection");
+}
+
+/// The protocol exchange itself: the client must send the messages a real server
+/// expects, in order, with the token it was given.
+#[tokio::test]
+async fn test_session_sends_the_expected_protocol_messages() {
+    let server = flow_server::start(Behaviour::Plain).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+    client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Quote".to_string(),
+                symbol: "AAPL".to_string(),
+                from_time: None,
+                source: None,
+            }],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    // Wait for the event so the subscription is known to have been processed.
+    assert_eq!(collect_events(&mut event_stream, 1).await.len(), 1);
+
+    let received = server.received();
+    let types: Vec<&str> = received
+        .iter()
+        .filter_map(|m| m["type"].as_str())
+        .filter(|t| *t != "KEEPALIVE")
+        .collect();
+    assert_eq!(
+        types,
+        vec![
+            "SETUP",
+            "AUTH",
+            "CHANNEL_REQUEST",
+            "FEED_SETUP",
+            "FEED_SUBSCRIPTION"
+        ],
+        "unexpected protocol sequence"
+    );
+
+    let auth = received
+        .iter()
+        .find(|m| m["type"] == "AUTH")
+        .expect("no AUTH message");
+    assert_eq!(auth["token"], "test-token");
+
+    // FEED_SETUP is the half of the COMPACT contract that pins the column order;
+    // if this list changes, parse_compact_data must change with it.
+    let feed_setup = received
+        .iter()
+        .find(|m| m["type"] == "FEED_SETUP")
+        .expect("no FEED_SETUP message");
+    assert_eq!(feed_setup["acceptDataFormat"], "COMPACT");
+    let quote_fields = feed_setup["acceptEventFields"]["Quote"]
+        .as_array()
+        .expect("no Quote field list in FEED_SETUP");
+    let quote_fields: Vec<&str> = quote_fields.iter().filter_map(|f| f.as_str()).collect();
+    assert_eq!(
+        quote_fields,
+        vec![
+            "eventType",
+            "eventSymbol",
+            "bidPrice",
+            "askPrice",
+            "bidSize",
+            "askSize"
+        ],
+        "Quote column order changed; parse_compact_data must match it"
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -4,5 +4,6 @@
    Date: 7/3/25
 ******************************************************************************/
 mod dxlink_extra;
+mod dxlink_flow;
 mod dxlink_real;
 mod dxlink_test;


### PR DESCRIPTION
## Summary

`receive()` treated every non-`Text` frame as fatal, so a single server Ping tore the session down. Control frames are ordinary transport traffic — tungstenite answers Pings itself but still yields them to the consumer — which made this reproducible against any server that keepalives. The reporter saw it 100% of the time against the tastytrade certification feed: no session was ever established, so no quotes or greeks were ever delivered.

## Changes

- Ping, Pong and raw Frame are skipped and reading continues instead of failing.
- Close gets its own `DXLinkError::Connection` carrying the close code and reason. A server that closes during the handshake is usually reporting a bad token or an unsupported version, and folding that into "unexpected message" hides it.
- Binary frames still error, with a better message that names the frame kind and its size.
- New `DXLinkError::is_terminal()` tells a read loop whether the connection is gone or just the frame was bad.
- The message task stops on a terminal error instead of re-reading a dead socket every 100ms forever.

## Technical decisions

**Binary frames are still rejected, which is the opposite of what the issue suggested.** DXLink is a text-JSON protocol, so a binary frame is a real server anomaly and accepting it as text would hide it. Only control frames are skipped. @joaquinbejar offered to test against the certification feed — if a real server out there does send payloads in binary frames, that changes the answer and I would rather find out now than guess.

`is_terminal()` is true for `WebSocket`, `Connection` and `Authentication`, false for the six that describe a single bad message. It is matched exhaustively with no wildcard arm, so a future variant forces the decision rather than silently inheriting one.

The `tokio::sync::Mutex` guard on the read half is now held across the loop. That is correct here and is what serialises readers; the "no guard across await" rule applies to the `std::sync::Mutex` state in `client.rs`, not to this file.

## Public API impact — BREAKING, 0.2.0 to 0.3.0

`tokio-tungstenite` moves from 0.28 to 0.30. `DXLinkError::WebSocket` carries `Box<tokio_tungstenite::tungstenite::Error>` and `impl From<tungstenite::Error> for DXLinkError` accepts it, so both are part of the public surface. A 0.x minor is semver incompatible, which means downstream code that constructs that variant or converts a 0.28 `tungstenite::Error` stops compiling. Callers upgrade their own `tokio-tungstenite` to 0.30 to match.

The `tokio` 1.49 to 1.53 bump in the same commit is semver compatible and is not part of the break.

Release note for 0.3.0 should lead with this.

Additive in the same release: `DXLinkError::is_terminal()`. Nothing was renamed or removed.

One behaviour change worth calling out for downstream matchers: `receive()` no longer returns `UnexpectedMessage` for Ping/Pong (they are skipped) or for Close (now `Connection`). Binary still returns `UnexpectedMessage`, though the message text changed.

## Protocol impact

No change to the message flow, to `setup_feed`'s field list, or to `parse_compact_data`'s stride. This is purely about which WebSocket frame kinds reach the JSON layer.

## Testing

- [x] Unit tests added next to the code
- [x] Property tested (frame kinds, close reason survival, terminal classification, task teardown), not the echo
- [x] `make check` clean locally
- [x] `cargo build --workspace --all-features` clean
- [x] Coverage: **73.37% → 76.14%**, `connection.rs` 67.7% → 89.0%

Ten new tests. The frame-level ones drive the server with `tokio_tungstenite::accept_async` rather than warp, because emitting a specific frame kind is the whole point and warp does not expose that cleanly. Each binds an ephemeral port, so unlike the six pre-existing port-conflict tests these actually run in CI.

I checked they catch the defect rather than just pass: against the previous `receive()` five of the seven frame tests fail, and without the message-loop break the teardown test hangs for its full timeout.

Note that `main` was already below the 75% codecov gate at 73.37%, so the coverage status was red before this branch.

## Review follow-ups

Three review comments, all fixed in `e4a845c`.

The close reason is free text chosen by the server and was reaching the error log and `DXLinkError::Connection` verbatim. Since closing is also the authentication failure path, a server echoing the token back would have turned our own error reporting into a credential leak. It now goes through a sanitizer that drops control characters, masks runs too long to be a word, and truncates; the close code is a protocol enum and stays verbatim because it is the actionable part.

Closing is a handshake and only half of it was being done. Confirmed before fixing: the requested test times out against the previous code because the peer never receives the reply. The write half is now driven before returning.

The dependency bump is handled as a break rather than reverted, see the public API section.

## Known limitation

When the message task stops, the consumer's `event_stream` does not close, because `DXLinkClient` still holds its own `Sender`. The consumer therefore waits on a stream that will never produce again. Signalling it properly is the reconnection work, not this fix — worth its own issue.

## Checklist

- [x] Follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()`/`.expect()` on new request paths
- [x] No `std::sync::Mutex` guard held across an `.await`
- [x] Auth token cannot reach a log; the redaction path is untouched
- [x] Every new public item has a doc comment
- [x] `src/lib.rs` docs unchanged, so no README regeneration needed
- [x] `examples/miscellaneous` still builds
- [x] No new `#[ignore]`; the six pre-existing ones are untouched
- [x] No new dependency
- [x] No tokens or secrets in logs, tests, or committed files

## Verified against a real server

Confirmed against `wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed`, the endpoint from the issue. That server sends a Ping immediately after the upgrade, so this is the exact failure the reporter hit:

```
Sending message: {"...","type":"SETUP",...}
Skipping WebSocket control frame: Ping(b"\x7f")
Received message: {"type":"SETUP","channel":0,"version":"1.0-2.8.3",...}
Received message: {"type":"AUTH_STATE","channel":0,"state":"UNAUTHORIZED"}
```

Before this branch that Ping ended the connection with `Unexpected message: Expected text message`. Now it is skipped and the handshake proceeds to AUTH. The token is redacted in the outbound log, as expected.

Two unrelated defects surfaced while verifying, both filed separately rather than folded in here: the demo URL shipped in the example and `.env.example` returns HTTP 400 (#15 covers the example being wrong), and a server `ERROR` during the handshake is reported as `missing field \`state\`` instead of an authentication error (#11).

Closes #4


