### PR TITLE
Consolidate offline fixtures and restore deterministic assertions (#16)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,8 @@ futures-util = "0.3"
 tracing = "0.1"
 
 [dev-dependencies]
-warp = { version = "0.4", features = ["websocket", "server"] }
+# test-util drives virtual time so the keepalive test does not spend 20 real seconds.
+tokio = { version = "1.53", features = ["full", "test-util"] }
 chrono = "0.4"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ tracing = "0.1"
 [dev-dependencies]
 # test-util drives virtual time so the keepalive test does not spend 20 real seconds.
 tokio = { version = "1.53", features = ["full", "test-util"] }
-chrono = "0.4"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 
 [[test]]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -367,10 +367,11 @@ impl KeepAliveSender {
 mod frame_tests {
     //! Frame-level tests for [`WebSocketConnection::receive`].
     //!
-    //! These drive the server side with `tokio_tungstenite::accept_async` rather
-    //! than warp, because the whole point is emitting specific frame kinds — a
-    //! Ping, or a Close with a chosen code — which warp does not expose cleanly.
-    //! Every server binds an ephemeral port so the suite stays parallel-safe.
+    //! These drive the server side with `tokio_tungstenite::accept_async`, which
+    //! is the only way to emit a specific frame kind on demand — a Ping, or a
+    //! Close with a chosen code. Every server binds an ephemeral port so the
+    //! suite stays parallel-safe; the fixed ports these replaced are why six of
+    //! these tests used to be `#[ignore]`d.
 
     use super::*;
     use futures_util::SinkExt;
@@ -383,6 +384,158 @@ mod frame_tests {
     /// then keeps the socket open. Returns the URL to connect to.
     async fn serve_frames(frames: Vec<Message>) -> String {
         serve_frames_after(frames, Duration::ZERO).await
+    }
+
+    /// Starts a server that reports every text message it receives and forwards
+    /// anything pushed into the returned sender back to the client.
+    ///
+    /// Returns `(url, received, to_client)`.
+    #[allow(clippy::type_complexity)]
+    async fn serve_recording() -> (
+        String,
+        tokio::sync::mpsc::Receiver<String>,
+        tokio::sync::mpsc::Sender<String>,
+    ) {
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("failed to bind test server");
+        let addr = listener.local_addr().expect("failed to read local addr");
+
+        let (received_tx, received_rx) = tokio::sync::mpsc::channel::<String>(16);
+        let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<String>(16);
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("failed to accept");
+            let ws = accept_async(stream).await.expect("failed to handshake");
+            let (mut write, mut read) = ws.split();
+
+            tokio::spawn(async move {
+                while let Some(text) = outbound_rx.recv().await {
+                    if write.send(Message::Text(text.into())).await.is_err() {
+                        return;
+                    }
+                }
+            });
+
+            while let Some(Ok(message)) = read.next().await {
+                if let Message::Text(text) = message
+                    && received_tx.send(text.to_string()).await.is_err()
+                {
+                    return;
+                }
+            }
+        });
+
+        (format!("ws://{}", addr), received_rx, outbound_tx)
+    }
+
+    /// Waits for the next message the server recorded, or fails the test.
+    async fn next_received(rx: &mut tokio::sync::mpsc::Receiver<String>) -> String {
+        tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("server never received a message")
+            .expect("server channel closed")
+    }
+
+    #[tokio::test]
+    async fn test_send_and_receive_round_trip() {
+        let (url, mut received, to_client) = serve_recording().await;
+
+        let connection = WebSocketConnection::connect(&url)
+            .await
+            .expect("failed to connect");
+
+        #[derive(Serialize)]
+        struct TestMessage {
+            channel: u32,
+            #[serde(rename = "type")]
+            message_type: String,
+            data: String,
+        }
+
+        connection
+            .send(&TestMessage {
+                channel: 1,
+                message_type: "TEST".to_string(),
+                data: "Hello, World!".to_string(),
+            })
+            .await
+            .expect("failed to send");
+
+        let raw = next_received(&mut received).await;
+        let parsed: serde_json::Value =
+            serde_json::from_str(&raw).expect("server got invalid JSON");
+        assert_eq!(parsed["channel"], 1);
+        assert_eq!(parsed["type"], "TEST");
+        assert_eq!(parsed["data"], "Hello, World!");
+
+        to_client
+            .send("test_response".to_string())
+            .await
+            .expect("failed to push a response");
+        assert_eq!(
+            connection.receive().await.expect("failed to receive"),
+            "test_response"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_clone_shares_the_underlying_stream() {
+        let (url, _received, to_client) = serve_recording().await;
+
+        let connection = WebSocketConnection::connect(&url)
+            .await
+            .expect("failed to connect");
+        let clone = connection.clone();
+
+        to_client
+            .send("first".to_string())
+            .await
+            .expect("failed to push");
+        assert_eq!(
+            connection.receive().await.expect("failed to receive"),
+            "first"
+        );
+
+        // The clone reads from the same stream, so it picks up the next message
+        // rather than repeating the first.
+        to_client
+            .send("second".to_string())
+            .await
+            .expect("failed to push");
+        assert_eq!(clone.receive().await.expect("failed to receive"), "second");
+    }
+
+    #[tokio::test]
+    async fn test_keepalive_sender_targets_the_requested_channel() {
+        let (url, mut received, _to_client) = serve_recording().await;
+
+        let connection = WebSocketConnection::connect(&url)
+            .await
+            .expect("failed to connect");
+
+        connection
+            .create_keepalive_sender()
+            .send_keepalive(5)
+            .await
+            .expect("failed to send keepalive");
+
+        let parsed: serde_json::Value = serde_json::from_str(&next_received(&mut received).await)
+            .expect("server got invalid JSON");
+        assert_eq!(parsed["channel"], 5);
+        assert_eq!(parsed["type"], "KEEPALIVE");
+
+        // A sender built from a clone shares the same socket.
+        connection
+            .clone()
+            .create_keepalive_sender()
+            .send_keepalive(10)
+            .await
+            .expect("failed to send keepalive from a clone");
+
+        let parsed: serde_json::Value = serde_json::from_str(&next_received(&mut received).await)
+            .expect("server got invalid JSON");
+        assert_eq!(parsed["channel"], 10);
     }
 
     /// As [`serve_frames`], but waits `delay` before sending anything.
@@ -623,10 +776,8 @@ mod frame_tests {
 mod redaction_tests {
     use super::*;
     use crate::messages::{AuthMessage, KeepaliveMessage};
-    use futures_util::StreamExt;
     use std::sync::Arc;
     use tracing_subscriber::fmt::MakeWriter;
-    use warp::Filter;
 
     #[test]
     fn test_redact_sensitive_masks_auth_token() {
@@ -755,464 +906,78 @@ mod redaction_tests {
         }
     }
 
+    /// Captures `tracing` output for the whole test binary.
+    ///
+    /// A per-test `set_default` subscriber is thread-local, so once the runtime
+    /// resumed a test future on another worker the capture stopped and the
+    /// assertions ran against a buffer missing the very line they check. One
+    /// global subscriber, installed once, has no such race. Tests scope
+    /// themselves by searching for their own unique marker.
+    fn captured_logs() -> &'static SharedLogBuffer {
+        static BUFFER: std::sync::OnceLock<SharedLogBuffer> = std::sync::OnceLock::new();
+        BUFFER.get_or_init(|| {
+            let buffer = SharedLogBuffer::default();
+            let subscriber = tracing_subscriber::fmt()
+                .with_max_level(tracing::Level::DEBUG)
+                .with_writer(buffer.clone())
+                .finish();
+            // Another test may have won the race; either way a subscriber that
+            // writes into this buffer is installed.
+            let _ = tracing::subscriber::set_global_default(subscriber);
+            buffer
+        })
+    }
+
     #[tokio::test]
     async fn test_auth_token_never_appears_in_debug_logs() {
-        let buffer = SharedLogBuffer::default();
-        let subscriber = tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
-            .with_writer(buffer.clone())
-            .finish();
-        let _guard = tracing::subscriber::set_default(subscriber);
+        let logs = captured_logs();
+        let token = "tastytrade-live-bearer-token-unique-to-this-test";
 
         // Minimal WebSocket server on an ephemeral port that swallows messages.
-        let websocket = warp::path("websocket")
-            .and(warp::ws())
-            .map(|ws: warp::ws::Ws| {
-                ws.on_upgrade(|mut socket| async move { while socket.next().await.is_some() {} })
-            });
         let listener = tokio::net::TcpListener::bind(("127.0.0.1", 0))
             .await
             .expect("Failed to bind test server");
         let addr = listener.local_addr().expect("Failed to get local addr");
-        tokio::spawn(warp::serve(websocket).incoming(listener).run());
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("failed to accept");
+            let mut ws = tokio_tungstenite::accept_async(stream)
+                .await
+                .expect("failed to handshake");
+            while ws.next().await.is_some() {}
+        });
 
-        let connection = WebSocketConnection::connect(&format!("ws://{}/websocket", addr))
+        let connection = WebSocketConnection::connect(&format!("ws://{}", addr))
             .await
             .expect("Failed to connect");
 
-        let token = "tastytrade-live-bearer-token";
-        let auth_msg = AuthMessage {
-            channel: 0,
-            message_type: "AUTH".to_string(),
-            token: token.to_string(),
-        };
         connection
-            .send(&auth_msg)
+            .send(&AuthMessage {
+                channel: 0,
+                message_type: "AUTH".to_string(),
+                token: token.to_string(),
+            })
             .await
             .expect("Failed to send auth message");
 
-        let logs = buffer.contents();
-        assert!(logs.contains("Sending message"));
-        assert!(!logs.contains(token), "auth token leaked into logs: {logs}");
-        assert!(logs.contains(REDACTED_PLACEHOLDER));
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use futures_util::{SinkExt, StreamExt};
-    use std::net::SocketAddr;
-    use std::sync::Arc;
-    use tokio::sync::mpsc;
-    use warp::Filter;
-    use warp::ws::{Message as WarpMessage, WebSocket as WarpWebSocket};
-
-    async fn setup_test_server() -> (SocketAddr, mpsc::Receiver<String>, mpsc::Sender<String>) {
-        let (client_tx, client_rx) = mpsc::channel::<String>(10);
-        let (server_tx, server_rx) = mpsc::channel::<String>(10);
-
-        let client_tx = Arc::new(Mutex::new(client_tx));
-        let server_rx = Arc::new(Mutex::new(server_rx));
-
-        let websocket = warp::path("websocket")
-            .and(warp::ws())
-            .map(move |ws: warp::ws::Ws| {
-                let client_tx = client_tx.clone();
-                let server_rx = server_rx.clone();
-
-                ws.on_upgrade(move |websocket| handle_websocket(websocket, client_tx, server_rx))
-            });
-
-        // Use a fixed port for testing
-        let addr = ([127, 0, 0, 1], 3030).into();
-        let server = warp::serve(websocket).run(addr);
-
-        tokio::spawn(server);
-
-        (addr, client_rx, server_tx)
-    }
-
-    async fn handle_websocket(
-        websocket: WarpWebSocket,
-        client_tx: Arc<Mutex<mpsc::Sender<String>>>,
-        server_rx: Arc<Mutex<mpsc::Receiver<String>>>,
-    ) {
-        let (mut ws_tx, mut ws_rx) = websocket.split();
-
-        let server_to_client = tokio::spawn(async move {
-            let mut rx = server_rx.lock().await;
-            while let Some(msg) = rx.recv().await {
-                ws_tx
-                    .send(WarpMessage::text(msg))
-                    .await
-                    .expect("Failed to send message");
-            }
-        });
-
-        let client_to_server = tokio::spawn(async move {
-            let tx = client_tx.lock().await;
-            while let Some(result) = ws_rx.next().await {
-                match result {
-                    Ok(msg) if msg.is_text() => {
-                        if let Ok(text) = msg.to_str() {
-                            tx.send(text.to_string())
-                                .await
-                                .expect("Failed to send to channel");
-                        }
-                    }
-                    _ => break,
-                }
-            }
-        });
-
-        let _ = tokio::join!(server_to_client, client_to_server);
-    }
-
-    #[tokio::test]
-    #[ignore] // Temporarily disabled due to port conflicts
-    async fn test_websocket_connection() {
-        // Configurar servidor de prueba
-        let (addr, mut client_rx, server_tx) = setup_test_server().await;
-
-        // Crear URL de conexión
-        let ws_url = format!("ws://{}/websocket", addr);
-
-        // Crear una conexión real
-        let connection = WebSocketConnection::connect(&ws_url)
-            .await
-            .expect("Failed to connect");
-
-        // Crear y enviar un mensaje de prueba
-        #[derive(Serialize)]
-        struct TestMessage {
-            channel: u32,
-            #[serde(rename = "type")]
-            message_type: String,
-            data: String,
-        }
-
-        let test_msg = TestMessage {
-            channel: 1,
-            message_type: "TEST".to_string(),
-            data: "Hello, World!".to_string(),
-        };
-
-        // Enviar el mensaje
-        connection
-            .send(&test_msg)
-            .await
-            .expect("Failed to send message");
-
-        // Verificar que el mensaje fue recibido por el servidor
-        if let Some(received) = client_rx.recv().await {
-            let parsed: serde_json::Value = serde_json::from_str(&received).unwrap();
-            assert_eq!(parsed["channel"], 1);
-            assert_eq!(parsed["type"], "TEST");
-            assert_eq!(parsed["data"], "Hello, World!");
-        } else {
-            panic!("No message received");
-        }
-
-        server_tx
-            .send("test_response".to_string())
-            .await
-            .expect("Failed to send from server");
-
-        let received = connection
-            .receive()
-            .await
-            .expect("Failed to receive message");
-        assert_eq!(received, "test_response");
-    }
-}
-
-#[cfg(test)]
-mod additional_tests {
-    use super::*;
-    use futures_util::{SinkExt, StreamExt};
-    use std::net::SocketAddr;
-    use std::sync::Arc;
-    use tokio::sync::mpsc;
-    use tokio::time::sleep;
-    use warp::Filter;
-    use warp::ws::{Message as WarpMessage, WebSocket as WarpWebSocket};
-
-    async fn setup_test_server() -> (
-        SocketAddr,
-        mpsc::Receiver<String>,
-        mpsc::Sender<String>,
-        mpsc::Sender<bool>,
-    ) {
-        // Channels for communication with test server
-        let (client_tx, client_rx) = mpsc::channel::<String>(10);
-        let (server_tx, server_rx) = mpsc::channel::<String>(10);
-        let (binary_tx, binary_rx) = mpsc::channel::<bool>(10);
-
-        let client_tx = Arc::new(tokio::sync::Mutex::new(client_tx));
-        let server_rx = Arc::new(tokio::sync::Mutex::new(server_rx));
-        let binary_rx = Arc::new(tokio::sync::Mutex::new(binary_rx));
-
-        // Define WebSocket test endpoint
-        let websocket = warp::path("websocket")
-            .and(warp::ws())
-            .map(move |ws: warp::ws::Ws| {
-                let client_tx = client_tx.clone();
-                let server_rx = server_rx.clone();
-                let binary_rx = binary_rx.clone();
-
-                ws.on_upgrade(move |websocket| {
-                    handle_websocket(websocket, client_tx, server_rx, binary_rx)
-                })
-            });
-
-        // Start server on fixed port for testing
-        let addr = ([127, 0, 0, 1], 3031).into();
-        let server = warp::serve(websocket).run(addr);
-
-        // Run server in separate tokio task
-        tokio::spawn(server);
-
-        (addr, client_rx, server_tx, binary_tx)
-    }
-
-    async fn handle_websocket(
-        websocket: WarpWebSocket,
-        client_tx: Arc<tokio::sync::Mutex<mpsc::Sender<String>>>,
-        server_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<String>>>,
-        binary_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<bool>>>,
-    ) {
-        let (ws_tx, mut ws_rx) = websocket.split();
-
-        // Wrap ws_tx in Arc<Mutex<>> so it can be shared between tasks
-        let ws_tx = Arc::new(tokio::sync::Mutex::new(ws_tx));
-
-        // Task to send text messages to client
-        let ws_tx_clone = ws_tx.clone();
-        let server_to_client = tokio::spawn(async move {
-            let mut rx = server_rx.lock().await;
-            while let Some(msg) = rx.recv().await {
-                let mut tx = ws_tx_clone.lock().await;
-                tx.send(WarpMessage::text(msg))
-                    .await
-                    .expect("Failed to send message");
-            }
-        });
-
-        // Task to send binary messages to client
-        let binary_to_client = tokio::spawn(async move {
-            let mut rx = binary_rx.lock().await;
-            while rx.recv().await.is_some() {
-                // Send a binary message
-                let mut tx = ws_tx.lock().await;
-                tx.send(WarpMessage::binary(vec![1, 2, 3]))
-                    .await
-                    .expect("Failed to send binary message");
-            }
-        });
-
-        // Task to receive messages from client
-        let client_to_server = tokio::spawn(async move {
-            let tx = client_tx.lock().await;
-            while let Some(result) = ws_rx.next().await {
-                match result {
-                    Ok(msg) if msg.is_text() => {
-                        if let Ok(text) = msg.to_str() {
-                            tx.send(text.to_string())
-                                .await
-                                .expect("Failed to send to channel");
-                        }
-                    }
-                    _ => break,
-                }
-            }
-        });
-
-        // Wait for all tasks to complete
-        let _ = tokio::join!(server_to_client, binary_to_client, client_to_server);
-    }
-
-    // Test for receive_with_timeout with successful response
-    #[tokio::test]
-    #[ignore] // Temporarily disabled due to port conflicts
-    async fn test_receive_with_timeout_success() {
-        // Set up test server
-        let (addr, _client_rx, server_tx, _binary_tx) = setup_test_server().await;
-
-        // Create connection URL
-        let ws_url = format!("ws://{}/websocket", addr);
-
-        // Create a real connection
-        let connection = WebSocketConnection::connect(&ws_url)
-            .await
-            .expect("Failed to connect");
-
-        // Send a message from server after a short delay
-        let server_tx_clone = server_tx.clone();
-        tokio::spawn(async move {
-            sleep(Duration::from_millis(50)).await;
-            server_tx_clone
-                .send("test_response".to_string())
-                .await
-                .expect("Failed to send from server");
-        });
-
-        // Test receive_with_timeout with successful response
-        let result = connection
-            .receive_with_timeout(Duration::from_millis(500))
-            .await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), Some("test_response".to_string()));
-    }
-
-    // Test for receive_with_timeout with timeout
-    #[tokio::test]
-    #[ignore] // Temporarily disabled due to port conflicts
-    async fn test_receive_with_timeout_timeout() {
-        // Set up test server
-        let (addr, _client_rx, _server_tx, _binary_tx) = setup_test_server().await;
-
-        // Create connection URL
-        let ws_url = format!("ws://{}/websocket", addr);
-
-        // Create a real connection
-        let connection = WebSocketConnection::connect(&ws_url)
-            .await
-            .expect("Failed to connect");
-
-        // Test receive_with_timeout with timeout
-        let result = connection
-            .receive_with_timeout(Duration::from_millis(100))
-            .await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), None);
-    }
-
-    // Test receiving a non-text message
-    #[tokio::test]
-    #[ignore] // Temporarily disabled due to port conflicts
-    async fn test_receive_non_text_message() {
-        // Set up test server
-        let (addr, _client_rx, _server_tx, binary_tx) = setup_test_server().await;
-
-        // Create connection URL
-        let ws_url = format!("ws://{}/websocket", addr);
-
-        // Create a real connection
-        let connection = WebSocketConnection::connect(&ws_url)
-            .await
-            .expect("Failed to connect");
-
-        // Trigger server to send a binary message
-        binary_tx
-            .send(true)
-            .await
-            .expect("Failed to trigger binary message");
-
-        // Try to receive the binary message
-        let result = connection.receive().await;
-
-        // Should result in an UnexpectedMessage error
-        assert!(result.is_err());
-        match result {
-            Err(DXLinkError::UnexpectedMessage(msg)) => {
-                assert!(msg.contains("Expected text message"));
-            }
-            _ => panic!("Expected UnexpectedMessage error, got: {:?}", result),
-        }
-    }
-
-    // Test the clone implementation
-    #[tokio::test]
-    #[ignore] // Temporarily disabled due to port conflicts
-    async fn test_clone() {
-        // Set up test server
-        let (addr, _client_rx, server_tx, _binary_tx) = setup_test_server().await;
-
-        // Create connection URL
-        let ws_url = format!("ws://{}/websocket", addr);
-
-        // Create a real connection
-        let connection = WebSocketConnection::connect(&ws_url)
-            .await
-            .expect("Failed to connect");
-
-        // Clone the connection
-        let connection_clone = connection.clone();
-
-        // Send a message from server
-        server_tx
-            .send("test_message".to_string())
-            .await
-            .expect("Failed to send from server");
-
-        // Both connections should be able to receive the message
-        let result = connection.receive().await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "test_message");
-
-        // Send another message for the clone
-        server_tx
-            .send("clone_message".to_string())
-            .await
-            .expect("Failed to send from server");
-
-        // The clone should receive the message
-        let result = connection_clone.receive().await;
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "clone_message");
-    }
-
-    // Test the KeepAliveSender with the cloned connection
-    #[tokio::test]
-    #[ignore] // Temporarily disabled due to port conflicts
-    async fn test_keepalive_sender_with_clone() {
-        // Set up test server
-        let (addr, mut client_rx, _server_tx, _binary_tx) = setup_test_server().await;
-
-        // Create connection URL
-        let ws_url = format!("ws://{}/websocket", addr);
-
-        // Create a real connection
-        let connection = WebSocketConnection::connect(&ws_url)
-            .await
-            .expect("Failed to connect");
-
-        // Create a KeepAliveSender from the connection
-        let keepalive_sender = connection.create_keepalive_sender();
-
-        // Send a keepalive message
-        keepalive_sender
-            .send_keepalive(5)
-            .await
-            .expect("Failed to send keepalive");
-
-        // Verify that the keepalive was sent
-        if let Some(received) = client_rx.recv().await {
-            let parsed: serde_json::Value = serde_json::from_str(&received).unwrap();
-            assert_eq!(parsed["channel"], 5);
-            assert_eq!(parsed["type"], "KEEPALIVE");
-        } else {
-            panic!("No keepalive message received");
-        }
-
-        // Clone the connection and create another KeepAliveSender
-        let connection_clone = connection.clone();
-        let keepalive_sender2 = connection_clone.create_keepalive_sender();
-
-        // Send another keepalive message
-        keepalive_sender2
-            .send_keepalive(10)
-            .await
-            .expect("Failed to send keepalive from clone");
-
-        // Verify that the second keepalive was sent
-        if let Some(received) = client_rx.recv().await {
-            let parsed: serde_json::Value = serde_json::from_str(&received).unwrap();
-            assert_eq!(parsed["channel"], 10);
-            assert_eq!(parsed["type"], "KEEPALIVE");
-        } else {
-            panic!("No keepalive message received from clone");
+        let contents = logs.contents();
+        let auth_lines: Vec<&str> = contents
+            .lines()
+            .filter(|line| line.contains("Sending message") && line.contains("\"type\":\"AUTH\""))
+            .collect();
+
+        assert!(
+            !auth_lines.is_empty(),
+            "no outbound AUTH was logged, the assertions below would be vacuous"
+        );
+        assert!(
+            !contents.contains(token),
+            "auth token leaked into logs: {contents}"
+        );
+        for line in auth_lines {
+            assert!(
+                line.contains(REDACTED_PLACEHOLDER),
+                "an AUTH payload was logged without redaction: {line}"
+            );
         }
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -921,8 +921,10 @@ mod redaction_tests {
                 .with_max_level(tracing::Level::DEBUG)
                 .with_writer(buffer.clone())
                 .finish();
-            // Another test may have won the race; either way a subscriber that
-            // writes into this buffer is installed.
+            // If some other code already installed a global subscriber this call
+            // fails and the buffer stays empty. That is why the test asserts it
+            // captured something before asserting on the contents: it fails
+            // loudly rather than passing vacuously.
             let _ = tracing::subscriber::set_global_default(subscriber);
             buffer
         })

--- a/tests/integration/dxlink_extra.rs
+++ b/tests/integration/dxlink_extra.rs
@@ -1,790 +1,148 @@
-/******************************************************************************
-   Author: Joaquín Béjar García
-   Email: jb@taunais.com
-   Date: 8/3/25
-******************************************************************************/
+//! Subscription-management integration tests: unsubscribe, reset, and
+//! historical (`fromTime`) subscriptions.
+//!
+//! Every assertion here used to be either commented out or replaced by a
+//! warning log, which is why subscription bugs could not fail the suite.
 
-// integration_tests.rs
-use dxlink::{DXLinkClient, EventType, FeedSubscription, MarketEvent};
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
-use std::time::Duration;
-use tokio::time::sleep;
-use tracing::info;
+use crate::fixture::{Behaviour, MockServer, is_type_on_channel};
+use dxlink::{DXLinkClient, EventType, FeedSubscription};
 
-mod mock_server {
-    use futures_util::{SinkExt, StreamExt};
-    use serde_json::{Value, json};
-    use std::net::SocketAddr;
-    use std::sync::{Arc, Mutex};
-    use tokio::net::TcpListener;
-    use tokio::sync::mpsc;
-    use tokio_tungstenite::tungstenite::Message;
-    use tracing::{error, info};
-
-    pub struct MockServer {
-        pub address: SocketAddr,
-        pub received_messages: Arc<Mutex<Vec<Value>>>,
-        #[allow(dead_code)]
-        pub messages_to_send: mpsc::Sender<(u32, String)>,
-        pub shutdown: mpsc::Sender<()>,
-    }
-
-    impl MockServer {
-        pub async fn new() -> Self {
-            let listener = TcpListener::bind("127.0.0.1:0")
-                .await
-                .expect("Failed to bind");
-            let address = listener.local_addr().expect("Failed to get local address");
-
-            // Channel for custom messages from test to connected clients
-            let (message_tx, mut message_rx) = mpsc::channel::<(u32, String)>(100);
-
-            // Channel for shutdown signal
-            let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
-
-            // Storage for received messages
-            let received_messages = Arc::new(Mutex::new(Vec::new()));
-
-            // Track active WebSocket sinks by channel ID
-            #[allow(clippy::type_complexity)]
-            let websocket_sinks: Arc<Mutex<Vec<(u32, mpsc::Sender<String>)>>> =
-                Arc::new(Mutex::new(Vec::new()));
-
-            // Clone for tasks
-            let websocket_sinks_clone = websocket_sinks.clone();
-            let received_messages_clone = received_messages.clone();
-
-            // Task to forward messages from test to appropriate client
-            tokio::spawn(async move {
-                while let Some((channel_id, msg)) = message_rx.recv().await {
-                    // Create a copy of the senders we need to use
-                    let senders_to_use = {
-                        let sinks = websocket_sinks.lock().unwrap();
-                        sinks
-                            .iter()
-                            .filter(|(id, _)| *id == channel_id || channel_id == 0)
-                            .map(|(_, sender)| sender.clone())
-                            .collect::<Vec<_>>()
-                    };
-
-                    // Now send to each one without holding the lock
-                    for sender in senders_to_use {
-                        let _ = sender.send(msg.clone()).await;
-                    }
-                }
-            });
-
-            // Main server task
-            tokio::spawn(async move {
-                tokio::select! {
-                    _ = async {
-                        loop {
-                            match listener.accept().await {
-                                Ok((stream, _)) => {
-                                    let ws_stream = tokio_tungstenite::accept_async(stream).await.expect("Failed to accept websocket");
-                                    let (write, mut read) = ws_stream.split();
-
-                                    // Create a channel for sending messages to this client
-                                    let (client_tx, mut client_rx) = mpsc::channel::<String>(100);
-
-                                    // Initially add with channel 0 (main)
-                                    {
-                                        let mut sinks = websocket_sinks_clone.lock().unwrap();
-                                        sinks.push((0, client_tx.clone()));
-                                    }
-
-                                    // Clone for tasks
-                                    let received_messages = received_messages_clone.clone();
-                                    let websocket_sinks = websocket_sinks_clone.clone();
-
-                                    // Task to send messages to client
-                                    let mut write_handle = write;
-                                    tokio::spawn(async move {
-                                        while let Some(msg) = client_rx.recv().await {
-                                            if let Err(e) = write_handle.send(Message::Text(msg.into())).await {
-                                                error!("Error sending to client: {}", e);
-                                                break;
-                                            }
-                                        }
-                                    });
-
-                                    // Task to process incoming client messages
-                                    tokio::spawn(async move {
-                                        while let Some(msg) = read.next().await {
-                                            if let Ok(Message::Text(text)) = msg {
-                                                // Parse the message
-                                                if let Ok(value) = serde_json::from_str::<Value>(&text) {
-                                                    // Store all received messages for later inspection
-                                                    {
-                                                        let mut messages = received_messages.lock().unwrap();
-                                                        // Replace this line:
-                                                        info!("MockServer received: type={}, channel={}",
-                                                            value.get("type").map_or("unknown", |v| v.as_str().unwrap_or("unknown")),
-                                                            value.get("channel").map_or("unknown".to_string(), |v| v.to_string()));
-                                                        // Add to collection
-                                                        messages.push(value.clone());
-                                                    }
-
-                                                    // Get the message type and channel
-                                                    let msg_type = value["type"].as_str().unwrap_or("");
-                                                    let channel_id = value["channel"].as_u64().unwrap_or(0) as u32;
-
-                                                    // Auto-respond based on message type
-                                                    match msg_type {
-                                                        "SETUP" => {
-                                                            let response = json!({
-                                                                "channel": channel_id,
-                                                                "type": "SETUP",
-                                                                "version": "1.0.0",
-                                                                "keepaliveTimeout": 60,
-                                                                "acceptKeepaliveTimeout": 60
-                                                            }).to_string();
-
-                                                            let _ = client_tx.send(response).await;
-
-                                                            // Send AUTH_STATE
-                                                            let auth_state = json!({
-                                                                "channel": 0,
-                                                                "type": "AUTH_STATE",
-                                                                "state": "UNAUTHORIZED"
-                                                            }).to_string();
-
-                                                            let _ = client_tx.send(auth_state).await;
-                                                        },
-                                                        "AUTH" => {
-                                                            let auth_response = json!({
-                                                                "channel": 0,
-                                                                "type": "AUTH_STATE",
-                                                                "state": "AUTHORIZED",
-                                                                "userId": "test-user"
-                                                            }).to_string();
-
-                                                            let _ = client_tx.send(auth_response).await;
-                                                        },
-                                                        "CHANNEL_REQUEST" => {
-                                                            if value["service"].as_str().unwrap_or("") == "FEED" {
-                                                                // Register this client with the requested channel ID
-                                                                {
-                                                                    let mut sinks = websocket_sinks.lock().unwrap();
-                                                                    sinks.push((channel_id, client_tx.clone()));
-                                                                }
-
-                                                                let channel_opened = json!({
-                                                                    "channel": channel_id,
-                                                                    "type": "CHANNEL_OPENED",
-                                                                    "service": "FEED",
-                                                                    "parameters": {}
-                                                                }).to_string();
-
-                                                                let _ = client_tx.send(channel_opened).await;
-                                                            }
-                                                        },
-                                                        "FEED_SETUP" => {
-                                                            let feed_config = json!({
-                                                                "channel": channel_id,
-                                                                "type": "FEED_CONFIG",
-                                                                "aggregationPeriod": 0.1,
-                                                                "dataFormat": "COMPACT"
-                                                            }).to_string();
-
-                                                            let _ = client_tx.send(feed_config).await;
-                                                        },
-                                                        "FEED_SUBSCRIPTION" => {
-                                                            info!("Received FEED_SUBSCRIPTION: channel={}, content={}",
-                                                                channel_id, value.to_string());
-
-                                                            if let Some(add) = value.get("add")
-                                                                && let Some(subscriptions) = add.as_array() {
-                                                                    for sub in subscriptions {
-                                                                        let event_type = sub["type"].as_str().unwrap_or("");
-                                                                        let symbol = sub["symbol"].as_str().unwrap_or("");
-
-                                                                        // Send mock data for this subscription
-                                                                        if event_type == "Quote" {
-                                                                            let quote_data = json!({
-                                                                                "channel": channel_id,
-                                                                                "type": "FEED_DATA",
-                                                                                "data": [
-                                                                                    "Quote",
-                                                                                    [
-                                                                                        symbol,
-                                                                                        "Quote",
-                                                                                        150.25,
-                                                                                        150.50,
-                                                                                        100,
-                                                                                        150
-                                                                                    ]
-                                                                                ]
-                                                                            }).to_string();
-
-                                                                            let _ = client_tx.send(quote_data).await;
-                                                                        } else if event_type == "Trade" {
-                                                                            let trade_data = json!({
-                                                                                "channel": channel_id,
-                                                                                "type": "FEED_DATA",
-                                                                                "data": [
-                                                                                    "Trade",
-                                                                                    [
-                                                                                        symbol,
-                                                                                        "Trade",
-                                                                                        151.25,
-                                                                                        75,
-                                                                                        10000000
-                                                                                    ]
-                                                                                ]
-                                                                            }).to_string();
-
-                                                                            let _ = client_tx.send(trade_data).await;
-                                                                        } else if event_type == "Candle" {
-                                                                            // Special case for test_historical_data
-                                                                            let candle_data = json!({
-                                                                                "channel": channel_id,
-                                                                                "type": "FEED_DATA",
-                                                                                "data": [
-                                                                                    "Candle",
-                                                                                    [
-                                                                                        symbol,
-                                                                                        "Candle",
-                                                                                        150.0,  // open
-                                                                                        155.0,  // high
-                                                                                        149.0,  // low
-                                                                                        152.5,  // close
-                                                                                        1000,   // volume
-                                                                                        System::now() - 300 // time (5 minutes ago)
-                                                                                    ]
-                                                                                ]
-                                                                            }).to_string();
-
-                                                                            let _ = client_tx.send(candle_data).await;
-                                                                        }
-                                                                    }
-                                                                }
-                                                        },
-                                                        "CHANNEL_CANCEL" => {
-                                                            // Remove this channel from tracked sinks
-                                                            {
-                                                                let mut sinks = websocket_sinks.lock().unwrap();
-                                                                sinks.retain(|(id, _)| *id != channel_id);
-                                                            }
-
-                                                            let channel_closed = json!({
-                                                                "channel": channel_id,
-                                                                "type": "CHANNEL_CLOSED"
-                                                            }).to_string();
-
-                                                            let _ = client_tx.send(channel_closed).await;
-                                                        },
-                                                        _ => {}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    });
-                                },
-                                Err(e) => {
-                                    error!("Error accepting connection: {}", e);
-                                    break;
-                                }
-                            }
-                        }
-                    } => {},
-                    _ = shutdown_rx.recv() => {
-                        info!("Mock server shutting down");
-                    }
-                }
-            });
-
-            MockServer {
-                address,
-                received_messages,
-                messages_to_send: message_tx,
-                shutdown: shutdown_tx,
-            }
-        }
-
-        pub fn get_received_messages(&self) -> Vec<Value> {
-            let messages = self.received_messages.lock().unwrap().clone();
-            info!("MockServer returning {} messages", messages.len());
-
-            for (i, msg) in messages.iter().enumerate() {
-                info!(
-                    "Message {}: type={}, channel={}",
-                    i,
-                    msg.get("type")
-                        .map_or("unknown", |v| v.as_str().unwrap_or("unknown")),
-                    msg.get("channel")
-                        .map_or("unknown".to_string(), |v| v.to_string())
-                );
-
-                // Special debug for subscription-related messages
-                if let Some(msg_type) = msg.get("type")
-                    && msg_type == "FEED_SUBSCRIPTION"
-                {
-                    info!("  Subscription details: {:?}", msg);
-                }
-            }
-
-            messages
-        }
-
-        pub async fn shutdown(self) {
-            let _ = self.shutdown.send(()).await;
-        }
-    }
-
-    // Helper for timestamp generation
-    struct System;
-
-    impl System {
-        fn now() -> i64 {
-            use std::time::{SystemTime, UNIX_EPOCH};
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap_or_default()
-                .as_millis() as i64
-        }
-    }
+/// Opens a connected client with a configured feed channel.
+async fn connected_feed(server: &MockServer, events: &[EventType]) -> (DXLinkClient, u32) {
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, events)
+        .await
+        .expect("failed to set up feed");
+    (client, channel_id)
 }
 
-#[tokio::test]
-async fn test_subscribe_and_receive_events() {
-    let server = mock_server::MockServer::new().await;
-    let url = format!("ws://{}", server.address);
-
-    info!("Starting test with server at {}", url);
-
-    // Create and connect client
-    let mut client = DXLinkClient::new(&url, "test-token");
-    let mut event_stream = client.connect().await.unwrap();
-    info!("Client connected");
-
-    // Create feed channel
-    let channel_id = client.create_feed_channel("AUTO").await.unwrap();
-    info!("Feed channel created: {}", channel_id);
-
-    // Setup feed
-    client
-        .setup_feed(channel_id, &[EventType::Quote, EventType::Trade])
-        .await
-        .unwrap();
-    info!("Feed setup completed");
-
-    // Create a counter for received events
-    let event_counter = Arc::new(Mutex::new(HashMap::<String, i32>::new()));
-    let event_counter_clone = event_counter.clone();
-
-    // Register callback for a specific symbol
-    client.on_event("AAPL", move |event| {
-        let mut counter = event_counter_clone.lock().unwrap();
-        match &event {
-            MarketEvent::Quote(_) => {
-                *counter.entry("AAPL:Quote".to_string()).or_insert(0) += 1;
-                info!("Callback received Quote event for AAPL");
-            }
-            MarketEvent::Trade(_) => {
-                *counter.entry("AAPL:Trade".to_string()).or_insert(0) += 1;
-                info!("Callback received Trade event for AAPL");
-            }
-            _ => {}
-        }
-    });
-
-    // Process events in a separate task, but with a timeout
-    let stream_counter = Arc::new(Mutex::new(HashMap::<String, i32>::new()));
-    let stream_counter_clone = stream_counter.clone();
-
-    let stream_task = tokio::spawn(async move {
-        // Create a timeout for the whole event processing
-        let timeout_duration = Duration::from_secs(3); // 3 second timeout
-
-        let event_processing = async {
-            // Only wait for a few events
-            let mut count = 0;
-            let max_events = 5;
-            while count < max_events {
-                match tokio::time::timeout(Duration::from_millis(500), event_stream.recv()).await {
-                    Ok(Some(event)) => {
-                        let mut counter = stream_counter_clone.lock().unwrap();
-                        match &event {
-                            MarketEvent::Quote(quote) => {
-                                let key = format!("{}:Quote", quote.event_symbol);
-                                *counter.entry(key).or_insert(0) += 1;
-                                info!("Stream received Quote event for {}", quote.event_symbol);
-                            }
-                            MarketEvent::Trade(trade) => {
-                                let key = format!("{}:Trade", trade.event_symbol);
-                                *counter.entry(key).or_insert(0) += 1;
-                                info!("Stream received Trade event for {}", trade.event_symbol);
-                            }
-                            _ => {
-                                info!("Stream received other event type");
-                            }
-                        }
-                        count += 1;
-                    }
-                    Ok(None) => {
-                        info!("Stream closed, exiting event loop");
-                        break;
-                    }
-                    Err(_) => {
-                        info!("Timeout waiting for event, continuing");
-                        // We'll just increment the counter to ensure we exit eventually
-                        count += 1;
-                    }
-                }
-            }
-            info!("Processed {} events, exiting event processing task", count);
-        };
-
-        // Apply overall timeout to the event processing
-        match tokio::time::timeout(timeout_duration, event_processing).await {
-            Ok(_) => info!("Event processing completed normally"),
-            Err(_) => info!(
-                "Event processing timed out after {} seconds",
-                timeout_duration.as_secs()
-            ),
-        }
-    });
-
-    // Subscribe to symbols
-    let subscriptions = vec![
-        FeedSubscription {
-            event_type: "Quote".to_string(),
-            symbol: "AAPL".to_string(),
-            from_time: None,
-            source: None,
-        },
-        FeedSubscription {
-            event_type: "Trade".to_string(),
-            symbol: "AAPL".to_string(),
-            from_time: None,
-            source: None,
-        },
-        FeedSubscription {
-            event_type: "Quote".to_string(),
-            symbol: "MSFT".to_string(),
-            from_time: None,
-            source: None,
-        },
-    ];
-
-    info!("Sending subscription request");
-    let result = client.subscribe(channel_id, subscriptions).await;
-    assert!(result.is_ok(), "Failed to subscribe: {:?}", result);
-    info!("Subscription request returned success");
-
-    // Give some time for the messages to be processed
-    sleep(Duration::from_millis(200)).await;
-
-    // Check subscription message
-    let messages = server.get_received_messages();
-
-    // Use a safer comparison that handles JSON structure variations
-    let subscription = messages.iter().find(|m| {
-        m.get("type")
-            .is_some_and(|t| t.as_str().unwrap_or("") == "FEED_SUBSCRIPTION")
-            && m.get("channel")
-                .is_some_and(|c| c.as_u64() == Some(channel_id as u64))
-    });
-
-    if subscription.is_none() {
-        info!(
-            "WARNING: Can't find FEED_SUBSCRIPTION message for channel {}",
-            channel_id
-        );
-        // Print all channel messages
-        for msg in messages.iter() {
-            if let Some(ch) = msg.get("channel")
-                && let Some(ch_id) = ch.as_u64()
-                && ch_id == channel_id as u64
-            {
-                info!(
-                    "Message for channel {}: type={}",
-                    channel_id,
-                    msg.get("type")
-                        .map_or("unknown", |v| v.as_str().unwrap_or("unknown"))
-                );
-            }
-        }
-    } else {
-        info!("Found FEED_SUBSCRIPTION message: {:?}", subscription);
-    }
-
-    // Wait for events to be processed, but with a timeout
-    info!("Waiting for event stream task to complete");
-    match tokio::time::timeout(Duration::from_secs(5), stream_task).await {
-        Ok(result) => match result {
-            Ok(_) => info!("Stream task completed successfully"),
-            Err(e) => info!("Stream task failed: {}", e),
-        },
-        Err(_) => info!("Timed out waiting for stream task to complete"),
-    }
-
-    // Check that we received events via callbacks
-    {
-        let callback_counts = event_counter.lock().unwrap();
-        info!("Callback events received: {:?}", *callback_counts);
-    }
-
-    // Check that we received events via stream
-    {
-        let stream_counts = stream_counter.lock().unwrap();
-        info!("Stream events received: {:?}", *stream_counts);
-    }
-
-    // Cleanup
-    info!("Test completed, cleaning up");
-    client.disconnect().await.unwrap();
-    server.shutdown().await;
-    info!("Test finished successfully");
-}
-
-#[tokio::test]
-async fn test_unsubscribe() {
-    let server = mock_server::MockServer::new().await;
-    let url = format!("ws://{}", server.address);
-
-    info!("Starting unsubscribe test with server at {}", url);
-
-    // Create and connect client
-    let mut client = DXLinkClient::new(&url, "test-token");
-    let _event_stream = client.connect().await.unwrap();
-    info!("Client connected");
-
-    // Create feed channel
-    let channel_id = client.create_feed_channel("AUTO").await.unwrap();
-    info!("Feed channel created: {}", channel_id);
-
-    // Setup feed
-    client
-        .setup_feed(channel_id, &[EventType::Quote])
-        .await
-        .unwrap();
-    info!("Feed setup completed");
-
-    // Subscribe to symbols
-    let subscriptions = vec![
-        FeedSubscription {
-            event_type: "Quote".to_string(),
-            symbol: "AAPL".to_string(),
-            from_time: None,
-            source: None,
-        },
-        FeedSubscription {
-            event_type: "Quote".to_string(),
-            symbol: "MSFT".to_string(),
-            from_time: None,
-            source: None,
-        },
-    ];
-
-    info!("Sending initial subscription");
-    client
-        .subscribe(channel_id, subscriptions.clone())
-        .await
-        .unwrap();
-    info!("Initial subscription completed");
-
-    // Wait for subscribe message to be processed
-    sleep(Duration::from_millis(200)).await;
-
-    // Unsubscribe from one symbol
-    let unsubscribe = vec![FeedSubscription {
+fn quote_sub(symbol: &str) -> FeedSubscription {
+    FeedSubscription {
         event_type: "Quote".to_string(),
-        symbol: "AAPL".to_string(),
+        symbol: symbol.to_string(),
         from_time: None,
         source: None,
-    }];
-
-    info!("Sending unsubscribe request");
-    let result = client.unsubscribe(channel_id, unsubscribe).await;
-    assert!(result.is_ok(), "Failed to unsubscribe: {:?}", result);
-    info!("Unsubscribe request completed");
-
-    // Wait for unsubscribe message to be processed
-    sleep(Duration::from_millis(200)).await;
-
-    // Check unsubscribe message
-    let messages = server.get_received_messages();
-
-    // Use a safer finder that handles JSON structure variations
-    let unsubscribe_msg = messages.iter().find(|m| {
-        m.get("type")
-            .is_some_and(|t| t.as_str().unwrap_or("") == "FEED_SUBSCRIPTION")
-            && m.get("channel")
-                .is_some_and(|c| c.as_u64() == Some(channel_id as u64))
-            && m.get("remove").is_some()
-    });
-
-    if unsubscribe_msg.is_none() {
-        info!("WARNING: Can't find unsubscribe message");
-        // Print all feed subscription messages
-        for msg in messages.iter() {
-            if let Some(msg_type) = msg.get("type")
-                && msg_type.as_str().unwrap_or("") == "FEED_SUBSCRIPTION"
-            {
-                info!("FEED_SUBSCRIPTION message: {:?}", msg);
-            }
-        }
     }
-
-    // Skip assertion for now
-    // assert!(unsubscribe_msg.is_some(), "No unsubscribe message sent");
-
-    // Reset all subscriptions
-    info!("Sending reset subscriptions request");
-    let result = client.reset_subscriptions(channel_id).await;
-    assert!(
-        result.is_ok(),
-        "Failed to reset subscriptions: {:?}",
-        result
-    );
-    info!("Reset subscriptions completed");
-
-    // Wait for reset message to be processed
-    sleep(Duration::from_millis(200)).await;
-
-    // Check reset message
-    let messages = server.get_received_messages();
-
-    let reset_msg = messages.iter().find(|m| {
-        m.get("type")
-            .is_some_and(|t| t.as_str().unwrap_or("") == "FEED_SUBSCRIPTION")
-            && m.get("channel")
-                .is_some_and(|c| c.as_u64() == Some(channel_id as u64))
-            && m.get("reset").is_some()
-    });
-
-    if reset_msg.is_none() {
-        info!("WARNING: Can't find reset message");
-        // Print subscription messages
-        for msg in messages.iter() {
-            if let Some(msg_type) = msg.get("type")
-                && msg_type.as_str().unwrap_or("") == "FEED_SUBSCRIPTION"
-            {
-                info!("FEED_SUBSCRIPTION message: {:?}", msg);
-            }
-        }
-    }
-
-    // Skip assertion for now
-    // assert!(reset_msg.is_some(), "No reset subscription message sent");
-
-    // Cleanup
-    client.disconnect().await.unwrap();
-    server.shutdown().await;
 }
 
 #[tokio::test]
-async fn test_historical_data() {
-    let server = mock_server::MockServer::new().await;
-    let url = format!("ws://{}", server.address);
+async fn test_unsubscribe_sends_a_remove_for_the_right_symbol() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, channel_id) = connected_feed(&server, &[EventType::Quote]).await;
 
-    info!("Starting historical data test with server at {}", url);
-
-    // Create and connect client
-    let mut client = DXLinkClient::new(&url, "test-token");
-    let _event_stream = client.connect().await.unwrap();
-    info!("Client connected");
-
-    // Create feed channel
-    let channel_id = client.create_feed_channel("AUTO").await.unwrap();
-    info!("Feed channel created: {}", channel_id);
-
-    // Setup feed for candles
     client
-        .setup_feed(channel_id, &[EventType::Candle])
+        .subscribe(channel_id, vec![quote_sub("AAPL"), quote_sub("MSFT")])
         .await
-        .unwrap();
-    info!("Candle feed setup completed");
+        .expect("failed to subscribe");
 
-    // Subscribe to historical data (candles)
-    let timestamp = chrono::Utc::now().timestamp_millis() - (24 * 60 * 60 * 1000); // 24 hours ago
-    info!("Using fromTime timestamp: {}", timestamp);
+    server
+        .wait_for("the add subscription", |m| {
+            is_type_on_channel("FEED_SUBSCRIPTION", channel_id)(m) && m.get("add").is_some()
+        })
+        .await;
 
-    let subscriptions = vec![FeedSubscription {
-        event_type: "Candle".to_string(),
-        symbol: "AAPL{=5m}".to_string(), // 5-minute candles
-        from_time: Some(timestamp),
-        source: None,
-    }];
+    client
+        .unsubscribe(channel_id, vec![quote_sub("AAPL")])
+        .await
+        .expect("failed to unsubscribe");
 
-    info!("Sending historical data subscription");
-    let result = client.subscribe(channel_id, subscriptions).await;
-    assert!(
-        result.is_ok(),
-        "Failed to subscribe to historical data: {:?}",
-        result
+    let removal = server
+        .wait_for("the remove subscription", |m| {
+            is_type_on_channel("FEED_SUBSCRIPTION", channel_id)(m) && m.get("remove").is_some()
+        })
+        .await;
+
+    let removed = removal["remove"]
+        .as_array()
+        .expect("remove should be a list");
+    assert_eq!(removed.len(), 1, "only AAPL was unsubscribed: {removed:?}");
+    assert_eq!(removed[0]["symbol"], "AAPL");
+    assert_eq!(removed[0]["type"], "Quote");
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+#[tokio::test]
+async fn test_reset_subscriptions_sends_the_reset_flag() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, channel_id) = connected_feed(&server, &[EventType::Quote]).await;
+
+    client
+        .subscribe(channel_id, vec![quote_sub("AAPL")])
+        .await
+        .expect("failed to subscribe");
+    server
+        .wait_for("the add subscription", |m| {
+            is_type_on_channel("FEED_SUBSCRIPTION", channel_id)(m) && m.get("add").is_some()
+        })
+        .await;
+
+    client
+        .reset_subscriptions(channel_id)
+        .await
+        .expect("failed to reset subscriptions");
+
+    let reset = server
+        .wait_for("the reset subscription", |m| {
+            is_type_on_channel("FEED_SUBSCRIPTION", channel_id)(m) && m.get("reset").is_some()
+        })
+        .await;
+
+    assert_eq!(
+        reset["reset"], true,
+        "reset must be sent as true, got {reset:#?}"
     );
-    info!("Historical data subscription completed");
 
-    // Wait for subscription message to be processed
-    sleep(Duration::from_millis(200)).await;
+    client.disconnect().await.expect("failed to disconnect");
+}
 
-    // Check subscription message with from_time
-    let messages = server.get_received_messages();
+/// Historical data is requested by adding `fromTime` to the subscription. The
+/// value must reach the wire unchanged: it is epoch milliseconds and a silent
+/// unit conversion would quietly shift every candle.
+#[tokio::test]
+async fn test_historical_subscription_carries_from_time() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, channel_id) = connected_feed(&server, &[EventType::Candle]).await;
 
-    info!("Looking for FEED_SUBSCRIPTION with fromTime={}", timestamp);
+    // Fixed value rather than "now": the assertion is about faithful transport.
+    let from_time: i64 = 1_700_000_000_000;
 
-    // Print all relevant messages for debugging
-    for msg in messages.iter() {
-        if let Some(msg_type) = msg.get("type")
-            && msg_type.as_str().unwrap_or("") == "FEED_SUBSCRIPTION"
-        {
-            info!("Found FEED_SUBSCRIPTION: {:?}", msg);
+    client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Candle".to_string(),
+                symbol: "AAPL{=5m}".to_string(),
+                from_time: Some(from_time),
+                source: None,
+            }],
+        )
+        .await
+        .expect("failed to subscribe to historical data");
 
-            if let Some(add) = msg.get("add")
-                && let Some(add_array) = add.as_array()
-            {
-                for (i, sub) in add_array.iter().enumerate() {
-                    info!("  Subscription {}: {:?}", i, sub);
+    let subscription = server
+        .wait_for("the historical subscription", |m| {
+            is_type_on_channel("FEED_SUBSCRIPTION", channel_id)(m) && m.get("add").is_some()
+        })
+        .await;
 
-                    if let Some(from_time) = sub.get("fromTime") {
-                        info!("  Has fromTime: {}", from_time);
-                    } else {
-                        info!("  No fromTime found");
-                    }
-                }
-            }
-        }
-    }
+    let added = subscription["add"]
+        .as_array()
+        .expect("add should be a list");
+    assert_eq!(added.len(), 1);
+    assert_eq!(added[0]["symbol"], "AAPL{=5m}");
+    assert_eq!(added[0]["type"], "Candle");
+    assert_eq!(
+        added[0]["fromTime"].as_i64(),
+        Some(from_time),
+        "fromTime must reach the wire unchanged"
+    );
 
-    // Use a more robust finder that handles JSON structure variations
-    let subscription = messages.iter().find(|m| {
-        if let Some(msg_type) = m.get("type") {
-            if msg_type.as_str().unwrap_or("") != "FEED_SUBSCRIPTION" {
-                return false;
-            }
-
-            if let Some(channel) = m.get("channel") {
-                if channel.as_u64() != Some(channel_id as u64) {
-                    return false;
-                }
-
-                if let Some(add) = m.get("add")
-                    && let Some(add_array) = add.as_array()
-                {
-                    for sub in add_array {
-                        if let Some(from_time) = sub.get("fromTime")
-                            && from_time.as_i64() == Some(timestamp)
-                        {
-                            return true;
-                        }
-                    }
-                }
-            }
-        }
-        false
-    });
-
-    if subscription.is_none() {
-        info!("WARNING: Can't find subscription with fromTime");
-    } else {
-        info!("Found subscription with fromTime: {:?}", subscription);
-    }
-
-    // Cleanup
-    client.disconnect().await.unwrap();
-    server.shutdown().await;
+    client.disconnect().await.expect("failed to disconnect");
 }

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -15,180 +15,7 @@ use dxlink::{DXLinkClient, EventType, FeedSubscription, MarketEvent};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-/// A DXLink server that speaks enough of the protocol to run a full session,
-/// and can interleave WebSocket control frames with every response.
-mod flow_server {
-    use futures_util::{SinkExt, StreamExt};
-    use serde_json::{Value, json};
-    use std::net::SocketAddr;
-    use std::sync::{Arc, Mutex};
-    use tokio::net::TcpListener;
-    use tokio_tungstenite::tungstenite::Message;
-
-    pub struct FlowServer {
-        pub address: SocketAddr,
-        received: Arc<Mutex<Vec<Value>>>,
-    }
-
-    impl FlowServer {
-        /// Every message the client sent, in order.
-        pub fn received(&self) -> Vec<Value> {
-            self.received
-                .lock()
-                .expect("received lock poisoned")
-                .clone()
-        }
-
-        pub fn url(&self) -> String {
-            format!("ws://{}", self.address)
-        }
-    }
-
-    /// What the server does besides answering the protocol.
-    #[derive(Clone, Copy, PartialEq)]
-    pub enum Behaviour {
-        /// Plain text responses only.
-        Plain,
-        /// Send a Ping before, and a Pong after, every response. Control frames
-        /// are ordinary traffic and must never break a session.
-        ControlFrames,
-        /// Complete the handshake, then hang up once the feed is subscribed.
-        CloseAfterSubscribe,
-    }
-
-    /// Column order for COMPACT rows. This MUST match the field list that
-    /// `setup_feed` requests for each event type — the server echoes back the
-    /// fields in the order they were asked for.
-    fn quote_row(symbol: &str) -> Value {
-        // eventType, eventSymbol, bidPrice, askPrice, bidSize, askSize
-        json!(["Quote", symbol, 150.25, 150.5, 100.0, 150.0])
-    }
-
-    fn trade_row(symbol: &str) -> Value {
-        // eventType, eventSymbol, price, size, dayVolume
-        json!(["Trade", symbol, 151.25, 75.0, 10_000_000.0])
-    }
-
-    pub async fn start(behaviour: Behaviour) -> FlowServer {
-        let listener = TcpListener::bind("127.0.0.1:0")
-            .await
-            .expect("failed to bind flow server");
-        let address = listener.local_addr().expect("failed to read local addr");
-
-        let received = Arc::new(Mutex::new(Vec::new()));
-        let received_task = received.clone();
-
-        tokio::spawn(async move {
-            let (stream, _) = listener.accept().await.expect("failed to accept");
-            let mut ws = tokio_tungstenite::accept_async(stream)
-                .await
-                .expect("failed to handshake");
-
-            // One task owns the whole socket, so requests and responses stay
-            // ordered and there is no sink to share.
-            while let Some(Ok(message)) = ws.next().await {
-                let Message::Text(text) = message else {
-                    continue;
-                };
-                let Ok(value) = serde_json::from_str::<Value>(&text) else {
-                    continue;
-                };
-
-                received_task
-                    .lock()
-                    .expect("received lock poisoned")
-                    .push(value.clone());
-
-                let channel = value["channel"].as_u64().unwrap_or(0);
-                let mut responses: Vec<Value> = Vec::new();
-                let mut close_after = false;
-
-                match value["type"].as_str().unwrap_or("") {
-                    "SETUP" => {
-                        responses.push(json!({
-                            "channel": channel,
-                            "type": "SETUP",
-                            "version": "1.0.0",
-                            "keepaliveTimeout": 60,
-                            "acceptKeepaliveTimeout": 60
-                        }));
-                        responses.push(json!({
-                            "channel": 0,
-                            "type": "AUTH_STATE",
-                            "state": "UNAUTHORIZED"
-                        }));
-                    }
-                    "AUTH" => responses.push(json!({
-                        "channel": 0,
-                        "type": "AUTH_STATE",
-                        "state": "AUTHORIZED",
-                        "userId": "test-user"
-                    })),
-                    "CHANNEL_REQUEST" => responses.push(json!({
-                        "channel": channel,
-                        "type": "CHANNEL_OPENED",
-                        "service": "FEED",
-                        "parameters": {}
-                    })),
-                    "FEED_SETUP" => responses.push(json!({
-                        "channel": channel,
-                        "type": "FEED_CONFIG",
-                        "aggregationPeriod": 0.1,
-                        "dataFormat": "COMPACT"
-                    })),
-                    "FEED_SUBSCRIPTION" => {
-                        if let Some(add) = value.get("add").and_then(|a| a.as_array()) {
-                            for sub in add {
-                                let symbol = sub["symbol"].as_str().unwrap_or("");
-                                let row = match sub["type"].as_str().unwrap_or("") {
-                                    "Quote" => quote_row(symbol),
-                                    "Trade" => trade_row(symbol),
-                                    _ => continue,
-                                };
-                                let event_type = sub["type"].as_str().unwrap_or("");
-                                responses.push(json!({
-                                    "channel": channel,
-                                    "type": "FEED_DATA",
-                                    "data": [event_type, row]
-                                }));
-                            }
-                        }
-                        close_after = behaviour == Behaviour::CloseAfterSubscribe;
-                    }
-                    // KEEPALIVE and anything else needs no reply.
-                    _ => {}
-                }
-
-                for response in responses {
-                    if behaviour == Behaviour::ControlFrames {
-                        ws.send(Message::Ping(vec![7].into()))
-                            .await
-                            .expect("failed to send ping");
-                    }
-
-                    ws.send(Message::Text(response.to_string().into()))
-                        .await
-                        .expect("failed to send response");
-
-                    if behaviour == Behaviour::ControlFrames {
-                        ws.send(Message::Pong(Vec::new().into()))
-                            .await
-                            .expect("failed to send pong");
-                    }
-                }
-
-                if close_after {
-                    let _ = ws.send(Message::Close(None)).await;
-                    return;
-                }
-            }
-        });
-
-        FlowServer { address, received }
-    }
-}
-
-use flow_server::Behaviour;
+use crate::fixture::{Behaviour, MockServer, expected};
 
 /// Collects events off the stream until `wanted` have arrived or time runs out.
 async fn collect_events(
@@ -217,7 +44,7 @@ async fn collect_events(
 /// Runs the same sequence as the `basic` example and checks the market data that
 /// comes out the other end, field by field.
 async fn run_full_session(behaviour: Behaviour) {
-    let server = flow_server::start(behaviour).await;
+    let server = MockServer::start(behaviour).await;
 
     let mut client = DXLinkClient::new(&server.url(), "test-token");
     let mut event_stream = client.connect().await.expect("failed to connect");
@@ -282,10 +109,10 @@ async fn run_full_session(behaviour: Behaviour) {
     // eventType and eventSymbol swap, this reads "Quote" instead of "AAPL".
     assert_eq!(quote.event_symbol, "AAPL");
     assert_eq!(quote.event_type, "Quote");
-    assert_eq!(quote.bid_price, 150.25);
-    assert_eq!(quote.ask_price, 150.5);
-    assert_eq!(quote.bid_size, 100.0);
-    assert_eq!(quote.ask_size, 150.0);
+    assert_eq!(quote.bid_price, expected::BID_PRICE);
+    assert_eq!(quote.ask_price, expected::ASK_PRICE);
+    assert_eq!(quote.bid_size, expected::BID_SIZE);
+    assert_eq!(quote.ask_size, expected::ASK_SIZE);
 
     let trade = events
         .iter()
@@ -296,9 +123,9 @@ async fn run_full_session(behaviour: Behaviour) {
         .expect("no Trade event reached the consumer");
 
     assert_eq!(trade.event_symbol, "AAPL");
-    assert_eq!(trade.price, 151.25);
-    assert_eq!(trade.size, 75.0);
-    assert_eq!(trade.day_volume, 10_000_000.0);
+    assert_eq!(trade.price, expected::PRICE);
+    assert_eq!(trade.size, expected::SIZE);
+    assert_eq!(trade.day_volume, expected::DAY_VOLUME);
 
     // The callback path is separate from the stream path; both must fire.
     // Copy out of the lock in its own scope so no guard reaches the await below.
@@ -317,7 +144,7 @@ async fn run_full_session(behaviour: Behaviour) {
 
 #[tokio::test]
 async fn test_full_session_delivers_market_data() {
-    run_full_session(Behaviour::Plain).await;
+    run_full_session(Behaviour::Normal).await;
 }
 
 /// End-to-end regression for issue #4. Before the fix the first Ping aborted the
@@ -330,7 +157,7 @@ async fn test_full_session_survives_interleaved_control_frames() {
 /// A callback registered for one symbol must not see another symbol's events.
 #[tokio::test]
 async fn test_callback_is_scoped_to_its_symbol() {
-    let server = flow_server::start(Behaviour::Plain).await;
+    let server = MockServer::start(Behaviour::Normal).await;
 
     let mut client = DXLinkClient::new(&server.url(), "test-token");
     let mut event_stream = client.connect().await.expect("failed to connect");
@@ -402,7 +229,7 @@ async fn test_callback_is_scoped_to_its_symbol() {
 /// and `disconnect` still succeeds.
 #[tokio::test]
 async fn test_session_survives_server_close() {
-    let server = flow_server::start(Behaviour::CloseAfterSubscribe).await;
+    let server = MockServer::start(Behaviour::CloseAfterSubscribe).await;
 
     let mut client = DXLinkClient::new(&server.url(), "test-token");
     let mut event_stream = client.connect().await.expect("failed to connect");
@@ -448,7 +275,7 @@ async fn test_session_survives_server_close() {
 /// expects, in order, with the token it was given.
 #[tokio::test]
 async fn test_session_sends_the_expected_protocol_messages() {
-    let server = flow_server::start(Behaviour::Plain).await;
+    let server = MockServer::start(Behaviour::Normal).await;
 
     let mut client = DXLinkClient::new(&server.url(), "test-token");
     let mut event_stream = client.connect().await.expect("failed to connect");

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -1,472 +1,177 @@
-// integration_tests.rs
+//! Protocol-level integration tests: what the client puts on the wire, and how
+//! it reacts to what comes back.
+//!
+//! Event delivery is covered in `dxlink_flow.rs`.
+
+use crate::fixture::{Behaviour, MockServer, is_type, is_type_on_channel};
 use dxlink::{DXLinkClient, DXLinkError, EventType};
 use std::time::Duration;
-use tokio::time::sleep;
 
-// Helper function to create a mock WebSocket server for testing
-mod mock_server {
-    use futures_util::{SinkExt, StreamExt};
-    use serde_json::{Value, json};
-    use std::net::SocketAddr;
-    use std::sync::{Arc, Mutex};
-    use tokio::net::TcpListener;
-    use tokio::sync::mpsc;
-    use tokio_tungstenite::tungstenite::Message;
-    use tracing::{error, info};
-
-    pub struct MockServer {
-        pub address: SocketAddr,
-        pub received_messages: Arc<Mutex<Vec<Value>>>,
-        pub messages_to_send: mpsc::Sender<(u32, String)>, // (channel_id, message)
-        pub shutdown: mpsc::Sender<()>,
-    }
-
-    impl MockServer {
-        pub async fn new() -> Self {
-            let listener = TcpListener::bind("127.0.0.1:0")
-                .await
-                .expect("Failed to bind");
-            let address = listener.local_addr().expect("Failed to get local address");
-
-            // Channel for custom messages from test to connected clients
-            let (message_tx, mut message_rx) = mpsc::channel::<(u32, String)>(100);
-
-            // Channel for shutdown signal
-            let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
-
-            // Storage for received messages
-            let received_messages = Arc::new(Mutex::new(Vec::new()));
-
-            // Track active WebSocket sinks by channel ID
-            #[allow(clippy::type_complexity)]
-            let websocket_sinks: Arc<Mutex<Vec<(u32, mpsc::Sender<String>)>>> =
-                Arc::new(Mutex::new(Vec::new()));
-
-            // Clone for tasks
-            let websocket_sinks_clone = websocket_sinks.clone();
-            let received_messages_clone = received_messages.clone();
-
-            // Task to forward messages from test to appropriate client
-            tokio::spawn(async move {
-                while let Some((channel_id, msg)) = message_rx.recv().await {
-                    // Create a copy of the senders we need to use
-                    let senders_to_use = {
-                        let sinks = websocket_sinks.lock().unwrap();
-                        sinks
-                            .iter()
-                            .filter(|(id, _)| *id == channel_id || channel_id == 0)
-                            .map(|(_, sender)| sender.clone())
-                            .collect::<Vec<_>>()
-                    };
-
-                    // Now send to each one without holding the lock
-                    for sender in senders_to_use {
-                        let _ = sender.send(msg.clone()).await;
-                    }
-                }
-            });
-
-            // Main server task
-            tokio::spawn(async move {
-                tokio::select! {
-                    _ = async {
-                        loop {
-                            match listener.accept().await {
-                                Ok((stream, _)) => {
-                                    let ws_stream = tokio_tungstenite::accept_async(stream).await.expect("Failed to accept websocket");
-                                    let (write, mut read) = ws_stream.split();
-
-                                    // Create a channel for sending messages to this client
-                                    let (client_tx, mut client_rx) = mpsc::channel::<String>(100);
-
-                                    // Initially add with channel 0 (main)
-                                    {
-                                        let mut sinks = websocket_sinks_clone.lock().unwrap();
-                                        sinks.push((0, client_tx.clone()));
-                                    }
-
-                                    // Clone for tasks
-                                    let received_messages = received_messages_clone.clone();
-                                    let websocket_sinks = websocket_sinks_clone.clone();
-
-                                    // Task to send messages to client
-                                    let mut write_handle = write;
-                                    tokio::spawn(async move {
-                                        while let Some(msg) = client_rx.recv().await {
-                                            if let Err(e) = write_handle.send(Message::Text(msg.into())).await {
-                                                error!("Error sending to client: {}", e);
-                                                break;
-                                            }
-                                        }
-                                    });
-
-                                    // Task to process incoming client messages
-                                    tokio::spawn(async move {
-                                        while let Some(msg) = read.next().await {
-                                            if let Ok(Message::Text(text)) = msg {
-                                                // Parse the message
-                                                if let Ok(value) = serde_json::from_str::<Value>(&text) {
-                                                    // Store ALL received messages for later inspection - CRITICAL
-                                                    {
-                                                        let mut messages = received_messages.lock().unwrap();
-                                                        info!("MockServer received message type: {}", value.get("type").unwrap());
-                                                        messages.push(value.clone());
-                                                    }
-
-                                                    // Get the message type and channel
-                                                    let msg_type = value["type"].as_str().unwrap_or("");
-                                                    let channel_id = value["channel"].as_u64().unwrap_or(0) as u32;
-
-                                                    // Auto-respond based on message type
-                                                    match msg_type {
-                                                        "SETUP" => {
-                                                            let response = json!({
-                                                                "channel": channel_id,
-                                                                "type": "SETUP",
-                                                                "version": "1.0.0",
-                                                                "keepaliveTimeout": 60,
-                                                                "acceptKeepaliveTimeout": 60
-                                                            }).to_string();
-
-                                                            let _ = client_tx.send(response).await;
-
-                                                            // Send AUTH_STATE
-                                                            let auth_state = json!({
-                                                                "channel": 0,
-                                                                "type": "AUTH_STATE",
-                                                                "state": "UNAUTHORIZED"
-                                                            }).to_string();
-
-                                                            let _ = client_tx.send(auth_state).await;
-                                                        },
-                                                        "AUTH" => {
-                                                            let auth_response = json!({
-                                                                "channel": 0,
-                                                                "type": "AUTH_STATE",
-                                                                "state": "AUTHORIZED",
-                                                                "userId": "test-user"
-                                                            }).to_string();
-
-                                                            let _ = client_tx.send(auth_response).await;
-                                                        },
-                                                        "CHANNEL_REQUEST" => {
-                                                            if value["service"].as_str().unwrap_or("") == "FEED" {
-                                                                // Register this client with the requested channel ID
-                                                                {
-                                                                    let mut sinks = websocket_sinks.lock().unwrap();
-                                                                    sinks.push((channel_id, client_tx.clone()));
-                                                                }
-
-                                                                let channel_opened = json!({
-                                                                    "channel": channel_id,
-                                                                    "type": "CHANNEL_OPENED",
-                                                                    "service": "FEED",
-                                                                    "parameters": {}
-                                                                }).to_string();
-
-                                                                let _ = client_tx.send(channel_opened).await;
-                                                            }
-                                                        },
-                                                        "FEED_SETUP" => {
-                                                            let feed_config = json!({
-                                                                "channel": channel_id,
-                                                                "type": "FEED_CONFIG",
-                                                                "aggregationPeriod": 0.1,
-                                                                "dataFormat": "COMPACT"
-                                                            }).to_string();
-
-                                                            let _ = client_tx.send(feed_config).await;
-                                                        },
-                                                        "FEED_SUBSCRIPTION" => {
-                                                            // This is the critical message we need to handle properly
-                                                            if let Some(add) = value.get("add")
-                                                                && let Some(subscriptions) = add.as_array() {
-                                                                    for sub in subscriptions {
-                                                                        let event_type = sub["type"].as_str().unwrap_or("");
-                                                                        let symbol = sub["symbol"].as_str().unwrap_or("");
-
-                                                                        // Send mock data for this subscription
-                                                                        if event_type == "Quote" {
-                                                                            let quote_data = json!({
-                                                                                "channel": channel_id,
-                                                                                "type": "FEED_DATA",
-                                                                                "data": [
-                                                                                    "Quote",
-                                                                                    [
-                                                                                        symbol,
-                                                                                        "Quote",
-                                                                                        150.25,
-                                                                                        150.50,
-                                                                                        100,
-                                                                                        150
-                                                                                    ]
-                                                                                ]
-                                                                            }).to_string();
-
-                                                                            let _ = client_tx.send(quote_data).await;
-                                                                        } else if event_type == "Trade" {
-                                                                            let trade_data = json!({
-                                                                                "channel": channel_id,
-                                                                                "type": "FEED_DATA",
-                                                                                "data": [
-                                                                                    "Trade",
-                                                                                    [
-                                                                                        symbol,
-                                                                                        "Trade",
-                                                                                        151.25,
-                                                                                        75,
-                                                                                        10000000
-                                                                                    ]
-                                                                                ]
-                                                                            }).to_string();
-
-                                                                            let _ = client_tx.send(trade_data).await;
-                                                                        }
-                                                                    }
-                                                                }
-                                                        },
-                                                        "CHANNEL_CANCEL" => {
-                                                            // Remove this channel from tracked sinks
-                                                            {
-                                                                let mut sinks = websocket_sinks.lock().unwrap();
-                                                                sinks.retain(|(id, _)| *id != channel_id);
-                                                            }
-
-                                                            let channel_closed = json!({
-                                                                "channel": channel_id,
-                                                                "type": "CHANNEL_CLOSED"
-                                                            }).to_string();
-
-                                                            let _ = client_tx.send(channel_closed).await;
-                                                        },
-                                                        _ => {}
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    });
-                                },
-                                Err(e) => {
-                                    error!("Error accepting connection: {}", e);
-                                    break;
-                                }
-                            }
-                        }
-                    } => {},
-                    _ = shutdown_rx.recv() => {
-                        info!("Mock server shutting down");
-                    }
-                }
-            });
-
-            MockServer {
-                address,
-                received_messages,
-                messages_to_send: message_tx,
-                shutdown: shutdown_tx,
-            }
-        }
-
-        pub async fn send(&self, message: &str) {
-            // Send to all clients (channel 0)
-            let _ = self.messages_to_send.send((0, message.to_string())).await;
-        }
-
-        pub fn get_received_messages(&self) -> Vec<Value> {
-            let messages = self.received_messages.lock().unwrap().clone();
-            info!("MockServer returning {} received messages", messages.len());
-            for (i, msg) in messages.iter().enumerate() {
-                if let Some(msg_type) = msg.get("type") {
-                    info!("  Message {}: type={}", i, msg_type);
-                }
-            }
-            messages
-        }
-
-        pub async fn shutdown(self) {
-            let _ = self.shutdown.send(()).await;
-        }
-    }
-}
-
-// A test that verifies the basic connection and authentication flow
 #[tokio::test]
 async fn test_connect_and_authenticate() {
-    let server = mock_server::MockServer::new().await;
-    let url = format!("ws://{}", server.address);
+    let server = MockServer::start(Behaviour::Normal).await;
 
-    // Create client with test token
-    let mut client = DXLinkClient::new(&url, "test-token");
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
 
-    // Connect to server
-    let result = client.connect().await;
-    assert!(result.is_ok(), "Failed to connect: {:?}", result);
-    let _event_stream = result.unwrap();
-
-    // Check that the server received the expected messages
-    let messages = server.get_received_messages();
-
-    // Find SETUP message
-    let setup_msg = messages.iter().find(|m| m["type"] == "SETUP");
-    assert!(setup_msg.is_some(), "No SETUP message sent");
-
-    // Find AUTH message
-    let auth_msg = messages.iter().find(|m| m["type"] == "AUTH");
-    assert!(auth_msg.is_some(), "No AUTH message sent");
-    assert_eq!(
-        auth_msg.unwrap()["token"],
-        "test-token",
-        "Incorrect token in AUTH message"
+    let setup = server.wait_for("SETUP", is_type("SETUP")).await;
+    assert_eq!(setup["channel"], 0, "SETUP must go out on the main channel");
+    assert!(
+        setup["version"].as_str().is_some_and(|v| !v.is_empty()),
+        "SETUP must carry a client version"
     );
 
-    // Cleanup
-    client.disconnect().await.unwrap();
-    server.shutdown().await;
+    let auth = server.wait_for("AUTH", is_type("AUTH")).await;
+    assert_eq!(auth["token"], "test-token");
+    assert_eq!(auth["channel"], 0);
+
+    client.disconnect().await.expect("failed to disconnect");
 }
 
-// Test creating a feed channel and setting it up
+/// A rejected token must surface as an authentication error, not as a hang and
+/// not as a success.
+#[tokio::test]
+async fn test_authentication_failure_is_reported() {
+    let server = MockServer::start(Behaviour::RejectAuth).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "invalid-token");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), client.connect())
+        .await
+        .expect("connect hung on a rejected token");
+
+    match result {
+        Err(DXLinkError::Authentication(msg)) => {
+            assert!(
+                msg.contains("UNAUTHORIZED"),
+                "error should name the state the server reported: {msg}"
+            );
+        }
+        Err(other) => panic!("expected an Authentication error, got: {other:?}"),
+        Ok(_) => panic!("connect succeeded against a server that rejected the token"),
+    }
+}
+
 #[tokio::test]
 async fn test_create_and_setup_feed() {
-    let server = mock_server::MockServer::new().await;
-    let url = format!("ws://{}", server.address);
+    let server = MockServer::start(Behaviour::Normal).await;
 
-    // Create and connect client
-    let mut client = DXLinkClient::new(&url, "test-token");
-    let _event_stream = client.connect().await.unwrap();
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
 
-    // Create feed channel
-    let channel_id = client.create_feed_channel("AUTO").await;
-    assert!(
-        channel_id.is_ok(),
-        "Failed to create feed channel: {:?}",
-        channel_id
-    );
-    let channel_id = channel_id.unwrap();
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
 
-    // Check channel request message
-    let messages = server.get_received_messages();
-    let channel_req = messages.iter().find(|m| {
-        m["type"] == "CHANNEL_REQUEST" && m["service"] == "FEED" && m["channel"] == channel_id
-    });
-    assert!(channel_req.is_some(), "No CHANNEL_REQUEST message sent");
-
-    // Setup feed channel
-    let result = client
-        .setup_feed(channel_id, &[EventType::Quote, EventType::Trade])
+    let request = server
+        .wait_for(
+            "CHANNEL_REQUEST",
+            is_type_on_channel("CHANNEL_REQUEST", channel_id),
+        )
         .await;
-    assert!(result.is_ok(), "Failed to setup feed: {:?}", result);
+    assert_eq!(request["service"], "FEED");
+    assert_eq!(request["parameters"]["contract"], "AUTO");
 
-    // Check feed setup message
-    let messages = server.get_received_messages();
-    let feed_setup = messages
+    client
+        .setup_feed(channel_id, &[EventType::Quote, EventType::Trade])
+        .await
+        .expect("failed to set up feed");
+
+    let setup = server
+        .wait_for("FEED_SETUP", is_type_on_channel("FEED_SETUP", channel_id))
+        .await;
+    assert_eq!(setup["acceptDataFormat"], "COMPACT");
+
+    // The requested field list is one half of the COMPACT contract; the decoder
+    // in utils.rs is the other. Pin it here so a change to either is visible.
+    let quote_fields: Vec<&str> = setup["acceptEventFields"]["Quote"]
+        .as_array()
+        .expect("no Quote field list")
         .iter()
-        .find(|m| m["type"] == "FEED_SETUP" && m["channel"] == channel_id);
-    assert!(feed_setup.is_some(), "No FEED_SETUP message sent");
+        .filter_map(|f| f.as_str())
+        .collect();
+    assert_eq!(
+        quote_fields,
+        vec![
+            "eventType",
+            "eventSymbol",
+            "bidPrice",
+            "askPrice",
+            "bidSize",
+            "askSize"
+        ]
+    );
 
-    // Cleanup
-    client.disconnect().await.unwrap();
-    server.shutdown().await;
+    client.disconnect().await.expect("failed to disconnect");
 }
 
-// Test closing a channel
 #[tokio::test]
 async fn test_close_channel() {
-    let server = mock_server::MockServer::new().await;
-    let url = format!("ws://{}", server.address);
+    let server = MockServer::start(Behaviour::Normal).await;
 
-    // Create and connect client
-    let mut client = DXLinkClient::new(&url, "test-token");
-    let _event_stream = client.connect().await.unwrap();
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
 
-    // Create feed channel
-    let channel_id = client.create_feed_channel("AUTO").await.unwrap();
+    client
+        .close_channel(channel_id)
+        .await
+        .expect("failed to close channel");
 
-    // Close the channel
-    let result = client.close_channel(channel_id).await;
-    assert!(result.is_ok(), "Failed to close channel: {:?}", result);
-
-    // Check channel cancel message
-    let messages = server.get_received_messages();
-    let cancel_msg = messages
-        .iter()
-        .find(|m| m["type"] == "CHANNEL_CANCEL" && m["channel"] == channel_id);
-
-    assert!(cancel_msg.is_some(), "No CHANNEL_CANCEL message sent");
-
-    // Cleanup
-    client.disconnect().await.unwrap();
-    server.shutdown().await;
-}
-
-// Test error handling - non-existent channel
-#[tokio::test]
-async fn test_error_non_existent_channel() {
-    let server = mock_server::MockServer::new().await;
-    let url = format!("ws://{}", server.address);
-
-    // Create and connect client
-    let mut client = DXLinkClient::new(&url, "test-token");
-    let _event_stream = client.connect().await.unwrap();
-
-    // Try to use a channel that doesn't exist
-    let result = client.setup_feed(999, &[EventType::Quote]).await;
-    assert!(result.is_err(), "Expected error for non-existent channel");
-
-    // Check error type
-    match result {
-        Err(DXLinkError::Channel(_)) => {} // Expected error type
-        Err(e) => panic!("Wrong error type: {:?}", e),
-        Ok(_) => panic!("Expected error but got Ok"),
-    }
-
-    // Cleanup
-    client.disconnect().await.unwrap();
-    server.shutdown().await;
-}
-
-// Test keepalive mechanism
-#[tokio::test]
-async fn test_keepalive() {
-    let server = mock_server::MockServer::new().await;
-    let url = format!("ws://{}", server.address);
-
-    // Create and connect client
-    let mut client = DXLinkClient::new(&url, "test-token");
-    let _event_stream = client.connect().await.unwrap();
-
-    // Wait for keepalive to be sent (adjust time based on keepalive interval)
-    sleep(Duration::from_secs(20)).await;
-
-    // Check keepalive messages
-    let messages = server.get_received_messages();
-    let keepalive_msgs = messages.iter().filter(|m| m["type"] == "KEEPALIVE").count();
-
-    assert!(keepalive_msgs > 0, "No KEEPALIVE messages sent");
-
-    // Cleanup
-    client.disconnect().await.unwrap();
-    server.shutdown().await;
-}
-
-// Test authentication failure
-#[tokio::test]
-async fn test_authentication_failure() {
-    let server = mock_server::MockServer::new().await;
-    let url = format!("ws://{}", server.address);
-
-    // Create client with invalid token
-    let mut client = DXLinkClient::new(&url, "invalid-token");
-
-    // Override normal auth response with failure
     server
-        .send(r#"{"channel":0,"type":"AUTH_STATE","state":"UNAUTHORIZED"}"#)
+        .wait_for(
+            "CHANNEL_CANCEL",
+            is_type_on_channel("CHANNEL_CANCEL", channel_id),
+        )
         .await;
 
-    // Connect to server (should fail due to authentication issues)
-    let _result = client.connect().await;
+    // A closed channel is no longer usable.
+    let result = client.setup_feed(channel_id, &[EventType::Quote]).await;
+    assert!(
+        matches!(result, Err(DXLinkError::Channel(_))),
+        "a closed channel should be rejected, got: {result:?}"
+    );
 
-    // Either connection will fail or it will hang waiting for AUTH_STATE response
-    // Force disconnect to clean up regardless
-    let _ = client.disconnect().await;
-    server.shutdown().await;
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+#[tokio::test]
+async fn test_error_non_existent_channel() {
+    let server = MockServer::start(Behaviour::Normal).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+
+    let result = client.setup_feed(999, &[EventType::Quote]).await;
+    assert!(
+        matches!(result, Err(DXLinkError::Channel(_))),
+        "expected a Channel error for an unknown channel, got: {result:?}"
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// The client must keep the session alive on its own. Virtual time drives the
+/// interval so the suite does not spend 20 real seconds proving it.
+#[tokio::test(start_paused = true)]
+async fn test_client_sends_keepalives() {
+    let server = MockServer::start(Behaviour::Normal).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+
+    // Past one keepalive interval; with time paused this costs nothing.
+    tokio::time::advance(Duration::from_secs(20)).await;
+
+    // Back to real time before waiting: delivering the keepalive is real socket
+    // I/O, and a virtual-time timeout would expire before it lands.
+    tokio::time::resume();
+
+    server.wait_for("KEEPALIVE", is_type("KEEPALIVE")).await;
+
+    client.disconnect().await.expect("failed to disconnect");
 }

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -1,0 +1,307 @@
+//! The single offline DXLink server used by every integration test.
+//!
+//! Two properties matter more than convenience here.
+//!
+//! It binds an **ephemeral port**, so the suite stays parallel-safe. The
+//! fixtures this replaces bound 3030 and 3031, which is why six connection
+//! tests were disabled as "port conflicts".
+//!
+//! It emits COMPACT rows in **the exact field order the client asked for** in
+//! its own `FEED_SETUP` message, rather than in an order hardcoded here. That
+//! makes the event tests a real check of the `setup_feed` ↔ `parse_compact_data`
+//! contract: if the requested field list and the parser stride ever diverge, the
+//! decoded values stop matching and the test fails. The fixtures this replaces
+//! hardcoded `[symbol, eventType, ...]`, the reverse of what `setup_feed` asks
+//! for, which is why no test could assert a decoded symbol.
+
+#![allow(dead_code)]
+
+use serde_json::{Value, json};
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::Notify;
+
+use futures_util::{SinkExt, StreamExt};
+use tokio_tungstenite::tungstenite::Message;
+
+/// How long a `wait_for` may block before the test is declared failed.
+const WAIT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What the server does beyond answering the protocol normally.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum Behaviour {
+    /// Plain, successful session.
+    Normal,
+    /// Send a Ping before and a Pong after every response. Control frames are
+    /// ordinary traffic and must never break a session.
+    ControlFrames,
+    /// Answer `AUTH` with `UNAUTHORIZED` instead of `AUTHORIZED`.
+    RejectAuth,
+    /// Complete the session, then hang up once the feed is subscribed.
+    CloseAfterSubscribe,
+}
+
+pub struct MockServer {
+    pub address: SocketAddr,
+    received: Arc<Mutex<Vec<Value>>>,
+    arrived: Arc<Notify>,
+}
+
+impl MockServer {
+    pub async fn start(behaviour: Behaviour) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind mock server");
+        let address = listener.local_addr().expect("failed to read local addr");
+
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let arrived = Arc::new(Notify::new());
+
+        let received_task = received.clone();
+        let arrived_task = arrived.clone();
+
+        tokio::spawn(async move {
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            let Ok(mut ws) = tokio_tungstenite::accept_async(stream).await else {
+                return;
+            };
+
+            // Field order per (channel, event type), learned from FEED_SETUP.
+            let mut event_fields: HashMap<(u64, String), Vec<String>> = HashMap::new();
+
+            while let Some(Ok(message)) = ws.next().await {
+                let Message::Text(text) = message else {
+                    continue;
+                };
+                let Ok(value) = serde_json::from_str::<Value>(&text) else {
+                    continue;
+                };
+
+                received_task
+                    .lock()
+                    .expect("received lock poisoned")
+                    .push(value.clone());
+                arrived_task.notify_waiters();
+
+                let channel = value["channel"].as_u64().unwrap_or(0);
+                let mut responses: Vec<Value> = Vec::new();
+                let mut close_after = false;
+
+                match value["type"].as_str().unwrap_or("") {
+                    "SETUP" => {
+                        responses.push(json!({
+                            "channel": channel,
+                            "type": "SETUP",
+                            "version": "1.0.0",
+                            "keepaliveTimeout": 60,
+                            "acceptKeepaliveTimeout": 60
+                        }));
+                        responses.push(json!({
+                            "channel": 0, "type": "AUTH_STATE", "state": "UNAUTHORIZED"
+                        }));
+                    }
+                    "AUTH" => {
+                        let state = if behaviour == Behaviour::RejectAuth {
+                            "UNAUTHORIZED"
+                        } else {
+                            "AUTHORIZED"
+                        };
+                        responses.push(json!({
+                            "channel": 0, "type": "AUTH_STATE",
+                            "state": state, "userId": "test-user"
+                        }));
+                    }
+                    "CHANNEL_REQUEST" => responses.push(json!({
+                        "channel": channel,
+                        "type": "CHANNEL_OPENED",
+                        "service": value["service"].as_str().unwrap_or("FEED"),
+                        "parameters": {}
+                    })),
+                    "FEED_SETUP" => {
+                        // Remember exactly which fields the client asked for, in
+                        // order: that is the wire layout it will decode against.
+                        if let Some(fields) = value["acceptEventFields"].as_object() {
+                            for (event_type, list) in fields {
+                                let order: Vec<String> = list
+                                    .as_array()
+                                    .map(|a| {
+                                        a.iter()
+                                            .filter_map(|f| f.as_str().map(String::from))
+                                            .collect()
+                                    })
+                                    .unwrap_or_default();
+                                event_fields.insert((channel, event_type.clone()), order);
+                            }
+                        }
+                        responses.push(json!({
+                            "channel": channel,
+                            "type": "FEED_CONFIG",
+                            "aggregationPeriod": 0.1,
+                            "dataFormat": "COMPACT"
+                        }));
+                    }
+                    "FEED_SUBSCRIPTION" => {
+                        if let Some(add) = value.get("add").and_then(|a| a.as_array()) {
+                            for sub in add {
+                                let event_type = sub["type"].as_str().unwrap_or("");
+                                let symbol = sub["symbol"].as_str().unwrap_or("");
+                                let Some(order) =
+                                    event_fields.get(&(channel, event_type.to_string()))
+                                else {
+                                    continue;
+                                };
+                                let row: Vec<Value> = order
+                                    .iter()
+                                    .map(|field| field_value(field, event_type, symbol))
+                                    .collect();
+                                responses.push(json!({
+                                    "channel": channel,
+                                    "type": "FEED_DATA",
+                                    "data": [event_type, row]
+                                }));
+                            }
+                        }
+                        close_after = behaviour == Behaviour::CloseAfterSubscribe;
+                    }
+                    "CHANNEL_CANCEL" => responses.push(json!({
+                        "channel": channel, "type": "CHANNEL_CLOSED"
+                    })),
+                    // KEEPALIVE and anything else needs no reply.
+                    _ => {}
+                }
+
+                for response in responses {
+                    if behaviour == Behaviour::ControlFrames {
+                        let _ = ws.send(Message::Ping(vec![7].into())).await;
+                    }
+                    if ws
+                        .send(Message::Text(response.to_string().into()))
+                        .await
+                        .is_err()
+                    {
+                        return;
+                    }
+                    if behaviour == Behaviour::ControlFrames {
+                        let _ = ws.send(Message::Pong(Vec::new().into())).await;
+                    }
+                }
+
+                if close_after {
+                    let _ = ws.send(Message::Close(None)).await;
+                    return;
+                }
+            }
+        });
+
+        MockServer {
+            address,
+            received,
+            arrived,
+        }
+    }
+
+    pub fn url(&self) -> String {
+        format!("ws://{}", self.address)
+    }
+
+    /// Every message the client has sent so far, in order.
+    pub fn received(&self) -> Vec<Value> {
+        self.received
+            .lock()
+            .expect("received lock poisoned")
+            .clone()
+    }
+
+    /// Blocks until the client has sent a message matching `predicate`.
+    ///
+    /// This is what replaces the fixed sleeps the old suites used to
+    /// "synchronise": the test proceeds as soon as the protocol message it
+    /// depends on has actually arrived, and fails with a dump of everything
+    /// received if it never does.
+    pub async fn wait_for<F>(&self, what: &str, predicate: F) -> Value
+    where
+        F: Fn(&Value) -> bool,
+    {
+        let wait = async {
+            loop {
+                // Register before scanning so a message arriving in between is
+                // not missed.
+                let notified = self.arrived.notified();
+                if let Some(found) = self.received().into_iter().find(&predicate) {
+                    return found;
+                }
+                notified.await;
+            }
+        };
+
+        match tokio::time::timeout(WAIT_TIMEOUT, wait).await {
+            Ok(found) => found,
+            Err(_) => panic!(
+                "timed out waiting for {what}; server received: {:#?}",
+                self.received()
+            ),
+        }
+    }
+}
+
+/// The value the server reports for one COMPACT column.
+///
+/// Keyed by wire field name so the row can be assembled in whatever order the
+/// client requested. Anything unrecognised becomes null, which surfaces as a
+/// decode failure rather than a plausible-looking number.
+fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
+    match field {
+        "eventType" => json!(event_type),
+        "eventSymbol" => json!(symbol),
+        // Quote
+        "bidPrice" => json!(150.25),
+        "askPrice" => json!(150.5),
+        "bidSize" => json!(100.0),
+        "askSize" => json!(150.0),
+        // Trade
+        "price" => json!(151.25),
+        "size" => json!(75.0),
+        "dayVolume" => json!(10_000_000.0),
+        // Greeks
+        "delta" => json!(0.65),
+        "gamma" => json!(0.05),
+        "theta" => json!(-0.15),
+        "vega" => json!(0.1),
+        "rho" => json!(0.03),
+        "volatility" => json!(0.25),
+        _ => Value::Null,
+    }
+}
+
+/// The values `field_value` reports, for assertions on the decoded event.
+pub mod expected {
+    pub const BID_PRICE: f64 = 150.25;
+    pub const ASK_PRICE: f64 = 150.5;
+    pub const BID_SIZE: f64 = 100.0;
+    pub const ASK_SIZE: f64 = 150.0;
+    pub const PRICE: f64 = 151.25;
+    pub const SIZE: f64 = 75.0;
+    pub const DAY_VOLUME: f64 = 10_000_000.0;
+    pub const DELTA: f64 = 0.65;
+    pub const GAMMA: f64 = 0.05;
+    pub const THETA: f64 = -0.15;
+    pub const VEGA: f64 = 0.1;
+    pub const RHO: f64 = 0.03;
+    pub const VOLATILITY: f64 = 0.25;
+}
+
+/// Convenience predicates for `wait_for`.
+pub fn is_type(kind: &str) -> impl Fn(&Value) -> bool + '_ {
+    move |m: &Value| m["type"].as_str() == Some(kind)
+}
+
+pub fn is_type_on_channel(kind: &str, channel: u32) -> impl Fn(&Value) -> bool + '_ {
+    move |m: &Value| {
+        m["type"].as_str() == Some(kind) && m["channel"].as_u64() == Some(channel as u64)
+    }
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -3,6 +3,8 @@
    Email: jb@taunais.com
    Date: 7/3/25
 ******************************************************************************/
+mod fixture;
+
 mod dxlink_extra;
 mod dxlink_flow;
 mod dxlink_real;


### PR DESCRIPTION
## Summary

The offline suite could stay green while event delivery was broken. Six connection tests were disabled as "port conflicts", two integration files carried near-identical copies of a large mock server, and the tests that mattered most asserted nothing.

## Changes

- One shared fixture (`tests/integration/fixture.rs`) on an ephemeral port replaces both duplicated mock servers.
- The six ignored connection tests are re-enabled; only the real-network test stays `#[ignore]`d.
- Assertions restored where they were commented out or replaced by warning logs.
- Sleeps replaced by waiting on the protocol message the test depends on.
- The keepalive test drives virtual time instead of spending 20 real seconds.
- `warp` dropped from dev-dependencies; `tokio` gains `test-util`.

## Technical decisions

**The fixture builds each COMPACT row in the field order the client asked for in its own `FEED_SETUP`**, rather than in an order hardcoded next to it. That turns the event tests into a real check of the `setup_feed` ↔ `parse_compact_data` contract. Verified: swapping just `eventType` and `eventSymbol` in `setup_feed`, leaving the parser alone, fails five tests. Before this PR that drift was undetectable.

The old mocks emitted `[symbol, eventType, ...]`, the reverse of what `setup_feed` requests. That is *why* no test asserted a decoded symbol — it would have failed. The swap is fixed here rather than papered over.

The token redaction test was capturing through a thread-local subscriber, so it stopped recording as soon as the runtime resumed the future on another worker, then asserted against a buffer missing the line it checks. It passed only by luck of timing. It now uses one global subscriber installed once and scopes itself with a unique token, and it fails loudly if nothing was captured rather than passing vacuously.

The re-enabled connection tests keep only the coverage that was unique to them (send/receive round trip, clone sharing the stream, keepalive channel targeting); the rest duplicated `frame_tests`.

## Testing

- [x] 63 lib + 14 integration + 18 doc tests pass, run repeatedly for flakiness
- [x] `cargo test -- --list --ignored` shows only `dxlink_real::test_integration_with_real_server`
- [x] Column-order drift proven to fail the suite
- [x] `make check` and `cargo build --workspace --all-features` clean
- [x] Coverage 76.56% to 77.83% (`connection.rs` +5.95%)

## Checklist

- [x] No public API change; only dev-dependencies moved
- [x] No new `#[ignore]`; the only one left has a network reason
- [x] Tests parallel-safe, no fixed ports
- [x] No runtime dependency added
- [x] `examples/miscellaneous` still builds

Closes #16
