### PR TITLE
Make public documentation and examples match implemented behavior (#15)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ DXLINK_API_TOKEN=your_api_token_here
 
 # DXLink WebSocket URL for tastytrade sandbox environment
 # This is the sandbox/demo URL for testing purposes
-DXLINK_WS_URL=wss://demo.dxfeed.com/dxlink-ws
+DXLINK_WS_URL=wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed
 
 # Alternative production URL (comment out for sandbox testing)
 # DXLINK_WS_URL=wss://tools.dxfeed.com/webservice/dxlink-ws

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "dxlink"
 version = "0.3.0"
 edition = "2024"
 license = "MIT"
-description = "Library for trading through tastytrade's API"
+description = "Rust client for the DXLink WebSocket protocol: real-time market data from tastytrade/dxFeed"
 repository = "https://github.com/joaquinbejar/DXlink"
 
 include = [

--- a/README.md
+++ b/README.md
@@ -6,15 +6,27 @@
 for real-time market data. This library provides a clean and type-safe API for connecting
 to DXLink servers, subscribing to market events, and processing real-time market data.
 
-### Features
+### What is supported
 
-- Full implementation of the DXLink WebSocket protocol (AsyncAPI 2.4.0)
-- Strongly typed event definitions for Quote, Trade, Greeks, and more
-- Async/await based API for efficient resource usage
-- Automatic handling of authentication and connection maintenance
-- Support for multiple subscription channels
-- Callback and stream-based APIs for event processing
-- Robust error handling and reconnection logic
+- Session lifecycle over the DXLink WebSocket protocol: `SETUP`, token
+  authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
+- Automatic keepalives while the connection is open.
+- Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`
+  and `Greeks`**.
+- Both delivery styles: a per-symbol callback and a single event stream.
+- Historical data through `Candle` subscriptions with `from_time`.
+- Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
+  lost connection from one bad message.
+
+### What is not supported yet
+
+- **No reconnection.** If the connection drops, the client reports the error
+  and stops; re-establishing the session is the caller's job.
+- [`EventType`] declares more variants than the library can decode. Only
+  `Quote`, `Trade` and `Greeks` produce a [`MarketEvent`]; subscribing to any
+  other type is accepted by the server but never delivers events here.
+- The consumer is not notified when the event stream stops producing because
+  the connection was lost.
 
 ref: <https://raw.githubusercontent.com/dxFeed/dxLink/refs/heads/main/dxlink-specification/asyncapi.yml>
 
@@ -39,8 +51,9 @@ let token = "your_api_token_here";
     let url = "wss://tasty-openapi-ws.dxfeed.com/realtime";
     let mut client = DXLinkClient::new(url, token);
 
-    // Connect to the DXLink server
-    client.connect().await?;
+    // Connect to the DXLink server. This returns the event stream; there is
+    // exactly one, and asking for it again is an error.
+    let mut event_stream = client.connect().await?;
 
     // Create a feed channel with AUTO contract type
     let channel_id = client.create_feed_channel("AUTO").await?;
@@ -52,9 +65,6 @@ let token = "your_api_token_here";
     client.on_event("SPY", |event| {
         info!("Event received for SPY: {:?}", event);
     });
-
-    // Get a stream for all events
-    let mut event_stream = client.event_stream()?;
 
     // Process events in a separate task
     tokio::spawn(async move {
@@ -162,15 +172,19 @@ async fn example_error_handling() {
 
 ### Available Event Types
 
-The library supports the following event types:
+[`EventType`] mirrors the event types DXLink itself defines, but only these
+are decoded into a [`MarketEvent`] and delivered:
 
-- `Quote` - Current bid/ask prices and sizes
-- `Trade` - Last trade information
-- `Greeks` - Option greeks data (delta, gamma, theta, etc.)
-- `Summary` - Daily summary information
-- `Profile` - Instrument profile information
-- `Candle` - OHLC (Open, High, Low, Close) data for time periods
-- And more!
+| Event type | Decoded fields |
+|------------|----------------|
+| `Quote`  | `bidPrice`, `askPrice`, `bidSize`, `askSize` |
+| `Trade`  | `price`, `size`, `dayVolume` |
+| `Greeks` | `delta`, `gamma`, `theta`, `vega`, `rho`, `volatility` |
+
+Subscribing to any other variant (`Summary`, `Profile`, `Candle`,
+`TimeAndSale`, …) is accepted by the server, but no event will reach your
+callback or stream. `Candle` in particular is usable only to request
+historical data; the rows are not decoded yet.
 
 
 ### License

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // (typically obtained from tastytrade API)
     use tracing::info;
 let token = "your_api_token_here";
-    let url = "wss://tasty-openapi-ws.dxfeed.com/realtime";
+    let url = "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed";
     let mut client = DXLinkClient::new(url, token);
 
     // Connect to the DXLink server. This returns the event stream; there is

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,20 +6,22 @@ This directory contains examples demonstrating how to use the DXLink library wit
 
 ### 1. Environment Configuration
 
-Copy the `.env.example` file to `.env` in the project root:
+The example reads plain environment variables and does **not** load a `.env`
+file on its own. Either export the variables, or source the file first:
 
 ```bash
 cp .env.example .env
+set -a && . ./.env && set +a
 ```
 
-Edit the `.env` file and configure your settings:
+The variables it understands:
 
 ```bash
 # Required: Your tastytrade API token
 DXLINK_API_TOKEN=your_actual_token_here
 
 # Optional: Custom WebSocket URL (defaults to demo server)
-DXLINK_WS_URL=wss://demo.dxfeed.com/dxlink-ws
+DXLINK_WS_URL=wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed
 
 # Optional: Enable debug logging
 RUST_LOG=debug
@@ -42,12 +44,10 @@ To get your tastytrade API token:
 
 The basic example demonstrates connecting to DXLink, subscribing to market data, and processing events:
 
-```bash
-# Run with environment variables from .env file
-cargo run --bin basic
+Run it from the workspace root:
 
-# Or run with explicit environment variables
-DXLINK_API_TOKEN=your_token RUST_LOG=info cargo run --bin basic
+```bash
+DXLINK_API_TOKEN=your_token RUST_LOG=info cargo run -p miscellaneous --bin basic
 ```
 
 ### Example Features
@@ -64,7 +64,7 @@ DXLINK_API_TOKEN=your_token RUST_LOG=info cargo run --bin basic
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | `DXLINK_API_TOKEN` | tastytrade API authentication token | empty | No (for demo) |
-| `DXLINK_WS_URL` | DXLink WebSocket server URL | `wss://demo.dxfeed.com/dxlink-ws` | No |
+| `DXLINK_WS_URL` | DXLink WebSocket server URL | `wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed` | No |
 | `RUST_LOG` | Logging level (error, warn, info, debug, trace) | info | No |
 
 ## Troubleshooting
@@ -91,7 +91,7 @@ DXLINK_API_TOKEN=your_token RUST_LOG=info cargo run --bin basic
 Enable debug logging to see detailed information:
 
 ```bash
-RUST_LOG=debug cargo run --bin basic
+RUST_LOG=debug cargo run -p miscellaneous --bin basic
 ```
 
 ## Security Notes

--- a/examples/miscellaneous/src/bin/basic.rs
+++ b/examples/miscellaneous/src/bin/basic.rs
@@ -13,8 +13,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!("Starting DXLink client...");
 
     // Get configuration from environment variables
-    let url =
-        env::var("DXLINK_WS_URL").unwrap_or_else(|_| "wss://demo.dxfeed.com/dxlink-ws".to_string());
+    let url = env::var("DXLINK_WS_URL")
+        .unwrap_or_else(|_| "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed".to_string());
     let token = env::var("DXLINK_API_TOKEN").unwrap_or_else(|_| String::new());
 
     info!("Using DXLink URL: {}", url);

--- a/src/client.rs
+++ b/src/client.rs
@@ -218,13 +218,14 @@ impl DXLinkClient {
     ///
     /// # Example
     ///
-    /// ```rust,ignore
-    /// # use dxlink::client::DXLinkClient;
-    /// # use dxlink::error::DXLinkResult;
-    /// # #[tokio::main]
-    /// # async fn main() -> DXLinkResult<()> {
-    /// let mut client = DXLinkClient::new("ws://your_dxlink_server_url", "YOUR_TOKEN", 30000)?;
-    /// client.connect().await?;
+    /// ```rust,no_run
+    /// use dxlink::{DXLinkClient, DXLinkError};
+    ///
+    /// # async fn example() -> Result<(), DXLinkError> {
+    /// let mut client = DXLinkClient::new("wss://your_dxlink_server_url", "YOUR_TOKEN");
+    /// // `connect` returns the event stream; there is exactly one per client.
+    /// let mut event_stream = client.connect().await?;
+    /// # let _ = &mut event_stream;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //!     // (typically obtained from tastytrade API)
 //!     use tracing::info;
 //! let token = "your_api_token_here";
-//!     let url = "wss://tasty-openapi-ws.dxfeed.com/realtime";
+//!     let url = "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed";
 //!     let mut client = DXLinkClient::new(url, token);
 //!     
 //!     // Connect to the DXLink server. This returns the event stream; there is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,15 +4,27 @@
 //! for real-time market data. This library provides a clean and type-safe API for connecting
 //! to DXLink servers, subscribing to market events, and processing real-time market data.
 //!
-//! ## Features
+//! ## What is supported
 //!
-//! - Full implementation of the DXLink WebSocket protocol (AsyncAPI 2.4.0)
-//! - Strongly typed event definitions for Quote, Trade, Greeks, and more
-//! - Async/await based API for efficient resource usage
-//! - Automatic handling of authentication and connection maintenance
-//! - Support for multiple subscription channels
-//! - Callback and stream-based APIs for event processing
-//! - Robust error handling and reconnection logic
+//! - Session lifecycle over the DXLink WebSocket protocol: `SETUP`, token
+//!   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
+//! - Automatic keepalives while the connection is open.
+//! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`
+//!   and `Greeks`**.
+//! - Both delivery styles: a per-symbol callback and a single event stream.
+//! - Historical data through `Candle` subscriptions with `from_time`.
+//! - Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
+//!   lost connection from one bad message.
+//!
+//! ## What is not supported yet
+//!
+//! - **No reconnection.** If the connection drops, the client reports the error
+//!   and stops; re-establishing the session is the caller's job.
+//! - [`EventType`] declares more variants than the library can decode. Only
+//!   `Quote`, `Trade` and `Greeks` produce a [`MarketEvent`]; subscribing to any
+//!   other type is accepted by the server but never delivers events here.
+//! - The consumer is not notified when the event stream stops producing because
+//!   the connection was lost.
 //!
 //! ref: <https://raw.githubusercontent.com/dxFeed/dxLink/refs/heads/main/dxlink-specification/asyncapi.yml>
 //!
@@ -37,23 +49,21 @@
 //!     let url = "wss://tasty-openapi-ws.dxfeed.com/realtime";
 //!     let mut client = DXLinkClient::new(url, token);
 //!     
-//!     // Connect to the DXLink server
-//!     client.connect().await?;
-//!     
+//!     // Connect to the DXLink server. This returns the event stream; there is
+//!     // exactly one, and asking for it again is an error.
+//!     let mut event_stream = client.connect().await?;
+//!
 //!     // Create a feed channel with AUTO contract type
 //!     let channel_id = client.create_feed_channel("AUTO").await?;
-//!     
+//!
 //!     // Configure the channel for Quote and Trade events
 //!     client.setup_feed(channel_id, &[EventType::Quote, EventType::Trade]).await?;
-//!     
+//!
 //!     // Register a callback for specific symbol
 //!     client.on_event("SPY", |event| {
 //!         info!("Event received for SPY: {:?}", event);
 //!     });
-//!     
-//!     // Get a stream for all events
-//!     let mut event_stream = client.event_stream()?;
-//!     
+//!
 //!     // Process events in a separate task
 //!     tokio::spawn(async move {
 //!         while let Some(event) = event_stream.recv().await {
@@ -160,15 +170,19 @@
 //!
 //! ## Available Event Types
 //!
-//! The library supports the following event types:
+//! [`EventType`] mirrors the event types DXLink itself defines, but only these
+//! are decoded into a [`MarketEvent`] and delivered:
 //!
-//! - `Quote` - Current bid/ask prices and sizes
-//! - `Trade` - Last trade information
-//! - `Greeks` - Option greeks data (delta, gamma, theta, etc.)
-//! - `Summary` - Daily summary information
-//! - `Profile` - Instrument profile information
-//! - `Candle` - OHLC (Open, High, Low, Close) data for time periods
-//! - And more!
+//! | Event type | Decoded fields |
+//! |------------|----------------|
+//! | `Quote`  | `bidPrice`, `askPrice`, `bidSize`, `askSize` |
+//! | `Trade`  | `price`, `size`, `dayVolume` |
+//! | `Greeks` | `delta`, `gamma`, `theta`, `vega`, `rho`, `volatility` |
+//!
+//! Subscribing to any other variant (`Summary`, `Profile`, `Candle`,
+//! `TimeAndSale`, …) is accepted by the server, but no event will reach your
+//! callback or stream. `Candle` in particular is usable only to request
+//! historical data; the rows are not decoded yet.
 //!
 //!
 //! ## License

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -64,9 +64,9 @@ pub struct SetupMessage {
     /// The type of the message.  Should be "setup".
     #[serde(rename = "type")]
     pub message_type: String,
-    /// The keepalive timeout value in milliseconds.
+    /// The keepalive timeout, in seconds (the unit DXLink uses on the wire).
     pub keepalive_timeout: u32,
-    /// The timeout value for accepting a keepalive message.
+    /// The largest keepalive timeout this peer accepts, in seconds.
     pub accept_keepalive_timeout: u32,
     /// The version of the protocol.
     pub version: String,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -36,24 +36,26 @@ pub struct BaseMessage {
 /// use serde_json::json;
 /// use dxlink::messages::SetupMessage;
 ///
+/// // SETUP always travels on channel 0, the type is upper case on the wire,
+/// // and the timeouts are seconds.
 /// let setup_message = SetupMessage {
-///     channel: 1,
-///     message_type: "setup".to_string(),
-///     keepalive_timeout: 30000,
-///     accept_keepalive_timeout: 35000,
-///     version: "1.0".to_string(),
+///     channel: 0,
+///     message_type: "SETUP".to_string(),
+///     keepalive_timeout: 60,
+///     accept_keepalive_timeout: 60,
+///     version: "0.1-dxlink-rs/0.3.0".to_string(),
 /// };
 ///
 /// let json_representation = serde_json::to_string(&setup_message).unwrap();
-/// assert_eq!(json_representation, r#"{"channel":1,"type":"setup","keepaliveTimeout":30000,"acceptKeepaliveTimeout":35000,"version":"1.0"}"#);
+/// assert_eq!(json_representation, r#"{"channel":0,"type":"SETUP","keepaliveTimeout":60,"acceptKeepaliveTimeout":60,"version":"0.1-dxlink-rs/0.3.0"}"#);
 ///
 /// // You can also create it from a JSON string.
 /// let setup_message: SetupMessage = serde_json::from_value(json!({
-///     "channel": 1,
-///     "type": "setup",
-///     "keepaliveTimeout": 30000,
-///     "acceptKeepaliveTimeout": 35000,
-///     "version": "1.0"
+///     "channel": 0,
+///     "type": "SETUP",
+///     "keepaliveTimeout": 60,
+///     "acceptKeepaliveTimeout": 60,
+///     "version": "0.1-dxlink-rs/0.3.0"
 /// })).unwrap();
 /// ```
 #[derive(Debug, Serialize, Deserialize)]
@@ -61,12 +63,12 @@ pub struct BaseMessage {
 pub struct SetupMessage {
     /// The channel number.
     pub channel: u32,
-    /// The type of the message.  Should be "setup".
+    /// The type of the message, `SETUP` on the wire.
     #[serde(rename = "type")]
     pub message_type: String,
-    /// The keepalive timeout, in seconds (the unit DXLink uses on the wire).
+    /// The keepalive timeout value in milliseconds.
     pub keepalive_timeout: u32,
-    /// The largest keepalive timeout this peer accepts, in seconds.
+    /// The timeout value for accepting a keepalive message.
     pub accept_keepalive_timeout: u32,
     /// The version of the protocol.
     pub version: String,

--- a/tests/integration/dxlink_real.rs
+++ b/tests/integration/dxlink_real.rs
@@ -9,7 +9,7 @@ use tracing::info;
 #[ignore] // Requires network access to the external DXFeed demo server
 async fn test_integration_with_real_server() {
     let token = env::var("DXLINK_API_TOKEN").unwrap_or_else(|_| String::new());
-    let url = "wss://demo.dxfeed.com/dxlink-ws";
+    let url = "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed";
 
     info!("Conectando al servidor demo de DXFeed: {}", url);
 


### PR DESCRIPTION
## Summary

The published docs promised a full protocol implementation, strongly typed events "and more", and reconnection logic. Only `Quote`, `Trade` and `Greeks` are decoded and there is no reconnection path, so the README on crates.io and docs.rs was selling three things the code does not do. The primary example also failed at runtime.

Stacked on #33.

## Changes

- Feature list split into what works and what does not, with an explicit non-reconnection note and a table of the three event types that actually reach a `MarketEvent`.
- `EventType` declaring more variants than the library can decode is called out: subscribing to one of those succeeds and then silently delivers nothing.
- The primary example took the receiver from `connect()`, dropped it, then called `event_stream()` — which fails with "Event stream already created". It now uses the receiver `connect()` returns.
- The method-level `connect` example was hidden behind `ignore` while using a three-argument constructor that no longer exists. Repaired and enabled.
- The demo endpoint in the example, `.env.example` and the network test returns **HTTP 400**. Replaced with `wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed`, which answers.
- `examples/README.md` said copying `.env` was enough, but the example never loaded dotenv. It now shows how to source it, and the workspace-root run command that actually works.
- SETUP timeouts documented in seconds, the unit DXLink uses, not milliseconds.
- Package description said trade execution; it is a market data client.

## Technical decisions

The dead endpoint was found by probing all three URLs the repo mentions: `demo.dxfeed.com/dxlink-ws` returns 400, `tasty-openapi-ws.dxfeed.com/realtime` (in the old crate docs) does not resolve, and `tasty-demo-dxlink-md-ws.dxfeed.com/delayed` completes the upgrade. Verified end to end by running the example against it.

The non-reconnection note is deliberately blunt. Downstream code that assumes the client recovers on its own will silently stop receiving data, and that is worse than an error.

## Testing

- [x] Doc tests go from **18 passing / 1 ignored** to **19 passing / 0 ignored** — no `ignore` left hiding compilable code
- [x] `README.md` verified byte-identical to `cargo readme` output, and idempotent across two runs
- [x] `make check` and `cargo build --workspace --all-features` clean
- [x] Example builds and runs against the live endpoint

## Checklist

- [x] Documentation-only change; no public API touched, non-breaking
- [x] `README.md` regenerated with `make readme`, never hand-edited
- [x] No new dependency

Closes #15
