### PR TITLE
Redact the auth token from AuthMessage Debug output (#7)

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -66,9 +66,9 @@ pub struct SetupMessage {
     /// The type of the message, `SETUP` on the wire.
     #[serde(rename = "type")]
     pub message_type: String,
-    /// The keepalive timeout value in milliseconds.
+    /// The keepalive timeout, in seconds (the unit DXLink uses on the wire).
     pub keepalive_timeout: u32,
-    /// The timeout value for accepting a keepalive message.
+    /// The largest keepalive timeout this peer accepts, in seconds.
     pub accept_keepalive_timeout: u32,
     /// The version of the protocol.
     pub version: String,

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -6,6 +6,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::fmt;
 
 /// Represents a basic message structure.
 ///
@@ -119,7 +120,7 @@ pub struct KeepaliveMessage {
 /// let json_string = to_string(&auth_message).unwrap();
 /// println!("{}", json_string);
 /// ```
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AuthMessage {
     /// The channel number.
@@ -129,6 +130,22 @@ pub struct AuthMessage {
     pub message_type: String,
     /// The authentication token.
     pub token: String,
+}
+
+/// Redacted by hand rather than derived: a derived `Debug` prints the bearer
+/// token verbatim, so any `{:?}` of this message — in a log line, an error, a
+/// panic message, a test failure — would leak the credential.
+///
+/// Nothing about the token is reported, not its length, prefix or suffix: those
+/// narrow a brute force and are of no diagnostic use. Only whether one is set.
+impl fmt::Debug for AuthMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AuthMessage")
+            .field("channel", &self.channel)
+            .field("message_type", &self.message_type)
+            .field("has_token", &!self.token.is_empty())
+            .finish()
+    }
 }
 
 /// Represents an authentication state message.  This structure is used for serializing
@@ -558,4 +575,70 @@ pub struct FeedDataMessage<T> {
     pub message_type: String,
     /// The actual data being transmitted in the message.  This can be any serializable type.
     pub data: T,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_auth_message_debug_never_reveals_the_token() {
+        let token = "tastytrade-live-bearer-token";
+        let rendered = format!(
+            "{:?}",
+            AuthMessage {
+                channel: 0,
+                message_type: "AUTH".to_string(),
+                token: token.to_string(),
+            }
+        );
+
+        assert!(!rendered.contains(token), "token leaked: {rendered}");
+        // Not even a fragment: a prefix or suffix narrows a brute force and is
+        // of no diagnostic use.
+        assert!(
+            !rendered.contains("tastytrade"),
+            "token fragment leaked: {rendered}"
+        );
+        assert!(
+            !rendered.contains("token\""),
+            "token field rendered: {rendered}"
+        );
+
+        // The parts that help diagnose are still there.
+        assert!(rendered.contains("AuthMessage"));
+        assert!(rendered.contains("channel: 0"));
+        assert!(rendered.contains("AUTH"));
+        assert!(rendered.contains("has_token: true"));
+    }
+
+    #[test]
+    fn test_auth_message_debug_reports_a_missing_token() {
+        let rendered = format!(
+            "{:?}",
+            AuthMessage {
+                channel: 0,
+                message_type: "AUTH".to_string(),
+                token: String::new(),
+            }
+        );
+        assert!(rendered.contains("has_token: false"), "{rendered}");
+    }
+
+    #[test]
+    fn test_auth_message_still_round_trips_over_the_wire() {
+        // Debug is redacted; serialization is not, the server needs the token.
+        let json = serde_json::to_string(&AuthMessage {
+            channel: 0,
+            message_type: "AUTH".to_string(),
+            token: "secret".to_string(),
+        })
+        .expect("failed to serialize");
+        assert!(json.contains("secret"));
+
+        let back: AuthMessage = serde_json::from_str(&json).expect("failed to deserialize");
+        assert_eq!(back.token, "secret");
+        assert_eq!(back.channel, 0);
+        assert_eq!(back.message_type, "AUTH");
+    }
 }

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -243,10 +243,36 @@ impl MockServer {
             Ok(found) => found,
             Err(_) => panic!(
                 "timed out waiting for {what}; server received: {:#?}",
-                self.received()
+                redacted(self.received())
             ),
         }
     }
+}
+
+/// Masks credential fields before a failure dump reaches the test output.
+///
+/// The server records the client's outbound `AUTH`, so dumping everything it
+/// received would print the bearer token. Harmless with the fixed test token,
+/// not harmless the day someone points this fixture at a real one.
+fn redacted(mut messages: Vec<Value>) -> Vec<Value> {
+    fn mask(value: &mut Value) {
+        match value {
+            Value::Object(map) => {
+                for (key, field) in map.iter_mut() {
+                    if key.eq_ignore_ascii_case("token") {
+                        *field = Value::String("<redacted>".to_string());
+                    } else {
+                        mask(field);
+                    }
+                }
+            }
+            Value::Array(items) => items.iter_mut().for_each(mask),
+            _ => {}
+        }
+    }
+
+    messages.iter_mut().for_each(mask);
+    messages
 }
 
 /// The value the server reports for one COMPACT column.
@@ -303,5 +329,27 @@ pub fn is_type(kind: &str) -> impl Fn(&Value) -> bool + '_ {
 pub fn is_type_on_channel(kind: &str, channel: u32) -> impl Fn(&Value) -> bool + '_ {
     move |m: &Value| {
         m["type"].as_str() == Some(kind) && m["channel"].as_u64() == Some(channel as u64)
+    }
+}
+
+#[cfg(test)]
+mod redaction_tests {
+    use super::redacted;
+    use serde_json::json;
+
+    #[test]
+    fn test_failure_dumps_do_not_carry_the_token() {
+        let dumped = format!(
+            "{:#?}",
+            redacted(vec![
+                json!({"type": "AUTH", "channel": 0, "token": "real-secret"})
+            ])
+        );
+
+        assert!(!dumped.contains("real-secret"), "token leaked: {dumped}");
+        assert!(dumped.contains("<redacted>"));
+        // The rest of the message still has to be readable, that is the point
+        // of the dump.
+        assert!(dumped.contains("AUTH"));
     }
 }


### PR DESCRIPTION
## Summary

`AuthMessage` derived `Debug` over a public `token` field, so any `{:?}` of it printed the bearer token verbatim. A log line, an error, a panic message or a test failure was enough to leak the credential.

Stacked on #34.

## Changes

`Debug` is now written by hand. It reports `channel`, `message_type` and `has_token`, and nothing about the token itself.

## Technical decisions

Not even a prefix, suffix or length is reported. Those narrow a brute force and are of no diagnostic use — knowing *whether* a token is set is the only part that helps when debugging a handshake. `DXLinkClient` already used exactly this shape, so this aligns the two.

Serialization is deliberately untouched: the server needs the real token on the wire. Only the human-facing rendering changes.

Audited the rest of the public surface for the same invariant: `DXLinkClient` was already redacted, and no other public type carries a credential.

## Public API impact

Non-breaking. `AuthMessage` still implements `Debug`, `Serialize` and `Deserialize`; no signature moves. Only the text a `Debug` format produces changes. Patch-level security fix.

## Testing

- [x] Regression test proves neither the token nor a fragment of it appears
- [x] Test that the wire round-trip still carries the real token
- [x] Existing outbound-log redaction tests still green
- [x] `make check` and `cargo build --workspace --all-features` clean

Closes #7
