### PR TITLE
Scan dependencies for RustSec advisories (#18)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,26 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --all-features
+
+  # RustSec advisory scan. Cargo.lock is deliberately not committed for this
+  # library, so the graph is resolved fresh here: this is what a consumer
+  # actually gets, not a snapshot pinned months ago.
+  #
+  # Advisory exceptions: none are configured, and an unsoundness or memory
+  # corruption advisory must never be ignored. If a non-exploitable advisory
+  # ever needs to be waived, add it to a `[advisories] ignore` list in
+  # `audit.toml` together with the RUSTSEC id, the reason, and a review date no
+  # more than 90 days out. An entry past its review date is a bug, not a policy.
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit --version ^0.22
+      - name: Resolve the dependency graph from scratch
+        run: cargo generate-lockfile
+      # Covers dev-dependencies too: a compromised test-only crate still runs
+      # on CI machines with repository credentials in scope.
+      - run: cargo audit --deny warnings

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`
   and `Greeks`**.
 - Both delivery styles: a per-symbol callback and a single event stream.
-- Historical data through `Candle` subscriptions with `from_time`.
+- `Candle` subscriptions carry `from_time` to the wire, so historical data
+  can be requested — but the rows that come back are not decoded yet.
 - Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
   lost connection from one bad message.
 
@@ -125,8 +126,11 @@ let token = "your_api_token_here";
 ### Working with historical data
 
 DXLink supports subscribing to historical data through Candle events.
-When subscribing to candle events, you need to specify the period,
-type, and a timestamp from which to fetch the data:
+When subscribing to candle events, you specify the period, type, and a
+timestamp from which to fetch the data.
+
+Note the subscription reaches the server, but `Candle` rows are not decoded
+into a [`MarketEvent`] yet, so nothing arrives on the stream for them:
 
 ```rust
 use dxlink::FeedSubscription;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,8 @@
 //! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`
 //!   and `Greeks`**.
 //! - Both delivery styles: a per-symbol callback and a single event stream.
-//! - Historical data through `Candle` subscriptions with `from_time`.
+//! - `Candle` subscriptions carry `from_time` to the wire, so historical data
+//!   can be requested — but the rows that come back are not decoded yet.
 //! - Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
 //!   lost connection from one bad message.
 //!
@@ -123,8 +124,11 @@
 //! ## Working with historical data
 //!
 //! DXLink supports subscribing to historical data through Candle events.
-//! When subscribing to candle events, you need to specify the period,
-//! type, and a timestamp from which to fetch the data:
+//! When subscribing to candle events, you specify the period, type, and a
+//! timestamp from which to fetch the data.
+//!
+//! Note the subscription reaches the server, but `Candle` rows are not decoded
+//! into a [`MarketEvent`] yet, so nothing arrives on the stream for them:
 //!
 //! ```rust,no_run
 //! use dxlink::FeedSubscription;


### PR DESCRIPTION
## Summary

`cargo audit` reported **RUSTSEC-2026-0007** (integer overflow in `BytesMut::reserve`) against `bytes 1.10.1`, reachable at runtime. CI performed no advisory scan at all, so it could have shipped.

Stacked on #35.

## Remediation paths

| Advisory | Crate | Path | Resolution |
|---|---|---|---|
| RUSTSEC-2026-0007 | `bytes 1.10.1` → `1.12.1` | runtime: `dxlink` → `tokio`/`tungstenite` → `bytes` | fresh resolution already selects the patched version |
| RUSTSEC-2026-0097 | `rand` | dev + runtime via `tungstenite` | already gone: the `tokio-tungstenite 0.30` bump brought `rand 0.10.2` |

`bytes` is transitive and `Cargo.lock` is deliberately uncommitted for this library, so no direct constraint is needed — a consumer resolving fresh gets the patched version. The stale local lock was the only thing pinning 1.10.1.

The duplicate `tokio-tungstenite` the issue asks about is also resolved: dropping `warp` in #33 removed the second copy, which is what pulled the vulnerable `rand`.

## Technical decisions

The job runs `cargo generate-lockfile` before auditing, so it checks the graph a consumer actually gets rather than a snapshot pinned months ago.

It covers dev-dependencies too. A compromised test-only crate still executes on CI machines with repository credentials in scope, so excluding them would be a gap, not a simplification.

The exception policy is documented next to the job: unsoundness and memory corruption are never waived, and any other waiver carries a RUSTSEC id, a reason and a review date at most 90 days out.

## Testing

- [x] `cargo audit` clean locally after a fresh resolution
- [x] YAML validated
- [x] `Cargo.lock` still untracked
- [x] `make check` clean

## Checklist

- [x] No new runtime dependency
- [x] No public API change
- [x] `Cargo.lock` not committed or force-added

Closes #18
