### PR TITLE
Declare and test the minimum supported Rust version (#31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,3 +59,19 @@ jobs:
       # Covers dev-dependencies too: a compromised test-only crate still runs
       # on CI machines with repository credentials in scope.
       - run: cargo audit --deny warnings
+
+  # The declared MSRV, proven rather than asserted. A dependency upgrade that
+  # needs a newer compiler fails here instead of surprising consumers after
+  # release. Raising `rust-version` is a compatibility break: say so in the
+  # release notes.
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.88.0
+      - uses: Swatinem/rust-cache@v2
+      # rust-toolchain.toml pins `stable` for contributors; override it so this
+      # job actually exercises the floor.
+      - run: rm -f rust-toolchain.toml
+      - run: cargo +1.88.0 build --workspace --all-features
+      - run: cargo +1.88.0 test --workspace --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,9 @@
 name = "dxlink"
 version = "0.3.0"
 edition = "2024"
+# Measured, not guessed: 1.87 rejects the let-chains this crate uses.
+# Raising this is a compatibility break for consumers and belongs in release notes.
+rust-version = "1.88"
 license = "MIT"
 description = "Rust client for the DXLink WebSocket protocol: real-time market data from tastytrade/dxFeed"
 repository = "https://github.com/joaquinbejar/DXlink"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - The consumer is not notified when the event stream stops producing because
   the connection was lost.
 
+### Minimum supported Rust version
+
+**Rust 1.88.** The crate is edition 2024 and uses let-chains, which 1.87
+rejects. Raising this floor is a compatibility break and is called out in
+the release notes; CI builds and tests the full workspace on it so a
+dependency upgrade cannot raise it silently.
+
 ref: <https://raw.githubusercontent.com/dxFeed/dxLink/refs/heads/main/dxlink-specification/asyncapi.yml>
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ use std::time::Duration;
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
 
-    // Create a new DXLink client with the API token
-    // (typically obtained from tastytrade API)
     use tracing::info;
-let token = "your_api_token_here";
+
+    // Create a new DXLink client with the API token
+    // (typically obtained from the tastytrade API)
+    let token = "your_api_token_here";
     let url = "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed";
     let mut client = DXLinkClient::new(url, token);
 

--- a/examples/miscellaneous/Cargo.toml
+++ b/examples/miscellaneous/Cargo.toml
@@ -2,6 +2,7 @@
 name = "miscellaneous"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.88"
 
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,13 @@
 //! - The consumer is not notified when the event stream stops producing because
 //!   the connection was lost.
 //!
+//! ## Minimum supported Rust version
+//!
+//! **Rust 1.88.** The crate is edition 2024 and uses let-chains, which 1.87
+//! rejects. Raising this floor is a compatibility break and is called out in
+//! the release notes; CI builds and tests the full workspace on it so a
+//! dependency upgrade cannot raise it silently.
+//!
 //! ref: <https://raw.githubusercontent.com/dxFeed/dxLink/refs/heads/main/dxlink-specification/asyncapi.yml>
 //!
 //! ## Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,10 +50,11 @@
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn Error>> {
 //!     
-//!     // Create a new DXLink client with the API token
-//!     // (typically obtained from tastytrade API)
 //!     use tracing::info;
-//! let token = "your_api_token_here";
+//!
+//!     // Create a new DXLink client with the API token
+//!     // (typically obtained from the tastytrade API)
+//!     let token = "your_api_token_here";
 //!     let url = "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed";
 //!     let mut client = DXLinkClient::new(url, token);
 //!     


### PR DESCRIPTION
## Summary

The crate published no `rust-version`, so `cargo metadata` reported `null` and consumers had no way to know the compiler floor. `rust-toolchain.toml` and CI both tracked whatever `stable` meant that day, which is not a compatibility promise.

Stacked on #36.

## The floor is 1.88, measured not guessed

| Toolchain | Result |
|---|---|
| 1.87.0 | `error[E0658]: let expressions in this position are unstable` |
| 1.88.0 | builds and passes the full suite (`--workspace --all-features`) |

Dependencies top out at 1.85 (`tungstenite`, `rand`, `sha1`, …), so the crate's own let-chain syntax is what sets the floor, not the graph.

## Technical decisions

The MSRV job removes `rust-toolchain.toml` before building. That file pins `stable` for contributors, and leaving it in place would make the job silently test current stable rather than the floor — an MSRV job that cannot fail is worse than none.

`rust-version` is set on the example package too, so the workspace is consistent and `cargo build --workspace` respects the same floor.

Documented in `src/lib.rs` (README regenerated) rather than only in metadata, since the floor is something a reader evaluating the crate wants before they add it.

## Public API impact

Declaring an MSRV is a compatibility statement. This is the initial declaration and matches what the code already required, so nothing that compiled before stops compiling. Any future increase is a break and belongs in release notes.

## Testing

- [x] 1.87 confirmed failing, 1.88 confirmed building and testing green
- [x] `cargo metadata` now reports `1.88` for both workspace packages
- [x] YAML validated
- [x] `make check` clean, README regenerated with `make readme`

Closes #31
