### PR TITLE
Bound and validate the SETUP/AUTH handshake (#11)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -10,7 +10,7 @@ use crate::events::{CompactData, EventType, MarketEvent};
 use crate::messages::{
     AuthMessage, AuthStateMessage, BaseMessage, ChannelRequestMessage, ErrorMessage,
     FeedDataMessage, FeedSetupMessage, FeedSubscription, FeedSubscriptionMessage, KeepaliveMessage,
-    SetupMessage,
+    ServerSetupMessage, SetupMessage,
 };
 
 use crate::parse_compact_data;
@@ -34,6 +34,12 @@ const DEFAULT_KEEPALIVE_INTERVAL: u32 = 15;
 /// Default client version string.  This is used to identify the client
 /// software version to the server.
 const DEFAULT_CLIENT_VERSION: &str = "1.0.2-dxlink-0.1.3";
+
+/// How long any single handshake response may take before `connect()` gives up.
+///
+/// Every SETUP/AUTH read is bounded by this: a server that accepts the socket
+/// and then says nothing must not hold a caller open forever.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// The main communication channel identifier. This is likely used for
 /// primary message exchange between client and server.
@@ -80,6 +86,73 @@ struct ResponseRequest {
     channel_id: Option<u32>,
     /// A `oneshot::Sender` used to send the `ResponseType` back to the requester once the expected response is received.
     response_sender: oneshot::Sender<ResponseType>,
+}
+
+/// Reads one handshake response and checks it is the message the protocol calls
+/// for at this point.
+///
+/// The handshake used to deserialize whatever arrived straight into the type it
+/// hoped for, so a server `ERROR` surfaced as `missing field \`state\`` and a
+/// message on the wrong channel was accepted silently. Errors name the state,
+/// what was expected and what arrived; none of them can carry the token.
+async fn expect_handshake_message(
+    connection: &WebSocketConnection,
+    state: &str,
+    expected_type: &str,
+    expected_channel: u32,
+) -> DXLinkResult<String> {
+    let raw = match connection.receive_with_timeout(HANDSHAKE_TIMEOUT).await? {
+        Some(raw) => raw,
+        None => {
+            return Err(DXLinkError::Timeout(format!(
+                "timed out after {}s waiting for {} on channel {} during {}",
+                HANDSHAKE_TIMEOUT.as_secs(),
+                expected_type,
+                expected_channel,
+                state
+            )));
+        }
+    };
+
+    let value: serde_json::Value = serde_json::from_str(&raw).map_err(|e| {
+        DXLinkError::Protocol(format!(
+            "during {state}, expected {expected_type} on channel {expected_channel} \
+             but the server sent malformed JSON: {e}"
+        ))
+    })?;
+
+    let received_type = value["type"].as_str().unwrap_or("<missing type>");
+    let received_channel = value["channel"].as_u64();
+
+    // A server ERROR here is the server telling us why, not an unexpected frame.
+    if received_type == "ERROR" {
+        let code = value["error"].as_str().unwrap_or("unknown");
+        let message = value["message"].as_str().unwrap_or("");
+        let detail = format!("during {state}, the server returned {code}: {message}");
+        return Err(if code.eq_ignore_ascii_case("UNAUTHORIZED") {
+            DXLinkError::Authentication(detail)
+        } else {
+            DXLinkError::Protocol(detail)
+        });
+    }
+
+    if received_type != expected_type {
+        return Err(DXLinkError::Protocol(format!(
+            "during {state}, expected {expected_type} but received {received_type}"
+        )));
+    }
+
+    if received_channel != Some(u64::from(expected_channel)) {
+        return Err(DXLinkError::Protocol(format!(
+            "during {state}, expected {expected_type} on channel {expected_channel} \
+             but it arrived on channel {}",
+            received_channel
+                .map(|c| c.to_string())
+                .unwrap_or_else(|| "<missing>".to_string())
+        )));
+    }
+
+    Ok(raw)
 }
 
 /// Represents a client for interacting with the DXLink service.
@@ -244,19 +317,25 @@ impl DXLinkClient {
 
         connection.send(&setup_msg).await?;
 
-        // Receive SETUP response
-        let response = connection.receive().await?;
-        let _: SetupMessage = serde_json::from_str(&response)?;
+        // Every read below is bounded and validated. On any failure `connection`
+        // is dropped here, so a partial handshake never leaves the client
+        // holding a half-established socket.
+        let response =
+            expect_handshake_message(&connection, "SETUP", "SETUP", MAIN_CHANNEL).await?;
+        let server_setup: ServerSetupMessage = serde_json::from_str(&response)?;
+        debug!(
+            "Server SETUP: version={:?}, keepaliveTimeout={:?}",
+            server_setup.version, server_setup.keepalive_timeout
+        );
 
-        // Check for AUTH_STATE message
-        let response = connection.receive().await?;
+        let response =
+            expect_handshake_message(&connection, "SETUP", "AUTH_STATE", MAIN_CHANNEL).await?;
         let auth_state: AuthStateMessage = serde_json::from_str(&response)?;
 
-        // Si ya estamos autorizados, podemos omitir el proceso de autenticación
+        // Already authorized means the token was accepted on the connection.
         if auth_state.state == "AUTHORIZED" {
             info!("Already authorized to DXLink server");
         } else if auth_state.state == "UNAUTHORIZED" {
-            // Send AUTH message
             let auth_msg = AuthMessage {
                 channel: MAIN_CHANNEL,
                 message_type: "AUTH".to_string(),
@@ -265,13 +344,13 @@ impl DXLinkClient {
 
             connection.send(&auth_msg).await?;
 
-            // Receive AUTH_STATE response, should be AUTHORIZED
-            let response = connection.receive().await?;
+            let response =
+                expect_handshake_message(&connection, "AUTH", "AUTH_STATE", MAIN_CHANNEL).await?;
             let auth_state: AuthStateMessage = serde_json::from_str(&response)?;
 
             if auth_state.state != "AUTHORIZED" {
                 return Err(DXLinkError::Authentication(format!(
-                    "Authentication failed. State: {}",
+                    "during AUTH, the server reported state {} instead of AUTHORIZED",
                     auth_state.state
                 )));
             }
@@ -279,7 +358,7 @@ impl DXLinkClient {
             info!("Successfully authenticated to DXLink server");
         } else {
             return Err(DXLinkError::Protocol(format!(
-                "Unexpected authentication state: {}",
+                "during SETUP, the server reported an unknown authentication state: {}",
                 auth_state.state
             )));
         }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -17,6 +17,12 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::{WebSocketStream, connect_async};
 use tracing::{debug, error};
 
+/// How long establishing the WebSocket may take before it is abandoned.
+///
+/// Without a bound, a server that accepts the TCP connection and then never
+/// completes the upgrade holds `connect()` open indefinitely.
+pub const DEFAULT_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Placeholder written in place of credential values when logging outbound messages.
 const REDACTED_PLACEHOLDER: &str = "<redacted>";
 
@@ -140,9 +146,18 @@ impl WebSocketConnection {
     pub async fn connect(url: &str) -> DXLinkResult<Self> {
         debug!("Connecting to WebSocket at: {}", url);
 
-        let (ws_stream, _) = connect_async(url)
-            .await
-            .map_err(|e| DXLinkError::Connection(format!("Failed to connect: {}", e)))?;
+        let (ws_stream, _) = match timeout(DEFAULT_CONNECT_TIMEOUT, connect_async(url)).await {
+            Ok(result) => {
+                result.map_err(|e| DXLinkError::Connection(format!("Failed to connect: {}", e)))?
+            }
+            Err(_) => {
+                return Err(DXLinkError::Timeout(format!(
+                    "timed out after {}s establishing the WebSocket connection to {}",
+                    DEFAULT_CONNECT_TIMEOUT.as_secs(),
+                    url
+                )));
+            }
+        };
 
         debug!("WebSocket connection established");
 

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -75,6 +75,32 @@ pub struct SetupMessage {
     pub version: String,
 }
 
+/// The `SETUP` a server sends back.
+///
+/// Separate from [`SetupMessage`] because the directions are not symmetric: the
+/// client must send every field, while the AsyncAPI schema lets the server omit
+/// any of them. Deserializing the reply into the outbound type made a
+/// spec-compliant server look like a protocol error.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServerSetupMessage {
+    /// The channel number. `SETUP` always travels on channel 0.
+    pub channel: u32,
+    /// The type of the message, always `SETUP`.
+    #[serde(rename = "type")]
+    pub message_type: String,
+    /// How long the server may stay silent before the client should give up, in
+    /// seconds. Absent if the server did not negotiate one.
+    #[serde(default)]
+    pub keepalive_timeout: Option<u32>,
+    /// The largest keepalive timeout the server accepts, in seconds.
+    #[serde(default)]
+    pub accept_keepalive_timeout: Option<u32>,
+    /// The server's protocol version string, when it reports one.
+    #[serde(default)]
+    pub version: Option<String>,
+}
+
 /// Represents a keepalive message.  This message is used to maintain an active connection
 /// and prevent timeouts.  It is sent periodically by the client or server.
 ///

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -157,14 +157,17 @@ async fn test_error_non_existent_channel() {
 
 /// The client must keep the session alive on its own. Virtual time drives the
 /// interval so the suite does not spend 20 real seconds proving it.
-#[tokio::test(start_paused = true)]
+#[tokio::test]
 async fn test_client_sends_keepalives() {
     let server = MockServer::start(Behaviour::Normal).await;
 
     let mut client = DXLinkClient::new(&server.url(), "test-token");
+    // Connect in real time: the handshake is bounded by a timeout that virtual
+    // time would fire before the socket finished being established.
     client.connect().await.expect("failed to connect");
 
     // Past one keepalive interval; with time paused this costs nothing.
+    tokio::time::pause();
     tokio::time::advance(Duration::from_secs(20)).await;
 
     // Back to real time before waiting: delivering the keepalive is real socket

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -175,3 +175,105 @@ async fn test_client_sends_keepalives() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+// --- Handshake validation (issue #11) -------------------------------------
+//
+// The handshake used to deserialize whatever arrived straight into the type it
+// hoped for, so a server ERROR surfaced as `missing field \`state\`` and a reply
+// on the wrong channel was accepted silently.
+
+/// A server that accepts the socket and says nothing must not hold the caller
+/// open. Virtual time makes the bound observable without waiting for it.
+#[tokio::test(start_paused = true)]
+async fn test_handshake_times_out_on_a_silent_server() {
+    let server = MockServer::start(Behaviour::Silent).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+
+    match client.connect().await {
+        // Either bound is a correct outcome: what matters is that one of them
+        // fired instead of hanging.
+        Err(DXLinkError::Timeout(msg)) => {
+            assert!(
+                msg.contains("timed out"),
+                "timeout should say what it waited for: {msg}"
+            );
+        }
+        other => panic!("expected a Timeout against a silent server, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_handshake_rejects_the_wrong_message_type() {
+    let server = MockServer::start(Behaviour::WrongTypeOnSetup).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+
+    match client.connect().await {
+        Err(DXLinkError::Protocol(msg)) => {
+            assert!(msg.contains("SETUP"), "expected type missing: {msg}");
+            assert!(msg.contains("FEED_CONFIG"), "received type missing: {msg}");
+        }
+        other => panic!("expected a Protocol error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_handshake_rejects_the_wrong_channel() {
+    let server = MockServer::start(Behaviour::WrongChannelOnSetup).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+
+    match client.connect().await {
+        Err(DXLinkError::Protocol(msg)) => {
+            assert!(msg.contains("channel 0"), "expected channel missing: {msg}");
+            assert!(msg.contains("channel 7"), "received channel missing: {msg}");
+        }
+        other => panic!("expected a Protocol error, got: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_handshake_rejects_malformed_json() {
+    let server = MockServer::start(Behaviour::MalformedSetup).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+
+    match client.connect().await {
+        Err(DXLinkError::Protocol(msg)) => {
+            assert!(msg.contains("malformed JSON"), "unclear error: {msg}");
+        }
+        other => panic!("expected a Protocol error, got: {other:?}"),
+    }
+}
+
+/// The failure the reporter of #4 actually hit next: no token, so the server
+/// answers ERROR/UNAUTHORIZED. That used to surface as `missing field \`state\``.
+#[tokio::test]
+async fn test_handshake_reports_a_server_error_as_authentication() {
+    let server = MockServer::start(Behaviour::ErrorOnSetup).await;
+    let mut client = DXLinkClient::new(&server.url(), "");
+
+    match client.connect().await {
+        Err(DXLinkError::Authentication(msg)) => {
+            assert!(msg.contains("UNAUTHORIZED"), "error code missing: {msg}");
+            assert!(
+                msg.contains("Authentication failed"),
+                "server message missing: {msg}"
+            );
+        }
+        other => panic!("expected an Authentication error, got: {other:?}"),
+    }
+}
+
+/// A failed handshake must leave the client disconnected, not half-established.
+#[tokio::test]
+async fn test_failed_handshake_leaves_the_client_disconnected() {
+    let server = MockServer::start(Behaviour::ErrorOnSetup).await;
+    let mut client = DXLinkClient::new(&server.url(), "");
+
+    assert!(client.connect().await.is_err());
+
+    // No channel can be opened, and tearing down is still safe.
+    assert!(client.create_feed_channel("AUTO").await.is_err());
+    client
+        .disconnect()
+        .await
+        .expect("disconnect after a failed handshake should be safe");
+}

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -42,6 +42,16 @@ pub enum Behaviour {
     RejectAuth,
     /// Complete the session, then hang up once the feed is subscribed.
     CloseAfterSubscribe,
+    /// Accept the socket and never say anything.
+    Silent,
+    /// Answer SETUP with a message of the wrong type.
+    WrongTypeOnSetup,
+    /// Answer SETUP on a channel other than 0.
+    WrongChannelOnSetup,
+    /// Answer SETUP with text that is not JSON.
+    MalformedSetup,
+    /// Answer SETUP with a protocol ERROR frame.
+    ErrorOnSetup,
 }
 
 pub struct MockServer {
@@ -91,6 +101,47 @@ impl MockServer {
                 let channel = value["channel"].as_u64().unwrap_or(0);
                 let mut responses: Vec<Value> = Vec::new();
                 let mut close_after = false;
+
+                // Handshake fault injection, before the normal answers.
+                match (behaviour, value["type"].as_str().unwrap_or("")) {
+                    (Behaviour::Silent, _) => continue,
+                    (Behaviour::WrongTypeOnSetup, "SETUP") => {
+                        let _ = ws
+                            .send(Message::Text(
+                                json!({"channel": 0, "type": "FEED_CONFIG"})
+                                    .to_string()
+                                    .into(),
+                            ))
+                            .await;
+                        continue;
+                    }
+                    (Behaviour::WrongChannelOnSetup, "SETUP") => {
+                        let _ = ws
+                            .send(Message::Text(
+                                json!({"channel": 7, "type": "SETUP", "version": "1.0"})
+                                    .to_string()
+                                    .into(),
+                            ))
+                            .await;
+                        continue;
+                    }
+                    (Behaviour::MalformedSetup, "SETUP") => {
+                        let _ = ws.send(Message::Text("not json at all".into())).await;
+                        continue;
+                    }
+                    (Behaviour::ErrorOnSetup, "SETUP") => {
+                        let _ = ws
+                            .send(Message::Text(
+                                json!({"channel": 0, "type": "ERROR", "error": "UNAUTHORIZED",
+                                       "message": "Authentication failed"})
+                                .to_string()
+                                .into(),
+                            ))
+                            .await;
+                        continue;
+                    }
+                    _ => {}
+                }
 
                 match value["type"].as_str().unwrap_or("") {
                     "SETUP" => {


### PR DESCRIPTION
## Summary

`connect()` awaited the socket and every handshake read with no deadline, and deserialized whatever arrived straight into the type it hoped for. A server that accepted the connection and said nothing held the caller open forever, and a server `ERROR` came back as `missing field \`state\`` instead of an authentication failure.

That second one is not hypothetical — it is exactly what a connection without a token produces against the tastytrade demo endpoint.

Stacked on #38.

## Changes

- Establishment and each SETUP/AUTH read are bounded, returning `DXLinkError::Timeout` naming what was awaited.
- Each transition validates message `type` and `channel`.
- A server `ERROR` becomes `Authentication` when the code is `UNAUTHORIZED`, `Protocol` otherwise.
- New `ServerSetupMessage` for the inbound SETUP.
- A failed handshake drops the socket before the client stores it.

## Technical decisions

**The inbound SETUP needed its own type.** The AsyncAPI schema lets a server omit fields the client must always send, so reusing the outbound `SetupMessage` made a spec-compliant server look like a protocol error. `ServerSetupMessage` has `Option` for the negotiable fields; #20 will consume them.

Error text names the handshake state, what was expected and what arrived. None of it can carry the token — the only value interpolated from the server side is the `error`/`message` pair and the observed type/channel.

A partial handshake leaves `connection` as a local, so an early return drops it and the client stays disconnected rather than half-established. There is a test for that.

## Public API impact

Additive: `ServerSetupMessage` and `DEFAULT_CONNECT_TIMEOUT`. Nothing renamed or removed. Timeouts are fixed constants for now — making them configurable is a builder, which #20 introduces; doing it here would be two API decisions in one PR.

## Testing

Six new tests, one per handshake branch, all offline and without sleeps: silence, wrong type, wrong channel, malformed JSON, server `ERROR`, and that a failed handshake leaves the client disconnected.

- [x] `make check` and `cargo build --workspace --all-features` clean

## Note on a test I had to adjust

`test_client_sends_keepalives` used `start_paused = true`. With a bounded connect, virtual time now fires that bound before the socket finishes being established, so the test connects in real time and pauses only to cross the interval. Worth knowing for any future test that pauses the clock around `connect()`.

Closes #11
