### PR TITLE
Build the SETUP client version from crate metadata (#19)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -31,9 +31,19 @@ const DEFAULT_KEEPALIVE_TIMEOUT: u32 = 60;
 /// send a keep-alive message at least this often to maintain the connection.
 const DEFAULT_KEEPALIVE_INTERVAL: u32 = 15;
 
-/// Default client version string.  This is used to identify the client
-/// software version to the server.
-const DEFAULT_CLIENT_VERSION: &str = "1.0.2-dxlink-0.1.3";
+/// The `version` advertised in `SETUP`.
+///
+/// The specification's format is `<protocol-version>-<implementation>/<client-version>`
+/// (for example `0.1-js/1.0.0`): protocol `0.1`, this implementation identified
+/// as `dxlink-rs`, and the crate version.
+///
+/// Built from `CARGO_PKG_VERSION` at compile time so bumping the crate updates
+/// what the server sees without a second edit. The previous hardcoded
+/// `1.0.2-dxlink-0.1.3` named a crate version three releases stale and did not
+/// follow the format, which leaves a client unidentifiable in server-side
+/// diagnostics. `concat!` needs literals, so the protocol and implementation
+/// tokens are spelled out here rather than composed from constants.
+const DEFAULT_CLIENT_VERSION: &str = concat!("0.1-dxlink-rs/", env!("CARGO_PKG_VERSION"));
 
 /// How long any single handshake response may take before `connect()` gives up.
 ///
@@ -1361,5 +1371,38 @@ mod tests {
             Err(DXLinkError::Connection(_)) => {}
             _ => panic!("Expected Connection error"),
         }
+    }
+}
+
+#[cfg(test)]
+mod version_tests {
+    use super::DEFAULT_CLIENT_VERSION;
+
+    /// The exact string the server sees. Pinned because a malformed version is
+    /// invisible in normal operation and only shows up in someone else's
+    /// telemetry.
+    #[test]
+    fn test_setup_version_follows_the_spec_format() {
+        let (protocol_and_impl, client_version) = DEFAULT_CLIENT_VERSION
+            .split_once('/')
+            .expect("version must be <protocol>-<implementation>/<client-version>");
+
+        let (protocol, implementation) = protocol_and_impl
+            .split_once('-')
+            .expect("the part before / must be <protocol>-<implementation>");
+
+        assert_eq!(protocol, "0.1", "protocol version token");
+        assert_eq!(implementation, "dxlink-rs", "implementation token");
+
+        // Bumping Cargo.toml must move this without another edit.
+        assert_eq!(
+            client_version,
+            env!("CARGO_PKG_VERSION"),
+            "the advertised version must be the crate version"
+        );
+        assert!(
+            !client_version.is_empty() && client_version.contains('.'),
+            "prerelease and normal versions alike are carried verbatim: {client_version}"
+        );
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,7 +4,7 @@
    Date: 7/3/25
 ******************************************************************************/
 
-use crate::connection::WebSocketConnection;
+use crate::connection::{WebSocketConnection, sanitize_server_text};
 use crate::error::{DXLinkError, DXLinkResult};
 use crate::events::{CompactData, EventType, MarketEvent};
 use crate::messages::{
@@ -136,8 +136,12 @@ async fn expect_handshake_message(
 
     // A server ERROR here is the server telling us why, not an unexpected frame.
     if received_type == "ERROR" {
-        let code = value["error"].as_str().unwrap_or("unknown");
-        let message = value["message"].as_str().unwrap_or("");
+        // Both fields are free text chosen by the server and end up in an error
+        // the caller will very likely log, so they get the same treatment as a
+        // close reason: a server echoing the token back must not turn our own
+        // error reporting into a credential leak.
+        let code = sanitize_server_text(value["error"].as_str().unwrap_or("unknown"));
+        let message = sanitize_server_text(value["message"].as_str().unwrap_or(""));
         let detail = format!("during {state}, the server returned {code}: {message}");
         return Err(if code.eq_ignore_ascii_case("UNAUTHORIZED") {
             DXLinkError::Authentication(detail)

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -33,7 +33,7 @@ const MAX_CLOSE_REASON_LEN: usize = 120;
 /// of short words; anything longer has the shape of a credential.
 const MAX_CLOSE_REASON_WORD_LEN: usize = 32;
 
-/// Returns a close reason that is safe to log and to embed in an error.
+/// Returns server-supplied text that is safe to log and to embed in an error.
 ///
 /// The reason is free text chosen by the server, and it reaches both the logs
 /// and [`DXLinkError::Connection`]. The close path is also the authentication
@@ -41,7 +41,7 @@ const MAX_CLOSE_REASON_WORD_LEN: usize = 32;
 /// error reporting into a credential leak. Control characters are dropped, runs
 /// too long to be a word are masked with [`REDACTED_PLACEHOLDER`], and the
 /// result is truncated. The close code is a protocol enum and is always kept.
-fn sanitize_close_reason(reason: &str) -> String {
+pub(crate) fn sanitize_server_text(reason: &str) -> String {
     let printable: String = reason.chars().filter(|c| !c.is_control()).collect();
 
     let masked = printable
@@ -238,7 +238,7 @@ impl WebSocketConnection {
                         Some(frame) => format!(
                             "code {}, reason: {}",
                             frame.code,
-                            sanitize_close_reason(&frame.reason)
+                            sanitize_server_text(&frame.reason)
                         ),
                         None => "no close frame".to_string(),
                     };
@@ -846,19 +846,19 @@ mod redaction_tests {
     }
 
     #[test]
-    fn test_sanitize_close_reason_keeps_ordinary_text() {
+    fn test_sanitize_server_text_keeps_ordinary_text() {
         // The diagnostic value of a close reason is the whole point of keeping
         // it, so normal wording must survive untouched.
         assert_eq!(
-            sanitize_close_reason("invalid token, please re-authenticate"),
+            sanitize_server_text("invalid token, please re-authenticate"),
             "invalid token, please re-authenticate"
         );
     }
 
     #[test]
-    fn test_sanitize_close_reason_masks_credential_shaped_runs() {
+    fn test_sanitize_server_text_masks_credential_shaped_runs() {
         let token = "a".repeat(64);
-        let sanitized = sanitize_close_reason(&format!("rejected token {token} for user bob"));
+        let sanitized = sanitize_server_text(&format!("rejected token {token} for user bob"));
 
         assert!(!sanitized.contains(&token), "token survived: {sanitized}");
         assert!(sanitized.contains(REDACTED_PLACEHOLDER));
@@ -868,8 +868,8 @@ mod redaction_tests {
     }
 
     #[test]
-    fn test_sanitize_close_reason_drops_control_characters() {
-        let sanitized = sanitize_close_reason("bad\u{0}token\nsecond line\u{7}");
+    fn test_sanitize_server_text_drops_control_characters() {
+        let sanitized = sanitize_server_text("bad\u{0}token\nsecond line\u{7}");
 
         assert!(!sanitized.contains('\u{0}'));
         assert!(!sanitized.contains('\u{7}'));
@@ -877,18 +877,18 @@ mod redaction_tests {
     }
 
     #[test]
-    fn test_sanitize_close_reason_is_bounded() {
+    fn test_sanitize_server_text_is_bounded() {
         // Many short words: nothing is credential-shaped, so only the overall
         // length limit applies.
         let long = "word ".repeat(200);
-        let sanitized = sanitize_close_reason(&long);
+        let sanitized = sanitize_server_text(&long);
 
         assert_eq!(sanitized.chars().count(), MAX_CLOSE_REASON_LEN);
     }
 
     #[test]
-    fn test_sanitize_close_reason_handles_empty_input() {
-        assert_eq!(sanitize_close_reason(""), "");
+    fn test_sanitize_server_text_handles_empty_input() {
+        assert_eq!(sanitize_server_text(""), "");
     }
 
     /// A `MakeWriter` that captures log output into a shared buffer so tests

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -280,3 +280,22 @@ async fn test_failed_handshake_leaves_the_client_disconnected() {
         .await
         .expect("disconnect after a failed handshake should be safe");
 }
+
+/// A server that echoes the credential back in its error message must not get
+/// it into an error the caller will log.
+#[tokio::test]
+async fn test_handshake_error_cannot_leak_an_echoed_token() {
+    let token = "tastytrade-live-bearer-token-long-enough-to-be-a-secret";
+    let server = MockServer::start(Behaviour::ErrorEchoingToken).await;
+    let mut client = DXLinkClient::new(&server.url(), token);
+
+    let err = client
+        .connect()
+        .await
+        .expect_err("the server rejected the handshake");
+
+    let text = err.to_string();
+    assert!(!text.contains(token), "token leaked into the error: {text}");
+    // The actionable part survives.
+    assert!(text.contains("UNAUTHORIZED"), "error code lost: {text}");
+}

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -52,6 +52,8 @@ pub enum Behaviour {
     MalformedSetup,
     /// Answer SETUP with a protocol ERROR frame.
     ErrorOnSetup,
+    /// Answer SETUP with an ERROR whose message echoes a credential back.
+    ErrorEchoingToken,
 }
 
 pub struct MockServer {
@@ -127,6 +129,18 @@ impl MockServer {
                     }
                     (Behaviour::MalformedSetup, "SETUP") => {
                         let _ = ws.send(Message::Text("not json at all".into())).await;
+                        continue;
+                    }
+                    (Behaviour::ErrorEchoingToken, "SETUP") => {
+                        let echoed = value["token"].as_str().unwrap_or("");
+                        let _ = ws
+                            .send(Message::Text(
+                                json!({"channel": 0, "type": "ERROR", "error": "UNAUTHORIZED",
+                                       "message": format!("rejected token {echoed}")})
+                                .to_string()
+                                .into(),
+                            ))
+                            .await;
                         continue;
                     }
                     (Behaviour::ErrorOnSetup, "SETUP") => {


### PR DESCRIPTION
## Summary

The advertised `SETUP` version was the hardcoded `1.0.2-dxlink-0.1.3`: a crate version three releases stale, in a format the specification does not use. A client that misreports itself is invisible in normal operation and only surfaces as a mystery in someone else's server-side diagnostics.

Stacked on #39.

## Changes

Built from `CARGO_PKG_VERSION` at compile time in the documented `<protocol-version>-<implementation>/<client-version>` shape: `0.1-dxlink-rs/0.3.0`. Bumping `Cargo.toml` moves it without a second edit.

## Technical decisions

`concat!` needs literals, so the protocol and implementation tokens are spelled out in the expression rather than composed from named constants — the constants would have been dead code and clippy rejects that. The doc comment carries the explanation instead.

Prerelease versions need no special handling: `CARGO_PKG_VERSION` carries them verbatim (`0.4.0-rc.1` becomes `0.1-dxlink-rs/0.4.0-rc.1`), which is what the format expects.

## Verified against the live server

```
Sending: {"...","type":"SETUP","version":"0.1-dxlink-rs/0.3.0"}
Received: {"type":"SETUP","channel":0,"version":"1.0-2.8.3",...}
```

The tastytrade demo endpoint accepts it and completes SETUP.

## Public API impact

None. `DEFAULT_CLIENT_VERSION` is private; only the string on the wire changes. Patch-level protocol fix.

## Testing

- [x] Unit test pins the exact format and asserts the client-version segment equals `CARGO_PKG_VERSION`, so a bump cannot silently desync
- [x] Live smoke against the demo endpoint
- [x] `make check` clean

Closes #19
