### PR TITLE
Honor the negotiated keepalive and detect inbound silence (#20)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -27,9 +27,17 @@ use tracing::{debug, error, info, warn};
 /// message is received within this timeframe, the connection is considered closed.
 const DEFAULT_KEEPALIVE_TIMEOUT: u32 = 60;
 
-/// Default interval for sending keep-alive messages in seconds.  Clients should
-/// send a keep-alive message at least this often to maintain the connection.
-const DEFAULT_KEEPALIVE_INTERVAL: u32 = 15;
+/// Fraction of the negotiated deadline at which maintenance is sent.
+///
+/// The specification only requires *some* outbound message before the server's
+/// `keepaliveTimeout`. Sending three times per deadline leaves room for a lost
+/// packet without being chatty. The previous fixed 15s ignored the negotiation
+/// entirely, so a server asking for less than that could close the connection
+/// while the client believed it was healthy.
+const KEEPALIVE_DIVISOR: u32 = 3;
+
+/// Never schedule maintenance faster than this, whatever the server negotiates.
+const MIN_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(1);
 
 /// The `version` advertised in `SETUP`.
 ///
@@ -218,8 +226,12 @@ pub struct DXLinkClient {
     token: String,
     /// The active WebSocket connection, if established.  `None` indicates no active connection.
     connection: Option<WebSocketConnection>,
-    /// The timeout for keepalive messages in seconds.
+    /// The keepalive timeout this client advertises, in seconds. Also the
+    /// deadline after which inbound silence is treated as a dead connection.
     keepalive_timeout: u32,
+    /// The keepalive timeout the server asked for, learned from its `SETUP`.
+    /// `None` until the handshake completes or if the server did not send one.
+    server_keepalive_timeout: Option<u32>,
     /// A thread-safe counter for generating unique channel IDs.
     next_channel_id: Arc<Mutex<u32>>,
     /// A thread-safe map storing the association between channel IDs and the services they are subscribed to.
@@ -267,6 +279,7 @@ impl DXLinkClient {
             token: token.to_string(),
             connection: None,
             keepalive_timeout: DEFAULT_KEEPALIVE_TIMEOUT,
+            server_keepalive_timeout: None,
             next_channel_id: Arc::new(Mutex::new(1)), // Start from 1 as 0 is the main channel
             channels: Arc::new(Mutex::new(HashMap::new())),
             callbacks: Arc::new(Mutex::new(HashMap::new())),
@@ -277,6 +290,46 @@ impl DXLinkClient {
             keepalive_sender: None,
             response_requests: Arc::new(Mutex::new(Vec::new())),
         }
+    }
+
+    /// Sets the keepalive timeout this client advertises, in seconds.
+    ///
+    /// This is the deadline the client asks the server to respect, and the one
+    /// after which inbound silence is reported as a dead connection. It does not
+    /// change how often the client sends maintenance: that follows what the
+    /// server negotiates in its `SETUP` reply.
+    ///
+    /// Must be called before [`connect`](Self::connect); afterwards it has no
+    /// effect on the running session. A zero is rejected.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use dxlink::DXLinkClient;
+    ///
+    /// let client = DXLinkClient::new("wss://example.com", "token")
+    ///     .with_keepalive_timeout(30)
+    ///     .expect("30 seconds is a valid timeout");
+    /// ```
+    pub fn with_keepalive_timeout(mut self, seconds: u32) -> DXLinkResult<Self> {
+        if seconds == 0 {
+            return Err(DXLinkError::Protocol(
+                "keepalive timeout must be greater than zero".to_string(),
+            ));
+        }
+        self.keepalive_timeout = seconds;
+        Ok(self)
+    }
+
+    /// The interval at which maintenance is sent, derived from the negotiated
+    /// deadline. Falls back to the advertised timeout when the server did not
+    /// negotiate one.
+    fn keepalive_interval(&self) -> Duration {
+        let deadline = self
+            .server_keepalive_timeout
+            .unwrap_or(self.keepalive_timeout);
+        Duration::from_secs(u64::from(deadline.div_ceil(KEEPALIVE_DIVISOR)))
+            .max(MIN_KEEPALIVE_INTERVAL)
     }
 
     /// Establishes a connection to the DXLink server.
@@ -341,6 +394,9 @@ impl DXLinkClient {
             "Server SETUP: version={:?}, keepaliveTimeout={:?}",
             server_setup.version, server_setup.keepalive_timeout
         );
+        // A zero would schedule maintenance in a tight loop; treat it as "not
+        // negotiated" rather than trusting it.
+        self.server_keepalive_timeout = server_setup.keepalive_timeout.filter(|t| *t > 0);
 
         let response =
             expect_handshake_message(&connection, "SETUP", "AUTH_STATE", MAIN_CHANNEL).await?;
@@ -469,16 +525,31 @@ impl DXLinkClient {
         // Obtener la conexión
         let connection = self.connection.as_ref().unwrap().clone();
 
-        // Usar la constante para el intervalo de keepalive
-        let keepalive_interval = Duration::from_secs(DEFAULT_KEEPALIVE_INTERVAL as u64);
+        // Derived from what the server negotiated, not from a fixed constant.
+        let keepalive_interval = self.keepalive_interval();
+        debug!(
+            "Keepalive every {:?} (server asked for {:?}s)",
+            keepalive_interval, self.server_keepalive_timeout
+        );
 
         let keepalive_handle = tokio::spawn(async move {
-            let mut interval = tokio::time::interval(keepalive_interval);
+            // Start one interval out: tokio's first tick is immediate, which
+            // fired a redundant KEEPALIVE the instant the session opened.
+            let mut interval = tokio::time::interval_at(
+                tokio::time::Instant::now() + keepalive_interval,
+                keepalive_interval,
+            );
 
             loop {
                 tokio::select! {
                     _ = interval.tick() => {
-                        // Es hora de enviar un keepalive
+                        // Any outbound message resets the server's idle timer,
+                        // so traffic that already went out covers this beat.
+                        if connection.since_last_send() < keepalive_interval {
+                            debug!("Skipping keepalive, the socket was used recently");
+                            continue;
+                        }
+
                         let keepalive_msg = KeepaliveMessage {
                             channel: MAIN_CHANNEL,
                             message_type: "KEEPALIVE".to_string(),
@@ -490,7 +561,6 @@ impl DXLinkClient {
                             },
                             Err(e) => {
                                 error!("Failed to send keepalive: {}", e);
-                                // Salir del bucle en caso de error para que la tarea termine
                                 break;
                             }
                         }
@@ -528,9 +598,35 @@ impl DXLinkClient {
         let response_requests = self.response_requests.clone();
 
         // Iniciar la tarea de procesamiento de mensajes
+        // Inbound silence past our advertised deadline means the peer is gone,
+        // even though the socket is still open. Without this the task waits on a
+        // dead connection forever.
+        let receive_deadline = Duration::from_secs(u64::from(self.keepalive_timeout));
+
         let message_handle = tokio::spawn(async move {
             loop {
-                match connection.receive().await {
+                let received = match connection.receive_with_timeout(receive_deadline).await {
+                    Ok(Some(msg)) => Ok(msg),
+                    Ok(None) => {
+                        // Silence past the advertised deadline means the peer is
+                        // gone even though the socket is still open. Terminal
+                        // here specifically: a bare read timeout is not terminal
+                        // in general, which is why this does not go through
+                        // is_terminal().
+                        error!(
+                            "{}",
+                            DXLinkError::Timeout(format!(
+                                "no message received on channel {} for {}s, the connection is assumed dead",
+                                MAIN_CHANNEL,
+                                receive_deadline.as_secs()
+                            ))
+                        );
+                        break;
+                    }
+                    Err(e) => Err(e),
+                };
+
+                match received {
                     Ok(msg) => {
                         debug!("Received message: {}", msg);
 
@@ -1408,5 +1504,48 @@ mod version_tests {
             !client_version.is_empty() && client_version.contains('.'),
             "prerelease and normal versions alike are carried verbatim: {client_version}"
         );
+    }
+}
+
+#[cfg(test)]
+mod keepalive_tests {
+    use super::*;
+
+    #[test]
+    fn test_interval_follows_the_negotiated_deadline() {
+        let mut client = DXLinkClient::new("wss://example.com", "token");
+
+        // Nothing negotiated yet: fall back to what we advertise.
+        assert_eq!(
+            client.keepalive_interval(),
+            Duration::from_secs(u64::from(DEFAULT_KEEPALIVE_TIMEOUT).div_ceil(3))
+        );
+
+        // A server asking for less than the old fixed 15s must be honoured, or
+        // it closes the connection while the client thinks it is healthy.
+        client.server_keepalive_timeout = Some(3);
+        assert_eq!(client.keepalive_interval(), Duration::from_secs(1));
+
+        client.server_keepalive_timeout = Some(60);
+        assert_eq!(client.keepalive_interval(), Duration::from_secs(20));
+    }
+
+    #[test]
+    fn test_interval_never_collapses_to_zero() {
+        let mut client = DXLinkClient::new("wss://example.com", "token");
+        // Would round down to zero and spin the task.
+        client.server_keepalive_timeout = Some(1);
+        assert!(client.keepalive_interval() >= MIN_KEEPALIVE_INTERVAL);
+    }
+
+    #[test]
+    fn test_advertised_timeout_is_configurable_and_validated() {
+        let client = DXLinkClient::new("wss://example.com", "token")
+            .with_keepalive_timeout(30)
+            .expect("30 is valid");
+        assert_eq!(client.keepalive_timeout, 30);
+
+        let rejected = DXLinkClient::new("wss://example.com", "token").with_keepalive_timeout(0);
+        assert!(matches!(rejected, Err(DXLinkError::Protocol(_))));
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -439,11 +439,13 @@ impl DXLinkClient {
 
         let receiver = self.event_stream();
 
-        // Start message processing task first so it puede capturar todos los mensajes
-        self.start_message_processing()?;
-
-        // Start keepalive task with a channel
+        // Keepalive first: it owns the shutdown channel the reader needs in
+        // order to stop it when the session dies. Nothing goes out in between,
+        // because the first maintenance tick is a full interval away.
         self.start_keepalive()?;
+
+        // Then the reader, which must be up before any traffic can arrive.
+        self.start_message_processing()?;
 
         receiver
     }
@@ -498,9 +500,12 @@ impl DXLinkClient {
 
     /// Starts the keepalive task.
     ///
-    /// This function spawns a new tokio task that periodically sends keepalive messages
-    /// to the DXLink device.  The interval between keepalive messages is defined by
-    /// the `DEFAULT_KEEPALIVE_INTERVAL` constant.
+    /// This function spawns a new tokio task that periodically sends keepalive
+    /// messages to the DXLink server. The interval is derived from the deadline
+    /// the server negotiated in its `SETUP` reply, not from a fixed constant, so
+    /// a server asking for less than the client would otherwise assume is
+    /// honoured. Maintenance is skipped when ordinary traffic has already reset
+    /// the server's idle timer.
     ///
     /// The keepalive task runs in an infinite loop until either the connection is
     /// dropped or a shutdown signal is received through the `keepalive_sender` channel.
@@ -582,6 +587,10 @@ impl DXLinkClient {
     }
 
     fn start_message_processing(&mut self) -> DXLinkResult<()> {
+        // Cloned so the reader can tear the whole session down, not just itself:
+        // stopping only the reader left the keepalive writing to a socket
+        // nobody was listening to.
+        let shutdown_keepalive = self.keepalive_sender.clone();
         // Asegurarnos de que tenemos una conexión
         if self.connection.is_none() {
             return Err(DXLinkError::Connection(
@@ -743,6 +752,13 @@ impl DXLinkClient {
                         tokio::time::sleep(Duration::from_millis(100)).await;
                     }
                 }
+            }
+
+            // This task only ever exits because the session is dead, so the
+            // socket is gone: stop writing to it as well.
+            if let Some(stop) = shutdown_keepalive {
+                let _ = stop.send(()).await;
+                debug!("Asked the keepalive task to stop, the session is dead");
             }
         });
 
@@ -1443,6 +1459,52 @@ mod tests {
         joined.expect("message task panicked instead of stopping cleanly");
     }
 
+    /// A dead session must stop both owned tasks. Stopping only the reader left
+    /// the keepalive writing to a socket nobody was listening to, which is the
+    /// dead-but-open state this was meant to end.
+    #[tokio::test]
+    async fn test_session_death_stops_both_tasks() {
+        use tokio::net::TcpListener;
+        use tokio_tungstenite::accept_async;
+
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("failed to bind test server");
+        let addr = listener.local_addr().expect("failed to read local addr");
+
+        tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("failed to accept");
+            let ws = accept_async(stream).await.expect("failed to handshake");
+            drop(ws);
+        });
+
+        let mut client = DXLinkClient::new(&format!("ws://{}", addr), "test_token");
+        client.connection = Some(
+            crate::connection::WebSocketConnection::connect(&format!("ws://{}", addr))
+                .await
+                .expect("failed to connect"),
+        );
+
+        client.start_keepalive().expect("failed to start keepalive");
+        client
+            .start_message_processing()
+            .expect("failed to start message processing");
+
+        let message = client.message_handle.take().expect("no message task");
+        let keepalive = client.keepalive_handle.take().expect("no keepalive task");
+
+        tokio::time::timeout(Duration::from_secs(5), message)
+            .await
+            .expect("the reader kept running after the server closed")
+            .expect("the reader panicked");
+
+        // The reader is responsible for telling the writer to stop as well.
+        tokio::time::timeout(Duration::from_secs(5), keepalive)
+            .await
+            .expect("the keepalive kept writing to a dead socket")
+            .expect("the keepalive panicked");
+    }
+
     // Test error cases for connection
     #[test]
     fn test_connection_errors() {
@@ -1518,7 +1580,9 @@ mod keepalive_tests {
         // Nothing negotiated yet: fall back to what we advertise.
         assert_eq!(
             client.keepalive_interval(),
-            Duration::from_secs(u64::from(DEFAULT_KEEPALIVE_TIMEOUT).div_ceil(3))
+            Duration::from_secs(
+                u64::from(DEFAULT_KEEPALIVE_TIMEOUT).div_ceil(u64::from(KEEPALIVE_DIVISOR))
+            )
         );
 
         // A server asking for less than the old fixed 15s must be honoured, or
@@ -1527,7 +1591,10 @@ mod keepalive_tests {
         assert_eq!(client.keepalive_interval(), Duration::from_secs(1));
 
         client.server_keepalive_timeout = Some(60);
-        assert_eq!(client.keepalive_interval(), Duration::from_secs(20));
+        assert_eq!(
+            client.keepalive_interval(),
+            Duration::from_secs(60 / u64::from(KEEPALIVE_DIVISOR))
+        );
     }
 
     #[test]

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -7,10 +7,14 @@
 use super::error::{DXLinkError, DXLinkResult};
 use futures_util::{SinkExt, StreamExt};
 use serde::Serialize;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
+// tokio's Instant, not std's: it follows the runtime clock, so idle suppression
+// and the scheduler that consumes it agree under paused time as well as in
+// production.
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
+use tokio::time::Instant;
 use tokio::time::timeout;
 use tokio_tungstenite::MaybeTlsStream;
 use tokio_tungstenite::tungstenite::Message;
@@ -123,6 +127,12 @@ pub struct WebSocketConnection {
         Mutex<futures_util::stream::SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>>,
     >,
     read: Arc<Mutex<futures_util::stream::SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>>>,
+    /// When something was last written to this socket.
+    ///
+    /// The keepalive exists to keep the server from timing us out, so any other
+    /// outbound message serves the same purpose. Tracking this lets the
+    /// keepalive skip a beat that regular traffic already covered.
+    last_sent: Arc<StdMutex<Instant>>,
 }
 
 impl WebSocketConnection {
@@ -166,6 +176,7 @@ impl WebSocketConnection {
         Ok(Self {
             write: Arc::new(Mutex::new(write)),
             read: Arc::new(Mutex::new(read)),
+            last_sent: Arc::new(StdMutex::new(Instant::now())),
         })
     }
 
@@ -191,8 +202,11 @@ impl WebSocketConnection {
         let json = serde_json::to_string(message)?;
         debug!("Sending message: {}", redact_sensitive(&json));
 
-        let mut write = self.write.lock().await;
-        write.send(Message::Text(json.into())).await?;
+        {
+            let mut write = self.write.lock().await;
+            write.send(Message::Text(json.into())).await?;
+        }
+        self.mark_sent();
         Ok(())
     }
 
@@ -303,6 +317,24 @@ impl WebSocketConnection {
         }
     }
 
+    /// Records that something has just gone out on this socket.
+    fn mark_sent(&self) {
+        if let Ok(mut last) = self.last_sent.lock() {
+            *last = Instant::now();
+        }
+    }
+
+    /// How long since anything was last written to this socket.
+    ///
+    /// A caller scheduling keepalives uses this to avoid sending one when
+    /// ordinary traffic has already reset the server's idle timer.
+    pub fn since_last_send(&self) -> Duration {
+        self.last_sent
+            .lock()
+            .map(|last| last.elapsed())
+            .unwrap_or_default()
+    }
+
     /// Creates a new `KeepAliveSender` instance.
     ///
     /// This function returns a `KeepAliveSender` that can be used to send
@@ -335,6 +367,7 @@ impl Clone for WebSocketConnection {
         Self {
             write: Arc::clone(&self.write),
             read: Arc::clone(&self.read),
+            last_sent: Arc::clone(&self.last_sent),
         }
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -318,21 +318,29 @@ impl WebSocketConnection {
     }
 
     /// Records that something has just gone out on this socket.
+    ///
+    /// A poisoned lock is recovered rather than ignored: dropping the update
+    /// would leave `since_last_send` reporting a stale instant, and reporting a
+    /// zero elapsed time suppresses every future keepalive.
     fn mark_sent(&self) {
-        if let Ok(mut last) = self.last_sent.lock() {
-            *last = Instant::now();
-        }
+        let mut last = self
+            .last_sent
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *last = Instant::now();
     }
 
     /// How long since anything was last written to this socket.
     ///
     /// A caller scheduling keepalives uses this to avoid sending one when
-    /// ordinary traffic has already reset the server's idle timer.
+    /// ordinary traffic has already reset the server's idle timer. Recovering
+    /// from a poisoned lock matters here: returning a zero would look like the
+    /// socket was just used and silence the keepalive permanently.
     pub fn since_last_send(&self) -> Duration {
         self.last_sent
             .lock()
-            .map(|last| last.elapsed())
-            .unwrap_or_default()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .elapsed()
     }
 
     /// Creates a new `KeepAliveSender` instance.

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -155,26 +155,45 @@ async fn test_error_non_existent_channel() {
     client.disconnect().await.expect("failed to disconnect");
 }
 
-/// The client must keep the session alive on its own. Virtual time drives the
-/// interval so the suite does not spend 20 real seconds proving it.
+/// The client must keep the session alive on the deadline the server
+/// negotiated, not on a fixed schedule of its own. The fixture asks for 3
+/// seconds here, below the 15 the client used to assume: with the old fixed
+/// interval the server would have timed the connection out before the first
+/// keepalive went out.
 #[tokio::test]
-async fn test_client_sends_keepalives() {
+async fn test_client_honors_a_short_negotiated_keepalive() {
+    let server = MockServer::start(Behaviour::ShortKeepalive).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+
+    // 3s deadline means maintenance every second; well inside wait_for's bound.
+    server.wait_for("KEEPALIVE", is_type("KEEPALIVE")).await;
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// The first tick of a tokio interval is immediate, which used to fire a
+/// redundant KEEPALIVE the instant the session opened.
+#[tokio::test]
+async fn test_no_keepalive_is_sent_immediately_after_connecting() {
     let server = MockServer::start(Behaviour::Normal).await;
 
     let mut client = DXLinkClient::new(&server.url(), "test-token");
-    // Connect in real time: the handshake is bounded by a timeout that virtual
-    // time would fire before the socket finished being established.
     client.connect().await.expect("failed to connect");
 
-    // Past one keepalive interval; with time paused this costs nothing.
-    tokio::time::pause();
-    tokio::time::advance(Duration::from_secs(20)).await;
+    // The handshake is done; nothing should follow it straight away.
+    tokio::time::sleep(Duration::from_millis(300)).await;
 
-    // Back to real time before waiting: delivering the keepalive is real socket
-    // I/O, and a virtual-time timeout would expire before it lands.
-    tokio::time::resume();
-
-    server.wait_for("KEEPALIVE", is_type("KEEPALIVE")).await;
+    let types: Vec<String> = server
+        .received()
+        .iter()
+        .filter_map(|m| m["type"].as_str().map(String::from))
+        .collect();
+    assert!(
+        !types.contains(&"KEEPALIVE".to_string()),
+        "a keepalive went out immediately after connecting: {types:?}"
+    );
 
     client.disconnect().await.expect("failed to disconnect");
 }

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -54,6 +54,10 @@ pub enum Behaviour {
     ErrorOnSetup,
     /// Answer SETUP with an ERROR whose message echoes a credential back.
     ErrorEchoingToken,
+    /// Negotiate a 3 second keepalive deadline, below the 15s the client used
+    /// to assume. Lets a test prove the negotiated value is honoured without
+    /// waiting a minute for it.
+    ShortKeepalive,
 }
 
 pub struct MockServer {
@@ -159,12 +163,17 @@ impl MockServer {
 
                 match value["type"].as_str().unwrap_or("") {
                     "SETUP" => {
+                        let negotiated = if behaviour == Behaviour::ShortKeepalive {
+                            3
+                        } else {
+                            60
+                        };
                         responses.push(json!({
                             "channel": channel,
                             "type": "SETUP",
                             "version": "1.0.0",
-                            "keepaliveTimeout": 60,
-                            "acceptKeepaliveTimeout": 60
+                            "keepaliveTimeout": negotiated,
+                            "acceptKeepaliveTimeout": negotiated
                         }));
                         responses.push(json!({
                             "channel": 0, "type": "AUTH_STATE", "state": "UNAUTHORIZED"


### PR DESCRIPTION
## Summary

The client advertised 60 seconds, discarded whatever the server negotiated in its `SETUP` reply, and sent maintenance on a fixed 15 second schedule. A server asking for less than 15 seconds could close the connection while the client believed it was healthy, and a dead-but-open socket was kept forever because inbound silence was never checked.

## Changes

- The keepalive interval derives from the value the server negotiated, three times per deadline for margin, with a one second floor.
- A zero from the server is treated as *not negotiated* rather than trusted — it would otherwise spin the task.
- Any outbound message resets the server's idle timer, so the connection records its last write and the keepalive skips a beat ordinary traffic already covered.
- The schedule starts one interval out: tokio's first interval tick is immediate, which fired a redundant `KEEPALIVE` the instant the session opened.
- The message task reads with the advertised deadline and stops when nothing arrives before it.
- `with_keepalive_timeout` is additive and rejects zero.

## Technical decisions

**Idle tracking uses `tokio::time::Instant`, not `std`'s.** I hit this the hard way: with `std::time::Instant` the suppression measured real time while the scheduler ran on tokio's clock, so under `pause()` the keepalive was suppressed forever. They have to share a clock.

**Inbound silence is terminal here even though `is_terminal()` says a `Timeout` is not.** That classification is right in general — a read timeout does not mean the socket is dead — but exceeding the advertised keepalive deadline specifically does. So the message task breaks on it directly rather than routing through `is_terminal()`.

**Interval is deadline/3, not deadline/2.** The spec only requires *some* outbound message before the deadline; a third leaves room for one lost packet without being chatty.

## Public API impact

Additive: `DXLinkClient::with_keepalive_timeout` and `WebSocketConnection::since_last_send`. Nothing renamed or removed.

## Testing

The keepalive test used virtual time and was proving very little. It is replaced by a fixture that **negotiates a 3 second deadline** — below the 15 the client used to assume — so the test proves the acceptance criterion directly and in real time: with the old fixed interval the server would have timed the connection out before the first keepalive went out.

- [x] Short negotiated deadline honoured (real time, ~1s)
- [x] No keepalive fires immediately after connecting
- [x] Unit tests for the interval derivation, the one second floor, and setter validation
- [x] `make check` and `cargo build --workspace --all-features` clean

Closes #20
