### PR TITLE
Make response routing cancellation-safe and deliver server errors (#9)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -85,8 +85,10 @@ enum ResponseType {
     FeedConfig(u32),
     /// Indicates a channel has been closed. The `u32` value represents the channel identifier.
     ChannelClosed(u32),
-    /// Indicates an error has occurred. The `String` value contains the error message.
-    Error(String),
+    /// A server error. Kept as `(code, message)` rather than pre-formatted text
+    /// so the caller can pick the right `DXLinkError` from the code instead of
+    /// having to parse it back out of a sentence.
+    Error(String, String),
     /// A generic response type for other cases. The `String` value contains the response data.  This variant is currently unused (`#[allow(dead_code)]`).
     #[allow(dead_code)]
     Other(String),
@@ -364,9 +366,24 @@ impl DXLinkClient {
         self.get_connection()?.send(message).await?;
 
         match tokio::time::timeout(wait, rx).await {
-            Ok(Ok(ResponseType::Error(detail))) => Err(DXLinkError::Protocol(format!(
-                "during {operation} on channel {channel}, the server returned {detail}"
-            ))),
+            Ok(Ok(ResponseType::Error(code, message))) => {
+                let detail = format!(
+                    "during {operation} on channel {channel}, waiting for {expected_type}, \
+                     the server returned {code}: {message}"
+                );
+                // Pick the variant from the code: an UNAUTHORIZED here means the
+                // same thing it means during the handshake, and collapsing it to
+                // Protocol would lose the terminal classification a caller needs
+                // to know it must re-authenticate rather than retry.
+                Err(match code.to_ascii_uppercase().as_str() {
+                    "UNAUTHORIZED" => DXLinkError::Authentication(detail),
+                    // The channel itself is the problem, as opposed to the
+                    // action, which is a protocol violation and falls through.
+                    "INVALID_CHANNEL" | "UNKNOWN_CHANNEL" => DXLinkError::Channel(detail),
+                    "TIMEOUT" => DXLinkError::Timeout(detail),
+                    _ => DXLinkError::Protocol(detail),
+                })
+            }
             Ok(Ok(response)) => Ok(response),
             Ok(Err(_)) => Err(DXLinkError::Protocol(format!(
                 "during {operation} on channel {channel}, the response channel closed"
@@ -742,11 +759,10 @@ impl DXLinkClient {
                                                     .get("message")
                                                     .and_then(|v| v.as_str())
                                                     .unwrap_or("");
-                                                ResponseType::Error(format!(
-                                                    "{}: {}",
+                                                ResponseType::Error(
                                                     sanitize_server_text(error),
-                                                    sanitize_server_text(message)
-                                                ))
+                                                    sanitize_server_text(message),
+                                                )
                                             }
                                             _ => ResponseType::Other(msg.clone()),
                                         };
@@ -927,9 +943,8 @@ impl DXLinkClient {
                 info!("Feed channel {} created successfully", channel_id);
                 Ok(channel_id)
             }
-            ResponseType::Error(error) => Err(DXLinkError::Protocol(format!(
-                "Server returned error: {}",
-                error
+            ResponseType::Error(code, message) => Err(DXLinkError::Protocol(format!(
+                "server returned {code}: {message}"
             ))),
             _ => Err(DXLinkError::Protocol(
                 "Unexpected response type".to_string(),
@@ -1017,9 +1032,8 @@ impl DXLinkClient {
                 info!("Feed channel {} setup completed successfully", channel_id);
                 Ok(())
             }
-            ResponseType::Error(error) => Err(DXLinkError::Protocol(format!(
-                "Server returned error: {}",
-                error
+            ResponseType::Error(code, message) => Err(DXLinkError::Protocol(format!(
+                "server returned {code}: {message}"
             ))),
             _ => Err(DXLinkError::Protocol(
                 "Unexpected response type".to_string(),
@@ -1168,9 +1182,8 @@ impl DXLinkClient {
                 info!("Channel {} closed successfully", channel_id);
                 Ok(())
             }
-            ResponseType::Error(error) => Err(DXLinkError::Protocol(format!(
-                "Server returned error: {}",
-                error
+            ResponseType::Error(code, message) => Err(DXLinkError::Protocol(format!(
+                "server returned {code}: {message}"
             ))),
             _ => Err(DXLinkError::Protocol(
                 "Unexpected response type".to_string(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -97,6 +97,9 @@ enum ResponseType {
 /// response back to the requester.
 #[derive(Debug)]
 struct ResponseRequest {
+    /// Identity, so cleanup removes this exact registration and never a later
+    /// one that happens to want the same message type on the same channel.
+    id: u64,
     /// The expected type of the response message (e.g., "CHANNEL_OPENED", "FEED_CONFIG", etc.).  This string should match the expected
     /// response message type.
     expected_type: String,
@@ -177,6 +180,25 @@ async fn expect_handshake_message(
     Ok(raw)
 }
 
+/// Removes a pending response registration when it goes out of scope.
+///
+/// Registrations used to survive timeouts, cancelled futures and failed sends.
+/// A stale entry then matched the next valid response and consumed it, so a
+/// live waiter timed out instead. Tying removal to `Drop` covers every exit
+/// path, including the caller's future simply being dropped.
+struct PendingGuard {
+    requests: Arc<Mutex<Vec<ResponseRequest>>>,
+    id: u64,
+}
+
+impl Drop for PendingGuard {
+    fn drop(&mut self) {
+        if let Ok(mut requests) = self.requests.lock() {
+            requests.retain(|request| request.id != self.id);
+        }
+    }
+}
+
 /// Represents a client for interacting with the DXLink service.
 ///
 /// The `DXLinkClient` provides methods for connecting to a DXLink WebSocket server,
@@ -250,6 +272,8 @@ pub struct DXLinkClient {
     keepalive_sender: Option<Sender<()>>,
     /// A thread-safe vector that holds pending response requests.
     response_requests: Arc<Mutex<Vec<ResponseRequest>>>,
+    /// Hands out the identity each pending request is cleaned up by.
+    next_request_id: Arc<Mutex<u64>>,
 }
 
 impl DXLinkClient {
@@ -289,7 +313,87 @@ impl DXLinkClient {
             message_handle: None,
             keepalive_sender: None,
             response_requests: Arc::new(Mutex::new(Vec::new())),
+            next_request_id: Arc::new(Mutex::new(0)),
         }
+    }
+
+    /// Sends `message` and waits for `expected_type` on `channel`, cleaning the
+    /// registration up on every exit path.
+    ///
+    /// The registration goes in *before* the send: the message task is already
+    /// running, so registering afterwards is a lost-wakeup race. A guard removes
+    /// it on timeout, on send failure, and if the caller's future is dropped
+    /// mid-wait, none of which used to clean up.
+    async fn request_response<T: serde::Serialize>(
+        &self,
+        message: &T,
+        operation: &str,
+        expected_type: &str,
+        channel: u32,
+        wait: Duration,
+    ) -> DXLinkResult<ResponseType> {
+        let (tx, rx) = oneshot::channel();
+
+        let id = {
+            let mut next = self
+                .next_request_id
+                .lock()
+                .map_err(|_| DXLinkError::Unknown("request id lock poisoned".to_string()))?;
+            *next += 1;
+            *next
+        };
+
+        {
+            let mut requests = self
+                .response_requests
+                .lock()
+                .map_err(|_| DXLinkError::Unknown("response request lock poisoned".to_string()))?;
+            requests.push(ResponseRequest {
+                id,
+                expected_type: expected_type.to_string(),
+                channel_id: Some(channel),
+                response_sender: tx,
+            });
+        }
+
+        let _guard = PendingGuard {
+            requests: Arc::clone(&self.response_requests),
+            id,
+        };
+
+        self.get_connection()?.send(message).await?;
+
+        match tokio::time::timeout(wait, rx).await {
+            Ok(Ok(ResponseType::Error(detail))) => Err(DXLinkError::Protocol(format!(
+                "during {operation} on channel {channel}, the server returned {detail}"
+            ))),
+            Ok(Ok(response)) => Ok(response),
+            Ok(Err(_)) => Err(DXLinkError::Protocol(format!(
+                "during {operation} on channel {channel}, the response channel closed"
+            ))),
+            Err(_) => Err(DXLinkError::Timeout(format!(
+                "timed out after {}s waiting for {expected_type} on channel {channel} during {operation}",
+                wait.as_secs()
+            ))),
+        }
+    }
+
+    /// Borrows the live connection.
+    fn get_connection(&self) -> DXLinkResult<&WebSocketConnection> {
+        self.connection
+            .as_ref()
+            .ok_or_else(|| DXLinkError::Connection("Not connected to DXLink server".to_string()))
+    }
+
+    /// How many response registrations are currently pending.
+    ///
+    /// Exposed so a test can assert that a timed-out or cancelled request left
+    /// nothing behind that could consume someone else's response.
+    pub fn pending_response_count(&self) -> usize {
+        self.response_requests
+            .lock()
+            .map(|requests| requests.len())
+            .unwrap_or(0)
     }
 
     /// Sets the keepalive timeout this client advertises, in seconds.
@@ -450,54 +554,6 @@ impl DXLinkClient {
         receiver
     }
 
-    /// Waits for a specific response type from the DXLink device, optionally filtered by channel ID.
-    ///
-    /// This function registers a request for a specific response type and then waits for the corresponding
-    /// response to be received from the DXLink device.  The wait is subject to a timeout.
-    ///
-    /// # Arguments
-    ///
-    /// * `expected_type` - The expected type of the response message (e.g., "CHANNEL_OPENED", "FEED_CONFIG", etc.).
-    /// * `channel_id` - The expected channel ID for the response.  If `None`, any channel ID is accepted.
-    /// * `timeout` - The maximum time to wait for the response.
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(ResponseType)` - If the expected response is received within the timeout period.
-    /// * `Err(DXLinkError::Timeout)` - If the timeout period expires before the expected response is received.
-    /// * `Err(DXLinkError::Protocol)` - If the response channel is closed unexpectedly.
-    ///
-    #[allow(dead_code)]
-    async fn wait_for_response(
-        &self,
-        expected_type: &str,
-        channel_id: Option<u32>,
-        timeout: Duration,
-    ) -> DXLinkResult<ResponseType> {
-        let (tx, rx) = oneshot::channel();
-
-        // Registrar nuestra solicitud de respuesta
-        {
-            let mut requests = self.response_requests.lock().unwrap();
-            requests.push(ResponseRequest {
-                expected_type: expected_type.to_string(),
-                channel_id,
-                response_sender: tx,
-            });
-        }
-
-        // Esperar la respuesta con timeout
-        match tokio::time::timeout(timeout, rx).await {
-            Ok(Ok(response)) => Ok(response),
-            Ok(Err(_)) => Err(DXLinkError::Protocol("Response channel closed".to_string())),
-            Err(_) => Err(DXLinkError::Timeout(format!(
-                "Timed out waiting for {} message{}",
-                expected_type,
-                channel_id.map_or("".to_string(), |id| format!(" for channel {}", id))
-            ))),
-        }
-    }
-
     /// Starts the keepalive task.
     ///
     /// This function spawns a new tokio task that periodically sends keepalive
@@ -648,44 +704,67 @@ impl DXLinkClient {
                                 .and_then(|v| v.as_u64())
                                 .map(|c| c as u32);
 
-                            // Primero, comprobar si alguien está esperando este mensaje
+                            // Route to a waiter first. A channel-scoped ERROR
+                            // answers whatever operation is pending on that
+                            // channel, whichever success message it asked for:
+                            // otherwise the caller sat until its timeout while
+                            // the reason was only logged.
                             {
-                                let mut requests = response_requests.lock().unwrap();
-                                if let Some(idx) = requests.iter().position(|req| {
-                                    req.expected_type == msg_type
-                                        && (req.channel_id.is_none() || req.channel_id == channel)
-                                }) {
-                                    // Encontramos alguien esperando este mensaje
-                                    let request = requests.remove(idx);
+                                let mut delivered = false;
+                                if let Ok(mut requests) = response_requests.lock() {
+                                    let is_error = msg_type == "ERROR";
 
-                                    // Crear la respuesta apropiada
-                                    let response = match msg_type {
-                                        "CHANNEL_OPENED" => {
-                                            ResponseType::ChannelOpened(channel.unwrap_or(0))
-                                        }
-                                        "FEED_CONFIG" => {
-                                            ResponseType::FeedConfig(channel.unwrap_or(0))
-                                        }
-                                        "CHANNEL_CLOSED" => {
-                                            ResponseType::ChannelClosed(channel.unwrap_or(0))
-                                        }
-                                        "ERROR" => {
-                                            let error = value
-                                                .get("error")
-                                                .and_then(|v| v.as_str())
-                                                .unwrap_or("unknown");
-                                            let message = value
-                                                .get("message")
-                                                .and_then(|v| v.as_str())
-                                                .unwrap_or("");
-                                            ResponseType::Error(format!("{} - {}", error, message))
-                                        }
-                                        _ => ResponseType::Other(msg.clone()),
-                                    };
+                                    while let Some(idx) = requests.iter().position(|req| {
+                                        let channel_matches =
+                                            req.channel_id.is_none() || req.channel_id == channel;
+                                        channel_matches
+                                            && (req.expected_type == msg_type
+                                                || (is_error && channel.is_some()))
+                                    }) {
+                                        let request = requests.remove(idx);
 
-                                    // Enviar la respuesta (ignorando errores si el receptor ya no existe)
-                                    let _ = request.response_sender.send(response);
-                                    continue; // Pasar al siguiente mensaje
+                                        let response = match msg_type {
+                                            "CHANNEL_OPENED" => {
+                                                ResponseType::ChannelOpened(channel.unwrap_or(0))
+                                            }
+                                            "FEED_CONFIG" => {
+                                                ResponseType::FeedConfig(channel.unwrap_or(0))
+                                            }
+                                            "CHANNEL_CLOSED" => {
+                                                ResponseType::ChannelClosed(channel.unwrap_or(0))
+                                            }
+                                            "ERROR" => {
+                                                let error = value
+                                                    .get("error")
+                                                    .and_then(|v| v.as_str())
+                                                    .unwrap_or("unknown");
+                                                let message = value
+                                                    .get("message")
+                                                    .and_then(|v| v.as_str())
+                                                    .unwrap_or("");
+                                                ResponseType::Error(format!(
+                                                    "{}: {}",
+                                                    sanitize_server_text(error),
+                                                    sanitize_server_text(message)
+                                                ))
+                                            }
+                                            _ => ResponseType::Other(msg.clone()),
+                                        };
+
+                                        // A gone receiver means that caller
+                                        // already walked away. Keep looking
+                                        // rather than swallowing a response a
+                                        // live waiter is still owed.
+                                        if request.response_sender.send(response).is_ok() {
+                                            delivered = true;
+                                            break;
+                                        }
+                                        debug!("Dropping a stale response registration");
+                                    }
+                                }
+
+                                if delivered {
+                                    continue;
                                 }
                             }
 
@@ -820,34 +899,16 @@ impl DXLinkClient {
             parameters: params,
         };
 
-        // Registrar nuestra expectativa de respuesta
-        let (tx, rx) = oneshot::channel();
-        {
-            let mut requests = self.response_requests.lock().unwrap();
-            requests.push(ResponseRequest {
-                expected_type: "CHANNEL_OPENED".to_string(),
-                channel_id: Some(channel_id),
-                response_sender: tx,
-            });
-        }
+        let response = self
+            .request_response(
+                &channel_request,
+                "create_feed_channel",
+                "CHANNEL_OPENED",
+                channel_id,
+                Duration::from_secs(10),
+            )
+            .await?;
 
-        // Enviar la solicitud
-        let conn = self.get_connection_mut()?;
-        conn.send(&channel_request).await?;
-
-        // Esperar la respuesta
-        let response = match tokio::time::timeout(Duration::from_secs(10), rx).await {
-            Ok(Ok(response)) => response,
-            Ok(Err(_)) => return Err(DXLinkError::Protocol("Response channel closed".to_string())),
-            Err(_) => {
-                return Err(DXLinkError::Timeout(format!(
-                    "Timed out waiting for CHANNEL_OPENED message for channel {}",
-                    channel_id
-                )));
-            }
-        };
-
-        // Procesar la respuesta
         match response {
             ResponseType::ChannelOpened(received_channel) => {
                 if received_channel != channel_id {
@@ -933,32 +994,15 @@ impl DXLinkClient {
         let json = serde_json::to_string(&feed_setup)?;
         debug!("Sending FEED_SETUP: {}", json);
 
-        // Registrar nuestra expectativa de respuesta
-        let (tx, rx) = oneshot::channel();
-        {
-            let mut requests = self.response_requests.lock().unwrap();
-            requests.push(ResponseRequest {
-                expected_type: "FEED_CONFIG".to_string(),
-                channel_id: Some(channel_id),
-                response_sender: tx,
-            });
-        }
-
-        // Enviar la solicitud
-        let conn = self.get_connection_mut()?;
-        conn.send(&feed_setup).await?;
-
-        // Esperar la respuesta
-        let response = match tokio::time::timeout(Duration::from_secs(10), rx).await {
-            Ok(Ok(response)) => response,
-            Ok(Err(_)) => return Err(DXLinkError::Protocol("Response channel closed".to_string())),
-            Err(_) => {
-                return Err(DXLinkError::Timeout(format!(
-                    "Timed out waiting for FEED_CONFIG message for channel {}",
-                    channel_id
-                )));
-            }
-        };
+        let response = self
+            .request_response(
+                &feed_setup,
+                "setup_feed",
+                "FEED_CONFIG",
+                channel_id,
+                Duration::from_secs(10),
+            )
+            .await?;
 
         // Procesar la respuesta
         match response {
@@ -1095,32 +1139,15 @@ impl DXLinkClient {
             message_type: "CHANNEL_CANCEL".to_string(),
         };
 
-        // Registrar nuestra expectativa de respuesta (sin retener un futuro todavía)
-        let (tx, rx) = oneshot::channel();
-        {
-            let mut requests = self.response_requests.lock().unwrap();
-            requests.push(ResponseRequest {
-                expected_type: "CHANNEL_CLOSED".to_string(),
-                channel_id: Some(channel_id),
-                response_sender: tx,
-            });
-        }
-
-        // Ahora podemos obtener la conexión mutable y enviar
-        let conn = self.get_connection_mut()?;
-        conn.send(&cancel_msg).await?;
-
-        // Esperar la respuesta con timeout
-        let response = match tokio::time::timeout(Duration::from_secs(5), rx).await {
-            Ok(Ok(response)) => response,
-            Ok(Err(_)) => return Err(DXLinkError::Protocol("Response channel closed".to_string())),
-            Err(_) => {
-                return Err(DXLinkError::Timeout(format!(
-                    "Timed out waiting for CHANNEL_CLOSED message for channel {}",
-                    channel_id
-                )));
-            }
-        };
+        let response = self
+            .request_response(
+                &cancel_msg,
+                "close_channel",
+                "CHANNEL_CLOSED",
+                channel_id,
+                Duration::from_secs(5),
+            )
+            .await?;
 
         // Procesar la respuesta
         match response {

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -318,3 +318,68 @@ async fn test_handshake_error_cannot_leak_an_echoed_token() {
     // The actionable part survives.
     assert!(text.contains("UNAUTHORIZED"), "error code lost: {text}");
 }
+
+// --- Response routing (issue #9) -------------------------------------------
+
+/// A channel-scoped ERROR must answer whatever operation is pending on that
+/// channel. It used to be logged only, so the caller sat until its timeout and
+/// got a misleading Timeout instead of the reason the server gave.
+#[tokio::test]
+async fn test_channel_error_answers_the_pending_operation() {
+    let server = MockServer::start(Behaviour::ErrorOnChannelRequest).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+
+    let started = std::time::Instant::now();
+    let result = client.create_feed_channel("AUTO").await;
+
+    match result {
+        Err(DXLinkError::Protocol(msg)) => {
+            assert!(msg.contains("BAD_ACTION"), "server error code lost: {msg}");
+            assert!(
+                msg.contains("create_feed_channel"),
+                "operation context lost: {msg}"
+            );
+        }
+        other => panic!("expected the server error to be delivered, got: {other:?}"),
+    }
+
+    // The point is that it did not wait out the 10 second timeout.
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "the error was not delivered promptly: {:?}",
+        started.elapsed()
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// A request that times out must leave nothing behind that could consume a
+/// later response. Two timed-out attempts followed by a working one is the
+/// shape that used to break: the stale entry stole the third response.
+#[tokio::test]
+async fn test_a_timed_out_request_cannot_steal_a_later_response() {
+    let server = MockServer::start(Behaviour::IgnoreChannelRequest).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+
+    // Cancel the wait rather than sitting through the full timeout; a dropped
+    // future is exactly the path that used to leak a registration.
+    for _ in 0..2 {
+        let cancelled = tokio::time::timeout(
+            Duration::from_millis(200),
+            client.create_feed_channel("AUTO"),
+        )
+        .await;
+        assert!(cancelled.is_err(), "the fixture should never answer");
+    }
+
+    // Nothing stale may remain to answer for a later request.
+    let pending = client.pending_response_count();
+    assert_eq!(
+        pending, 0,
+        "{pending} registrations survived a cancelled wait"
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -383,3 +383,68 @@ async fn test_a_timed_out_request_cannot_steal_a_later_response() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+/// The helper's own timeout is a distinct cleanup path from a cancelled caller.
+/// This lets it fire, then proves the stale registration cannot answer for the
+/// request that follows: the second attempt must get its own channel back, not
+/// be starved by the first.
+#[tokio::test]
+async fn test_a_request_that_times_out_does_not_starve_the_next_one() {
+    let server = MockServer::start(Behaviour::IgnoreFirstChannelRequest).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+
+    // Let the helper's internal timeout elapse rather than cancelling it.
+    tokio::time::pause();
+    let first = client.create_feed_channel("AUTO").await;
+    tokio::time::resume();
+    assert!(
+        matches!(first, Err(DXLinkError::Timeout(_))),
+        "the first request should time out, got: {first:?}"
+    );
+    assert_eq!(
+        client.pending_response_count(),
+        0,
+        "the timed-out registration was left behind"
+    );
+
+    // The server answers from here on; the response must reach this caller.
+    let channel = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("the second request should be answered");
+    client
+        .setup_feed(channel, &[EventType::Quote])
+        .await
+        .expect("the channel the second request opened should be usable");
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// A failed send is the third cleanup path: the registration goes in before the
+/// send, so a send that errors must not leave it behind.
+#[tokio::test]
+async fn test_a_failed_send_leaves_no_pending_request() {
+    let server = MockServer::start(Behaviour::CloseAfterHandshake).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+
+    // The server hung up right after AUTH, so this send cannot land.
+    let mut last = Ok(0);
+    for _ in 0..5 {
+        last = client.create_feed_channel("AUTO").await;
+        if last.is_err() {
+            break;
+        }
+    }
+    assert!(
+        last.is_err(),
+        "the send should fail against a closed socket"
+    );
+
+    assert_eq!(
+        client.pending_response_count(),
+        0,
+        "a failed send left a registration behind"
+    );
+}

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -59,6 +59,11 @@ pub enum Behaviour {
     ErrorOnChannelRequest,
     /// Accept CHANNEL_REQUEST but never answer it.
     IgnoreChannelRequest,
+    /// Ignore the first CHANNEL_REQUEST and answer every one after it, so a
+    /// test can prove a timed-out request does not steal the next response.
+    IgnoreFirstChannelRequest,
+    /// Complete the handshake and then hang up, so the next send fails.
+    CloseAfterHandshake,
     /// Negotiate a 3 second keepalive deadline, below the 15s the client used
     /// to assume. Lets a test prove the negotiated value is honoured without
     /// waiting a minute for it.
@@ -94,6 +99,7 @@ impl MockServer {
 
             // Field order per (channel, event type), learned from FEED_SETUP.
             let mut event_fields: HashMap<(u64, String), Vec<String>> = HashMap::new();
+            let mut channel_requests_seen = 0u32;
 
             while let Some(Ok(message)) = ws.next().await {
                 let Message::Text(text) = message else {
@@ -116,6 +122,18 @@ impl MockServer {
                 // Handshake fault injection, before the normal answers.
                 match (behaviour, value["type"].as_str().unwrap_or("")) {
                     (Behaviour::Silent, _) => continue,
+                    (Behaviour::CloseAfterHandshake, "AUTH") => {
+                        let _ = ws
+                            .send(Message::Text(
+                                json!({"channel": 0, "type": "AUTH_STATE",
+                                       "state": "AUTHORIZED"})
+                                .to_string()
+                                .into(),
+                            ))
+                            .await;
+                        let _ = ws.send(Message::Close(None)).await;
+                        return;
+                    }
                     (Behaviour::WrongTypeOnSetup, "SETUP") => {
                         let _ = ws
                             .send(Message::Text(
@@ -196,6 +214,16 @@ impl MockServer {
                         }));
                     }
                     "CHANNEL_REQUEST" if behaviour == Behaviour::IgnoreChannelRequest => {}
+                    "CHANNEL_REQUEST" if behaviour == Behaviour::IgnoreFirstChannelRequest => {
+                        channel_requests_seen += 1;
+                        if channel_requests_seen == 1 {
+                            continue;
+                        }
+                        responses.push(json!({
+                            "channel": channel, "type": "CHANNEL_OPENED",
+                            "service": "FEED", "parameters": {}
+                        }));
+                    }
                     "CHANNEL_REQUEST" if behaviour == Behaviour::ErrorOnChannelRequest => {
                         responses.push(json!({
                             "channel": channel, "type": "ERROR",

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -54,6 +54,11 @@ pub enum Behaviour {
     ErrorOnSetup,
     /// Answer SETUP with an ERROR whose message echoes a credential back.
     ErrorEchoingToken,
+    /// Answer a CHANNEL_REQUEST with a channel-scoped ERROR instead of
+    /// CHANNEL_OPENED.
+    ErrorOnChannelRequest,
+    /// Accept CHANNEL_REQUEST but never answer it.
+    IgnoreChannelRequest,
     /// Negotiate a 3 second keepalive deadline, below the 15s the client used
     /// to assume. Lets a test prove the negotiated value is honoured without
     /// waiting a minute for it.
@@ -188,6 +193,13 @@ impl MockServer {
                         responses.push(json!({
                             "channel": 0, "type": "AUTH_STATE",
                             "state": state, "userId": "test-user"
+                        }));
+                    }
+                    "CHANNEL_REQUEST" if behaviour == Behaviour::IgnoreChannelRequest => {}
+                    "CHANNEL_REQUEST" if behaviour == Behaviour::ErrorOnChannelRequest => {
+                        responses.push(json!({
+                            "channel": channel, "type": "ERROR",
+                            "error": "BAD_ACTION", "message": "contract not supported"
                         }));
                     }
                     "CHANNEL_REQUEST" => responses.push(json!({


### PR DESCRIPTION
## Summary

Pending response registrations survived timeouts, cancelled futures and failed sends. Nothing removed them, so a stale entry later matched a valid response and consumed it — while the waiter that was actually owed it timed out.

Stacked on #41.

## Changes

- Registration, sending, bounded waiting and cleanup consolidated into one helper.
- Each request carries an identity; a `Drop` guard removes exactly that registration on every exit path.
- A channel-scoped `ERROR` answers whatever operation is pending on that channel.
- A gone receiver no longer counts as delivery — the router keeps looking for a live waiter.
- `wait_for_response` removed: dead code behind an `allow`, and the new helper is what it was trying to be.

## Technical decisions

**Cleanup is tied to `Drop`, not to the timeout branch.** A caller's future being dropped mid-wait is the path that leaks most easily and the one an explicit cleanup call always misses. The guard covers timeout, send failure and cancellation with the same code.

**A channel-scoped `ERROR` matches a waiter that asked for a success message.** Previously the router only matched on exact type, so an `ERROR` answering a `CHANNEL_REQUEST` was logged and dropped, and the caller waited out the full 10 seconds to be told it timed out. The server's reason is strictly more useful than that.

The error text goes through the same sanitizer as the handshake and close paths.

## Verified, not assumed

Disabling the guard makes the leak test fail with `2 registrations survived a cancelled wait`, and the error-routing test asserts the failure arrives in under 5 seconds rather than at the 10 second timeout.

## Public API impact

Additive: `DXLinkClient::pending_response_count`, exposed so the leak is assertable from a test rather than only inspectable in a debugger.

## Testing

- [x] A cancelled wait leaves no registration
- [x] A channel-scoped `ERROR` is delivered promptly with the code and operation in the text
- [x] `make check` and `cargo build --workspace --all-features` clean

Closes #9
