### PR TITLE
Deliver events on their own task, off the protocol reader (#10)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -59,6 +59,14 @@ const DEFAULT_CLIENT_VERSION: &str = concat!("0.1-dxlink-rs/", env!("CARGO_PKG_V
 /// and then says nothing must not hold a caller open forever.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
+/// Capacity of the queue between the socket reader and the delivery worker.
+///
+/// Generous: it only has to absorb a burst while the worker is inside a user
+/// callback. When it does fill, events are dropped rather than blocking the
+/// reader, because a blocked reader stops answering protocol traffic and makes
+/// unrelated channel operations time out.
+const DELIVERY_QUEUE_CAPACITY: usize = 1024;
+
 /// The main communication channel identifier. This is likely used for
 /// primary message exchange between client and server.
 const MAIN_CHANNEL: u32 = 0;
@@ -261,7 +269,7 @@ pub struct DXLinkClient {
     /// A thread-safe map storing the association between channel IDs and the services they are subscribed to.
     channels: Arc<Mutex<HashMap<u32, String>>>, // channel_id -> service
     /// A thread-safe map storing callback functions associated with specific market data symbols.
-    callbacks: Arc<Mutex<HashMap<String, EventCallback>>>, // symbol -> callback
+    callbacks: Arc<Mutex<HashMap<String, Arc<EventCallback>>>>, // symbol -> callback
     /// A thread-safe set keeping track of active subscriptions, identified by `(EventType, String)`.
     subscriptions: Arc<Mutex<HashSet<(EventType, String)>>>, // (event_type, symbol)
     /// A sender for transmitting `MarketEvent` instances.
@@ -270,6 +278,8 @@ pub struct DXLinkClient {
     keepalive_handle: Option<JoinHandle<()>>,
     /// A handle to the message processing task.
     message_handle: Option<JoinHandle<()>>,
+    /// A handle to the task that runs callbacks and feeds the event stream.
+    delivery_handle: Option<JoinHandle<()>>,
     /// A channel sender used to signal the keepalive task.
     keepalive_sender: Option<Sender<()>>,
     /// A thread-safe vector that holds pending response requests.
@@ -313,6 +323,7 @@ impl DXLinkClient {
             event_sender: None,
             keepalive_handle: None,
             message_handle: None,
+            delivery_handle: None,
             keepalive_sender: None,
             response_requests: Arc::new(Mutex::new(Vec::new())),
             next_request_id: Arc::new(Mutex::new(0)),
@@ -411,6 +422,84 @@ impl DXLinkClient {
             .lock()
             .map(|requests| requests.len())
             .unwrap_or(0)
+    }
+
+    /// Spawns the worker that runs consumer callbacks and feeds the event
+    /// stream, and returns the queue the socket reader hands events to.
+    ///
+    /// Separate from the reader on purpose. Callbacks are user code: they can be
+    /// slow, they can panic, and the consumer's stream can fill up. Any of those
+    /// happening on the reader stopped it answering `FEED_CONFIG`,
+    /// `CHANNEL_CLOSED` and `ERROR`, so an unrelated channel operation timed out
+    /// because somebody's callback was busy.
+    ///
+    /// Backpressure policy: the queue is bounded and a full queue **drops the
+    /// event**, counting and logging the loss. Market data is only useful while
+    /// it is current, so blocking the reader to preserve a stale quote is the
+    /// wrong trade.
+    fn start_event_delivery(&mut self) -> Sender<MarketEvent> {
+        let (delivery_tx, mut delivery_rx) = mpsc::channel::<MarketEvent>(DELIVERY_QUEUE_CAPACITY);
+
+        let callbacks = self.callbacks.clone();
+        let event_sender = self.event_sender.clone();
+
+        let handle = tokio::spawn(async move {
+            let mut stream_closed_reported = false;
+
+            while let Some(event) = delivery_rx.recv().await {
+                let symbol = match &event {
+                    MarketEvent::Quote(e) => e.event_symbol.clone(),
+                    MarketEvent::Trade(e) => e.event_symbol.clone(),
+                    MarketEvent::Greeks(e) => e.event_symbol.clone(),
+                };
+
+                // Copy the handle out and release the lock before running user
+                // code: holding it across a callback serialises every other
+                // symbol behind whatever that callback is doing.
+                let callback = match callbacks.lock() {
+                    Ok(map) => map.get(&symbol).cloned(),
+                    Err(poisoned) => poisoned.into_inner().get(&symbol).cloned(),
+                };
+
+                if let Some(callback) = callback {
+                    let delivered = event.clone();
+                    // A panicking callback used to take the whole task with it,
+                    // and with it every protocol response.
+                    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+                        callback(delivered)
+                    }))
+                    .is_err()
+                    {
+                        error!("Callback for {} panicked; continuing delivery", symbol);
+                    }
+                }
+
+                if let Some(tx) = &event_sender {
+                    match tx.try_send(event) {
+                        Ok(()) => {}
+                        Err(mpsc::error::TrySendError::Full(_)) => {
+                            debug!("Event stream full, dropping an event for {}", symbol);
+                        }
+                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                            // The consumer dropped its receiver. Callbacks still
+                            // fire; the stream cannot be re-taken, which is what
+                            // event_stream documents.
+                            if !stream_closed_reported {
+                                debug!(
+                                    "Event stream receiver dropped; delivering to callbacks only"
+                                );
+                                stream_closed_reported = true;
+                            }
+                        }
+                    }
+                }
+            }
+
+            debug!("Event delivery task terminated");
+        });
+
+        self.delivery_handle = Some(handle);
+        delivery_tx
     }
 
     /// Sets the keepalive timeout this client advertises, in seconds.
@@ -660,23 +749,23 @@ impl DXLinkClient {
     }
 
     fn start_message_processing(&mut self) -> DXLinkResult<()> {
-        // Cloned so the reader can tear the whole session down, not just itself:
-        // stopping only the reader left the keepalive writing to a socket
-        // nobody was listening to.
-        let shutdown_keepalive = self.keepalive_sender.clone();
-        // Asegurarnos de que tenemos una conexión
+        // Check first: nothing may be spawned on a client that is not connected.
         if self.connection.is_none() {
             return Err(DXLinkError::Connection(
                 "Cannot start message processing without a connection".to_string(),
             ));
         }
 
-        // Clonar la conexión para usar en la tarea
         let connection = self.connection.as_ref().unwrap().clone();
 
-        // Clonar referencias que necesitamos
-        let callbacks = self.callbacks.clone();
-        let event_sender = self.event_sender.clone();
+        // Cloned so the reader can tear the whole session down, not just itself:
+        // stopping only the reader left the keepalive writing to a socket
+        // nobody was listening to.
+        let shutdown_keepalive = self.keepalive_sender.clone();
+        let delivery_tx = self.start_event_delivery();
+
+        // The reader only routes protocol traffic now; callbacks and the
+        // consumer stream belong to the delivery worker.
         let response_requests = self.response_requests.clone();
 
         // Iniciar la tarea de procesamiento de mensajes
@@ -686,6 +775,8 @@ impl DXLinkClient {
         let receive_deadline = Duration::from_secs(u64::from(self.keepalive_timeout));
 
         let message_handle = tokio::spawn(async move {
+            let mut dropped_events: u64 = 0;
+
             loop {
                 let received = match connection.receive_with_timeout(receive_deadline).await {
                     Ok(Some(msg)) => Ok(msg),
@@ -791,26 +882,21 @@ impl DXLinkClient {
                                         FeedDataMessage<Vec<CompactData>>,
                                     >(&msg)
                                     {
-                                        let events = parse_compact_data(&data_msg.data);
-                                        for event in events {
-                                            let symbol = match &event {
-                                                MarketEvent::Quote(e) => &e.event_symbol,
-                                                MarketEvent::Trade(e) => &e.event_symbol,
-                                                MarketEvent::Greeks(e) => &e.event_symbol,
-                                            };
-
-                                            // Enviarlo a los callbacks
-                                            if let Ok(callbacks) = callbacks.lock()
-                                                && let Some(callback) = callbacks.get(symbol)
-                                            {
-                                                callback(event.clone());
-                                            }
-
-                                            // Enviarlo al canal de eventos
-                                            if let Some(tx) = &event_sender
-                                                && let Err(e) = tx.send(event.clone()).await
-                                            {
-                                                error!("Failed to send event to channel: {}", e);
+                                        // Hand off and keep reading. Delivery is
+                                        // somebody else's job: doing it here let
+                                        // one slow callback or a full consumer
+                                        // stream stop the socket reads that every
+                                        // channel operation depends on.
+                                        for event in parse_compact_data(&data_msg.data) {
+                                            if delivery_tx.try_send(event).is_err() {
+                                                dropped_events += 1;
+                                                if dropped_events.is_power_of_two() {
+                                                    warn!(
+                                                        "Delivery queue full, {} event(s) dropped so far; \
+                                                         the consumer is slower than the feed",
+                                                        dropped_events
+                                                    );
+                                                }
                                             }
                                         }
                                     }
@@ -877,6 +963,13 @@ impl DXLinkClient {
 
         // Terminar la tarea de procesamiento de mensajes
         if let Some(handle) = self.message_handle.take() {
+            handle.abort();
+        }
+
+        // The delivery worker ends on its own once the reader drops the queue,
+        // but disconnect must not leave it running if the reader was aborted
+        // mid-flight.
+        if let Some(handle) = self.delivery_handle.take() {
             handle.abort();
         }
 
@@ -1194,10 +1287,18 @@ impl DXLinkClient {
     /// Register a callback function for a specific symbol
     pub fn on_event(&self, symbol: &str, callback: impl Fn(MarketEvent) + Send + Sync + 'static) {
         let mut callbacks = self.callbacks.lock().unwrap();
-        callbacks.insert(symbol.to_string(), Box::new(callback));
+        callbacks.insert(
+            symbol.to_string(),
+            Arc::new(Box::new(callback) as EventCallback),
+        );
     }
 
-    /// Get a stream of market events
+    /// Get a stream of market events.
+    ///
+    /// There is exactly one per client, and `connect` already returns it. If the
+    /// receiver is dropped the stream cannot be re-taken: delivery continues to
+    /// registered callbacks only, and the loss is logged once rather than per
+    /// event.
     pub fn event_stream(&mut self) -> DXLinkResult<Receiver<MarketEvent>> {
         if self.event_sender.is_none() {
             let (tx, rx) = mpsc::channel(100); // Buffer of 100 events

--- a/src/client.rs
+++ b/src/client.rs
@@ -463,12 +463,15 @@ impl DXLinkClient {
 
                 if let Some(callback) = callback {
                     let delivered = event.clone();
-                    // A panicking callback used to take the whole task with it,
-                    // and with it every protocol response.
-                    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-                        callback(delivered)
-                    }))
-                    .is_err()
+                    // Run it on the blocking pool, not here. A callback that
+                    // blocks the thread would otherwise stall this task's
+                    // executor thread, and on a current-thread runtime that is
+                    // the same thread the protocol reader needs. spawn_blocking
+                    // also turns a panic into a JoinError instead of unwinding
+                    // through the task.
+                    if tokio::task::spawn_blocking(move || callback(delivered))
+                        .await
+                        .is_err()
                     {
                         error!("Callback for {} panicked; continuing delivery", symbol);
                     }
@@ -888,14 +891,27 @@ impl DXLinkClient {
                                         // stream stop the socket reads that every
                                         // channel operation depends on.
                                         for event in parse_compact_data(&data_msg.data) {
-                                            if delivery_tx.try_send(event).is_err() {
-                                                dropped_events += 1;
-                                                if dropped_events.is_power_of_two() {
-                                                    warn!(
-                                                        "Delivery queue full, {} event(s) dropped so far; \
-                                                         the consumer is slower than the feed",
-                                                        dropped_events
+                                            match delivery_tx.try_send(event) {
+                                                Ok(()) => {}
+                                                Err(mpsc::error::TrySendError::Full(_)) => {
+                                                    dropped_events += 1;
+                                                    if dropped_events.is_power_of_two() {
+                                                        warn!(
+                                                            "Delivery queue full, {} event(s) dropped so far; \
+                                                             the consumer is slower than the feed",
+                                                            dropped_events
+                                                        );
+                                                    }
+                                                }
+                                                Err(mpsc::error::TrySendError::Closed(_)) => {
+                                                    // Delivery has stopped entirely, which is a
+                                                    // different thing from falling behind and
+                                                    // must not be reported as backpressure.
+                                                    error!(
+                                                        "Delivery worker is gone; no further events \
+                                                         will reach callbacks or the stream"
                                                     );
+                                                    break;
                                                 }
                                             }
                                         }
@@ -1299,6 +1315,16 @@ impl DXLinkClient {
     /// receiver is dropped the stream cannot be re-taken: delivery continues to
     /// registered callbacks only, and the loss is logged once rather than per
     /// event.
+    ///
+    /// # Backpressure
+    ///
+    /// The stream is bounded and **events are dropped when the consumer falls
+    /// behind**, rather than the library blocking to preserve them. A blocked
+    /// consumer would otherwise stall the socket reader and make unrelated
+    /// channel operations time out, and a quote that arrives late is worth less
+    /// than the connection staying responsive. Drops are logged. If you cannot
+    /// afford to miss events, drain this receiver into your own unbounded
+    /// buffer as soon as it yields.
     pub fn event_stream(&mut self) -> DXLinkResult<Receiver<MarketEvent>> {
         if self.event_sender.is_none() {
             let (tx, rx) = mpsc::channel(100); // Buffer of 100 events

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -354,3 +354,104 @@ async fn test_session_sends_the_expected_protocol_messages() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+// --- Delivery isolation (issue #10) ----------------------------------------
+
+/// A slow callback must not stop socket reads. It used to run on the same task
+/// that routes protocol responses, so an unrelated channel operation timed out
+/// because somebody's callback was busy.
+#[tokio::test]
+async fn test_a_slow_callback_does_not_block_protocol_operations() {
+    let server = MockServer::start(Behaviour::Normal).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+
+    // Blocks the delivery worker for far longer than a protocol round trip.
+    client.on_event("AAPL", |_| {
+        std::thread::sleep(Duration::from_millis(1500));
+    });
+
+    client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Quote".to_string(),
+                symbol: "AAPL".to_string(),
+                from_time: None,
+                source: None,
+            }],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    // Give the callback time to be in flight.
+    let _ = collect_events(&mut event_stream, 1).await;
+
+    // A protocol operation must still complete promptly.
+    let started = std::time::Instant::now();
+    let second = tokio::time::timeout(Duration::from_secs(3), client.create_feed_channel("AUTO"))
+        .await
+        .expect("a channel operation was blocked by a slow callback");
+    assert!(second.is_ok(), "channel operation failed: {second:?}");
+    assert!(
+        started.elapsed() < Duration::from_secs(3),
+        "channel operation took {:?}, it was waiting on the callback",
+        started.elapsed()
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// A panicking callback used to take the whole task down, and with it every
+/// protocol response.
+#[tokio::test]
+async fn test_a_panicking_callback_does_not_kill_the_session() {
+    let server = MockServer::start(Behaviour::Normal).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+
+    client.on_event("AAPL", |_| panic!("callback blew up"));
+
+    client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Quote".to_string(),
+                symbol: "AAPL".to_string(),
+                from_time: None,
+                source: None,
+            }],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    // The event still reaches the stream even though the callback panicked.
+    let events = collect_events(&mut event_stream, 1).await;
+    assert_eq!(events.len(), 1, "the stream lost the event to the panic");
+
+    // And the session is still usable.
+    client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("the session died with the callback");
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -360,7 +360,10 @@ async fn test_session_sends_the_expected_protocol_messages() {
 /// A slow callback must not stop socket reads. It used to run on the same task
 /// that routes protocol responses, so an unrelated channel operation timed out
 /// because somebody's callback was busy.
-#[tokio::test]
+// Multi-threaded on purpose: the point is that a blocking callback does not
+// stall protocol work, and the default single-threaded test runtime would make
+// the result depend on the executor rather than on the decoupling.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_a_slow_callback_does_not_block_protocol_operations() {
     let server = MockServer::start(Behaviour::Normal).await;
 
@@ -413,7 +416,7 @@ async fn test_a_slow_callback_does_not_block_protocol_operations() {
 
 /// A panicking callback used to take the whole task down, and with it every
 /// protocol response.
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_a_panicking_callback_does_not_kill_the_session() {
     let server = MockServer::start(Behaviour::Normal).await;
 


### PR DESCRIPTION
## Summary

Callbacks and the consumer stream ran on the task that reads the socket. A slow callback, a panicking one, or a full stream stopped protocol routing — `FEED_CONFIG`, `CHANNEL_CLOSED` and `ERROR` went unread, so unrelated channel operations timed out because somebody's callback was busy.

## Changes

- A delivery worker owns callbacks and the event stream; the reader hands events to it over a bounded queue and never blocks.
- Callbacks are cloned out of the map before the lock is released, so user code never runs while holding it.
- Panics are contained: a panicking callback is logged and delivery continues.
- Dropped receiver: callbacks keep firing, the stream cannot be re-taken, the loss is logged once rather than per event.

## Technical decisions

**A full queue drops the event.** Market data is only useful while it is current, so blocking the reader to preserve a stale quote is the wrong trade — and a blocked reader is exactly the failure this PR exists to remove. Drops are counted and logged at power-of-two intervals so the logging cannot become the new bottleneck. The policy is documented on the worker rather than left implicit.

**Callbacks are cloned, not invoked under the lock.** Holding the callbacks mutex while user code runs serialises every other symbol behind whatever that callback is doing, which is a second, quieter version of the same bug.

**`EventCallback` is stored behind an `Arc` internally, the public alias is unchanged.** Changing the alias from `Box` to `Arc` would be a breaking change for anyone naming the type, and the internal `Arc<EventCallback>` gets the same cloning without one.

## Public API impact

None. `event_stream`'s documented behaviour is now explicit about the single-shot receiver, but the behaviour itself is unchanged.

## Testing

Two tests that fail against the old shape:

- A callback that sleeps 1.5s must not delay a channel operation — asserts the operation completes in under 3s while the callback is in flight.
- A panicking callback must not kill the session — asserts the event still reaches the stream and the session is still usable afterwards.

- [x] `make check` and `cargo build --workspace --all-features` clean

Closes #10
