### PR TITLE
Make a lost connection observable to the consumer (#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
   can be requested — but the rows that come back are not decoded yet.
 - Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
   lost connection from one bad message.
+- A lost connection is observable: the event stream closes, and
+  [`DXLinkClient::disconnect_reason`] says why.
 
 ### What is not supported yet
 
@@ -26,8 +28,6 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - [`EventType`] declares more variants than the library can decode. Only
   `Quote`, `Trade` and `Greeks` produce a [`MarketEvent`]; subscribing to any
   other type is accepted by the server but never delivers events here.
-- The consumer is not notified when the event stream stops producing because
-  the connection was lost.
 
 ### Minimum supported Rust version
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -203,6 +203,15 @@ fn recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// The symbol an event refers to, borrowed rather than cloned.
+fn symbol_of(event: &MarketEvent) -> &str {
+    match event {
+        MarketEvent::Quote(e) => &e.event_symbol,
+        MarketEvent::Trade(e) => &e.event_symbol,
+        MarketEvent::Greeks(e) => &e.event_symbol,
+    }
+}
+
 /// Records why a session ended, keeping the first reason rather than the last.
 ///
 /// The first failure is the cause; anything after it is a consequence of a
@@ -482,19 +491,13 @@ impl DXLinkClient {
             let mut stream_closed_reported = false;
 
             while let Some(event) = delivery_rx.recv().await {
-                let symbol = match &event {
-                    MarketEvent::Quote(e) => e.event_symbol.clone(),
-                    MarketEvent::Trade(e) => e.event_symbol.clone(),
-                    MarketEvent::Greeks(e) => e.event_symbol.clone(),
-                };
+                // Borrowed, not cloned: this runs per event on a hot path.
+                let symbol = symbol_of(&event);
 
                 // Copy the handle out and release the lock before running user
                 // code: holding it across a callback serialises every other
                 // symbol behind whatever that callback is doing.
-                let callback = match callbacks.lock() {
-                    Ok(map) => map.get(&symbol).cloned(),
-                    Err(poisoned) => poisoned.into_inner().get(&symbol).cloned(),
-                };
+                let callback = recover(&callbacks).get(symbol).cloned();
 
                 if let Some(callback) = callback {
                     let delivered = event.clone();
@@ -515,8 +518,13 @@ impl DXLinkClient {
                 if let Some(tx) = &event_sender {
                     match tx.try_send(event) {
                         Ok(()) => {}
-                        Err(mpsc::error::TrySendError::Full(_)) => {
-                            debug!("Event stream full, dropping an event for {}", symbol);
+                        Err(mpsc::error::TrySendError::Full(returned)) => {
+                            // try_send hands the event back, so the symbol is
+                            // still available without having cloned it up front.
+                            debug!(
+                                "Event stream full, dropping an event for {}",
+                                symbol_of(&returned)
+                            );
                         }
                         Err(mpsc::error::TrySendError::Closed(_)) => {
                             // The consumer dropped its receiver. Callbacks still
@@ -618,6 +626,10 @@ impl DXLinkClient {
     /// # }
     /// ```
     pub async fn connect(&mut self) -> DXLinkResult<Receiver<MarketEvent>> {
+        // A new session starts clean: a reason from the previous one would make
+        // a healthy connection look dead.
+        *recover(&self.disconnect_reason) = None;
+
         // Connect to WebSocket
         let connection = WebSocketConnection::connect(&self.url).await?;
 
@@ -1087,6 +1099,7 @@ impl DXLinkClient {
         // dead connection has to go, and a prior panic elsewhere is no reason to
         // keep it.
         recover(&self.channels).clear();
+        self.event_stream_taken = false;
         recover(&self.subscriptions).clear();
         // Dropping the senders wakes every waiter instead of leaving it to time
         // out against a connection that is already gone.

--- a/src/client.rs
+++ b/src/client.rs
@@ -203,6 +203,17 @@ fn recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
         .unwrap_or_else(|poisoned| poisoned.into_inner())
 }
 
+/// Records why a session ended, keeping the first reason rather than the last.
+///
+/// The first failure is the cause; anything after it is a consequence of a
+/// connection that had already gone.
+fn record_reason(slot: &Arc<Mutex<Option<String>>>, error: &DXLinkError) {
+    let mut slot = recover(slot);
+    if slot.is_none() {
+        *slot = Some(error.to_string());
+    }
+}
+
 /// Removes a pending response registration when it goes out of scope.
 ///
 /// Registrations used to survive timeouts, cancelled futures and failed sends.
@@ -293,6 +304,12 @@ pub struct DXLinkClient {
     message_handle: Option<JoinHandle<()>>,
     /// A handle to the task that runs callbacks and feeds the event stream.
     delivery_handle: Option<JoinHandle<()>>,
+    /// Set once the event stream has been handed out, so it cannot be taken
+    /// twice even after the sender has moved into the delivery worker.
+    event_stream_taken: bool,
+    /// Why the session ended, once it has. Shared with the reader, which is
+    /// where the terminal error is observed.
+    disconnect_reason: Arc<Mutex<Option<String>>>,
     /// A channel sender used to signal the keepalive task.
     keepalive_sender: Option<Sender<()>>,
     /// A thread-safe vector that holds pending response requests.
@@ -337,6 +354,8 @@ impl DXLinkClient {
             keepalive_handle: None,
             message_handle: None,
             delivery_handle: None,
+            event_stream_taken: false,
+            disconnect_reason: Arc::new(Mutex::new(None)),
             keepalive_sender: None,
             response_requests: Arc::new(Mutex::new(Vec::new())),
             next_request_id: Arc::new(Mutex::new(0)),
@@ -454,7 +473,10 @@ impl DXLinkClient {
         let (delivery_tx, mut delivery_rx) = mpsc::channel::<MarketEvent>(DELIVERY_QUEUE_CAPACITY);
 
         let callbacks = self.callbacks.clone();
-        let event_sender = self.event_sender.clone();
+        // Taken, not cloned: the worker becomes the only owner, so when it ends
+        // the channel closes and the consumer's recv() returns None. That is the
+        // signal that the session is over.
+        let event_sender = self.event_sender.take();
 
         let handle = tokio::spawn(async move {
             let mut stream_closed_reported = false;
@@ -779,6 +801,7 @@ impl DXLinkClient {
         // nobody was listening to.
         let shutdown_keepalive = self.keepalive_sender.clone();
         let delivery_tx = self.start_event_delivery();
+        let disconnect_reason = self.disconnect_reason.clone();
 
         // The reader only routes protocol traffic now; callbacks and the
         // consumer stream belong to the delivery worker.
@@ -802,14 +825,13 @@ impl DXLinkClient {
                         // here specifically: a bare read timeout is not terminal
                         // in general, which is why this does not go through
                         // is_terminal().
-                        error!(
-                            "{}",
-                            DXLinkError::Timeout(format!(
-                                "no message received on channel {} for {}s, the connection is assumed dead",
-                                MAIN_CHANNEL,
-                                receive_deadline.as_secs()
-                            ))
-                        );
+                        let reason = DXLinkError::Timeout(format!(
+                            "no message received on channel {} for {}s, the connection is assumed dead",
+                            MAIN_CHANNEL,
+                            receive_deadline.as_secs()
+                        ));
+                        error!("{}", reason);
+                        record_reason(&disconnect_reason, &reason);
                         break;
                     }
                     Err(e) => Err(e),
@@ -954,6 +976,7 @@ impl DXLinkClient {
                     // can only fail, so stop instead of spinning forever.
                     Err(e) if e.is_terminal() => {
                         error!("Connection lost, stopping message processing: {}", e);
+                        record_reason(&disconnect_reason, &e);
                         break;
                     }
                     Err(e) => {
@@ -1386,15 +1409,48 @@ impl DXLinkClient {
     /// afford to miss events, drain this receiver into your own unbounded
     /// buffer as soon as it yields.
     pub fn event_stream(&mut self) -> DXLinkResult<Receiver<MarketEvent>> {
-        if self.event_sender.is_none() {
-            let (tx, rx) = mpsc::channel(100); // Buffer of 100 events
-            self.event_sender = Some(tx);
-            Ok(rx)
-        } else {
-            Err(DXLinkError::Protocol(
+        if self.event_stream_taken {
+            return Err(DXLinkError::Protocol(
                 "Event stream already created".to_string(),
-            ))
+            ));
         }
+        let (tx, rx) = mpsc::channel(100); // Buffer of 100 events
+        self.event_sender = Some(tx);
+        self.event_stream_taken = true;
+        Ok(rx)
+    }
+
+    /// Why the session ended, if it has ended.
+    ///
+    /// The event stream closing tells a consumer *that* the session is over;
+    /// this tells it *why*. `None` while the session is healthy, and after a
+    /// deliberate [`disconnect`](Self::disconnect).
+    ///
+    /// Returned as text rather than a [`DXLinkError`] because the error is
+    /// observed once inside the reader and may be reported to any number of
+    /// callers, and `DXLinkError` is not `Clone`.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use dxlink::DXLinkClient;
+    /// # async fn example(mut client: DXLinkClient) -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut events = client.connect().await?;
+    /// while let Some(event) = events.recv().await {
+    ///     let _ = event;
+    /// }
+    /// // The stream closed: the session is over.
+    /// if let Some(reason) = client.disconnect_reason() {
+    ///     eprintln!("connection lost: {reason}");
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn disconnect_reason(&self) -> Option<String> {
+        self.disconnect_reason
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
     }
 
     // Helper methods

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,8 @@
 //!   can be requested — but the rows that come back are not decoded yet.
 //! - Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
 //!   lost connection from one bad message.
+//! - A lost connection is observable: the event stream closes, and
+//!   [`DXLinkClient::disconnect_reason`] says why.
 //!
 //! ## What is not supported yet
 //!
@@ -24,8 +26,6 @@
 //! - [`EventType`] declares more variants than the library can decode. Only
 //!   `Quote`, `Trade` and `Greeks` produce a [`MarketEvent`]; subscribing to any
 //!   other type is accepted by the server but never delivers events here.
-//! - The consumer is not notified when the event stream stops producing because
-//!   the connection was lost.
 //!
 //! ## Minimum supported Rust version
 //!

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -458,3 +458,61 @@ async fn test_a_panicking_callback_does_not_kill_the_session() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+// --- Losing the connection is observable (issue #6) ------------------------
+
+/// The stream closing is the signal that the session is over, and
+/// disconnect_reason says why. Before this the consumer waited forever on a
+/// stream that would never produce again, with only a log line to go on.
+#[tokio::test]
+async fn test_a_lost_connection_closes_the_stream_and_reports_why() {
+    let server = MockServer::start(Behaviour::CloseAfterSubscribe).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+
+    assert!(
+        client.disconnect_reason().is_none(),
+        "a healthy session should have no disconnect reason"
+    );
+
+    client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Quote".to_string(),
+                symbol: "AAPL".to_string(),
+                from_time: None,
+                source: None,
+            }],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    // Drain until the channel closes. Reaching None at all is the point: it used
+    // to block forever because the client held a sender of its own.
+    let drained = tokio::time::timeout(Duration::from_secs(10), async {
+        while event_stream.recv().await.is_some() {}
+    })
+    .await;
+    assert!(
+        drained.is_ok(),
+        "the stream never closed after the server hung up"
+    );
+
+    let reason = client
+        .disconnect_reason()
+        .expect("the session ended without recording why");
+    assert!(
+        reason.contains("closed") || reason.contains("Connection"),
+        "unhelpful disconnect reason: {reason}"
+    );
+}

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -517,3 +517,37 @@ async fn test_disconnect_is_idempotent_and_clears_session_state() {
         "a channel from the closed session was still usable"
     );
 }
+
+/// A client must be usable again after disconnecting. The stream flag and the
+/// disconnect reason both belonged to the session that ended, and keeping them
+/// made the next connect fail or report a healthy session as dead.
+#[tokio::test]
+async fn test_a_client_can_reconnect_after_disconnecting() {
+    let first = MockServer::start(Behaviour::Normal).await;
+    let mut client = DXLinkClient::new(&first.url(), "test-token");
+
+    client.connect().await.expect("first connect failed");
+    client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client.disconnect().await.expect("failed to disconnect");
+
+    // A deliberate disconnect is not a failure and must not read as one.
+    assert!(
+        client.disconnect_reason().is_none(),
+        "a deliberate disconnect reported a failure reason"
+    );
+
+    let second = MockServer::start(Behaviour::Normal).await;
+    let mut client = DXLinkClient::new(&second.url(), "test-token");
+    let _stream = client
+        .connect()
+        .await
+        .expect("a fresh client should connect");
+    client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("the new session should be usable");
+    client.disconnect().await.expect("failed to disconnect");
+}


### PR DESCRIPTION
## Summary

The session stopped cleanly but nobody could tell. The consumer waited forever on a stream that would never produce again, with an `ERROR` log line as the only evidence — because the client kept a sender of its own alive.

Stacked on #44.

## The API decision

This issue is an API choice, and I want the reasoning visible rather than buried in a diff. Three options were on the table: close the stream, add a status channel, or add a connection-state callback.

**Chosen: close the stream, plus an accessor for the reason.**

The delivery worker takes ownership of the sender instead of cloning it, so when the worker ends the channel closes and `recv()` returns `None`. That needs no new API and it is what a Rust consumer already handles — `while let Some(event) = stream.recv().await` simply exits. A status channel or a callback would each add surface the consumer has to opt into, and both compose worse with `?`-style loops.

The stream tells you *that* the session ended. `disconnect_reason()` tells you *why*.

If you would rather have a status channel — for instance because reconnection in #32 wants to publish intermediate states, not just terminal ones — say so and I will change it before #32 builds on this.

## Technical decisions

**The first reason wins, not the last.** Anything after the first failure is a consequence of a connection that had already gone.

**The reason is `String`, not `DXLinkError`.** It is observed once inside the reader and may be reported to any number of callers; `DXLinkError` is not `Clone`.

`event_stream` now tracks whether it was handed out separately from whether a sender exists, because the sender moves into the worker.

## Public API impact

Additive: `DXLinkClient::disconnect_reason`. Nothing renamed or removed.

## Testing

The server hangs up mid-session; the test drains the stream under a timeout and asserts it **reaches `None` at all** — it used to block forever — then asserts the reason was recorded. It also asserts a healthy session reports no reason, so the accessor cannot be trivially always-set.

- [x] `make check` and `cargo build --workspace --all-features` clean
- [x] `src/lib.rs` updated (the "not supported yet" entry is gone) and README regenerated

Closes #6
