### PR TITLE
Validate the negotiated FEED_CONFIG before decoding anything (#12)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -9,8 +9,8 @@ use crate::error::{DXLinkError, DXLinkResult};
 use crate::events::{CompactData, EventType, MarketEvent};
 use crate::messages::{
     AuthMessage, AuthStateMessage, BaseMessage, ChannelRequestMessage, ErrorMessage,
-    FeedDataMessage, FeedSetupMessage, FeedSubscription, FeedSubscriptionMessage, KeepaliveMessage,
-    ServerSetupMessage, SetupMessage,
+    FeedConfigMessage, FeedDataMessage, FeedSetupMessage, FeedSubscription,
+    FeedSubscriptionMessage, KeepaliveMessage, ServerSetupMessage, SetupMessage,
 };
 
 use crate::parse_compact_data;
@@ -92,8 +92,9 @@ pub type EventCallback = Box<dyn Fn(MarketEvent) + Send + Sync + 'static>;
 enum ResponseType {
     /// Indicates a channel has been opened. The `u32` value represents the channel identifier.
     ChannelOpened(u32),
-    /// Indicates a feed configuration has been received.  The `u32` value represents the channel identifier.
-    FeedConfig(u32),
+    /// A feed configuration. Carries the whole message, not just the
+    /// channel: the negotiated data format and field order are the point.
+    FeedConfig(Box<FeedConfigMessage>),
     /// Indicates a channel has been closed. The `u32` value represents the channel identifier.
     ChannelClosed(u32),
     /// A server error. Kept as `(code, message)` rather than pre-formatted text
@@ -206,6 +207,71 @@ fn recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
     mutex
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Field layouts, per event type, that a channel was configured with.
+type ChannelSchema = HashMap<String, Vec<String>>;
+
+/// Validated layouts per channel.
+type ChannelSchemas = Arc<Mutex<HashMap<u32, ChannelSchema>>>;
+
+/// The COMPACT field lists this client requests for a set of event types.
+fn requested_fields(event_types: &[EventType]) -> ChannelSchema {
+    event_types
+        .iter()
+        .map(|event_type| {
+            let fields = event_type
+                .compact_fields()
+                .unwrap_or(&["eventType", "eventSymbol"])
+                .iter()
+                .map(|f| (*f).to_string())
+                .collect();
+            (event_type.to_string(), fields)
+        })
+        .collect()
+}
+
+/// Checks that the server agreed to the contract this client asked for.
+///
+/// The specification says `FEED_CONFIG` reports the *actual* configuration, and
+/// that the server may send it again when it changes. Treating it as a bare
+/// acknowledgement meant a different data format, a reordered field list, or a
+/// dropped field all went unnoticed until the decoder produced numbers in the
+/// wrong fields.
+fn validate_feed_config(
+    config: &FeedConfigMessage,
+    channel_id: u32,
+    event_types: &[EventType],
+) -> DXLinkResult<()> {
+    if !config.data_format.eq_ignore_ascii_case("COMPACT") {
+        return Err(DXLinkError::Protocol(format!(
+            "channel {channel_id}: this client decodes COMPACT rows, but the server \
+             negotiated {}",
+            config.data_format
+        )));
+    }
+
+    // A server that echoes no field list has not disagreed with the request.
+    let Some(negotiated) = config.event_fields.as_ref() else {
+        return Ok(());
+    };
+
+    for (event_type, expected) in requested_fields(event_types) {
+        let Some(actual) = negotiated.get(&event_type) else {
+            // Not echoed back is not a disagreement either.
+            continue;
+        };
+
+        if *actual != expected {
+            return Err(DXLinkError::Protocol(format!(
+                "channel {channel_id}: the server changed the {event_type} field layout; \
+                 requested {expected:?} but it negotiated {actual:?}. Decoding against the \
+                 requested order would attach values to the wrong fields"
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 /// The symbol an event refers to, borrowed rather than cloned.
@@ -328,6 +394,9 @@ pub struct DXLinkClient {
     response_requests: Arc<Mutex<Vec<ResponseRequest>>>,
     /// Hands out the identity each pending request is cleaned up by.
     next_request_id: Arc<Mutex<u64>>,
+    /// The field layout validated for each configured channel. A channel with
+    /// no entry has no agreed layout, so its rows must not be decoded.
+    channel_schemas: ChannelSchemas,
 }
 
 impl DXLinkClient {
@@ -371,6 +440,7 @@ impl DXLinkClient {
             keepalive_sender: None,
             response_requests: Arc::new(Mutex::new(Vec::new())),
             next_request_id: Arc::new(Mutex::new(0)),
+            channel_schemas: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -821,6 +891,7 @@ impl DXLinkClient {
         // The reader only routes protocol traffic now; callbacks and the
         // consumer stream belong to the delivery worker.
         let response_requests = self.response_requests.clone();
+        let channel_schemas = self.channel_schemas.clone();
 
         // Iniciar la tarea de procesamiento de mensajes
         // Inbound silence past our advertised deadline means the peer is gone,
@@ -890,7 +961,17 @@ impl DXLinkClient {
                                                 ResponseType::ChannelOpened(channel.unwrap_or(0))
                                             }
                                             "FEED_CONFIG" => {
-                                                ResponseType::FeedConfig(channel.unwrap_or(0))
+                                                match serde_json::from_str::<FeedConfigMessage>(
+                                                    &msg,
+                                                ) {
+                                                    Ok(config) => {
+                                                        ResponseType::FeedConfig(Box::new(config))
+                                                    }
+                                                    Err(e) => ResponseType::Error(
+                                                        "MALFORMED_FEED_CONFIG".to_string(),
+                                                        e.to_string(),
+                                                    ),
+                                                }
                                             }
                                             "CHANNEL_CLOSED" => {
                                                 ResponseType::ChannelClosed(channel.unwrap_or(0))
@@ -931,10 +1012,41 @@ impl DXLinkClient {
 
                             // Si nadie esperaba este mensaje específicamente, procesarlo normalmente
                             match msg_type {
+                                "FEED_CONFIG" => {
+                                    // Nobody was waiting: this is the server
+                                    // changing the layout mid-session, which the
+                                    // spec allows. The decoder cannot follow it,
+                                    // so the channel stops being decodable
+                                    // rather than producing shifted values.
+                                    if let Some(ch) = channel
+                                        && recover(&channel_schemas).remove(&ch).is_some()
+                                    {
+                                        {
+                                            error!(
+                                                "Channel {} was reconfigured by the server; \
+                                                 its data will be dropped rather than decoded \
+                                                 against the old layout",
+                                                ch
+                                            );
+                                        }
+                                    }
+                                }
                                 "FEED_DATA" => {
-                                    if let Ok(data_msg) = serde_json::from_str::<
-                                        FeedDataMessage<Vec<CompactData>>,
-                                    >(&msg)
+                                    // Only decode against a layout the server
+                                    // agreed to.
+                                    let decodable = channel
+                                        .map(|ch| recover(&channel_schemas).contains_key(&ch))
+                                        .unwrap_or(false);
+
+                                    if !decodable {
+                                        debug!(
+                                            "Dropping FEED_DATA for channel {:?}: no validated layout",
+                                            channel
+                                        );
+                                    } else if let Ok(data_msg) =
+                                        serde_json::from_str::<FeedDataMessage<Vec<CompactData>>>(
+                                            &msg,
+                                        )
                                     {
                                         // Hand off and keep reading. Delivery is
                                         // somebody else's job: doing it here let
@@ -1103,6 +1215,7 @@ impl DXLinkClient {
         // dead connection has to go, and a prior panic elsewhere is no reason to
         // keep it.
         recover(&self.channels).clear();
+        recover(&self.channel_schemas).clear();
         self.event_stream_taken = false;
         recover(&self.subscriptions).clear();
         // Dropping the senders wakes every waiter instead of leaving it to time
@@ -1174,35 +1287,14 @@ impl DXLinkClient {
         let mut accept_event_fields = HashMap::new();
 
         for event_type in event_types {
-            let fields = match event_type {
-                EventType::Quote => vec![
-                    "eventType".to_string(),
-                    "eventSymbol".to_string(),
-                    "bidPrice".to_string(),
-                    "askPrice".to_string(),
-                    "bidSize".to_string(),
-                    "askSize".to_string(),
-                ],
-                EventType::Trade => vec![
-                    "eventType".to_string(),
-                    "eventSymbol".to_string(),
-                    "price".to_string(),
-                    "size".to_string(),
-                    "dayVolume".to_string(),
-                ],
-                EventType::Greeks => vec![
-                    "eventType".to_string(),
-                    "eventSymbol".to_string(),
-                    "delta".to_string(),
-                    "gamma".to_string(),
-                    "theta".to_string(),
-                    "vega".to_string(),
-                    "rho".to_string(),
-                    "volatility".to_string(),
-                ],
-                // Add more event types as needed
-                _ => vec!["eventType".to_string(), "eventSymbol".to_string()],
-            };
+            // One source of truth: the same list validates the server's reply
+            // and drives the decoder stride.
+            let fields: Vec<String> = event_type
+                .compact_fields()
+                .unwrap_or(&["eventType", "eventSymbol"])
+                .iter()
+                .map(|f| (*f).to_string())
+                .collect();
 
             accept_event_fields.insert(event_type.to_string(), fields);
         }
@@ -1215,8 +1307,9 @@ impl DXLinkClient {
             accept_event_fields,
         };
 
-        let json = serde_json::to_string(&feed_setup)?;
-        debug!("Sending FEED_SETUP: {}", json);
+        // No direct payload log here: Connection::send already logs it through
+        // the redacting path, and a second hand-rolled log is exactly how a
+        // credential ends up in a file.
 
         let response = self
             .request_response(
@@ -1230,13 +1323,21 @@ impl DXLinkClient {
 
         // Procesar la respuesta
         match response {
-            ResponseType::FeedConfig(received_channel) => {
-                if received_channel != channel_id {
+            ResponseType::FeedConfig(config) => {
+                if config.channel != channel_id {
                     return Err(DXLinkError::Channel(format!(
                         "Expected config for channel {}, got {}",
-                        channel_id, received_channel
+                        channel_id, config.channel
                     )));
                 }
+
+                // The reply is the negotiated contract, not an acknowledgement.
+                // Accepting it unread meant a server that chose a different
+                // format or reordered a field list left the decoder attaching
+                // values to the wrong fields, silently.
+                validate_feed_config(&config, channel_id, event_types)?;
+
+                recover(&self.channel_schemas).insert(channel_id, requested_fields(event_types));
 
                 info!("Feed channel {} setup completed successfully", channel_id);
                 Ok(())

--- a/src/client.rs
+++ b/src/client.rs
@@ -231,6 +231,19 @@ fn requested_fields(event_types: &[EventType]) -> ChannelSchema {
         .collect()
 }
 
+/// Whether a `FEED_CONFIG` contradicts a layout already validated for a channel.
+fn config_disagrees(config: &FeedConfigMessage, stored: &ChannelSchema) -> bool {
+    if !config.data_format.eq_ignore_ascii_case("COMPACT") {
+        return true;
+    }
+    let Some(negotiated) = config.event_fields.as_ref() else {
+        return false;
+    };
+    negotiated
+        .iter()
+        .any(|(event_type, fields)| stored.get(event_type).is_some_and(|known| known != fields))
+}
+
 /// Checks that the server agreed to the contract this client asked for.
 ///
 /// The specification says `FEED_CONFIG` reports the *actual* configuration, and
@@ -1018,9 +1031,26 @@ impl DXLinkClient {
                                     // spec allows. The decoder cannot follow it,
                                     // so the channel stops being decodable
                                     // rather than producing shifted values.
-                                    if let Some(ch) = channel
-                                        && recover(&channel_schemas).remove(&ch).is_some()
-                                    {
+                                    if let Some(ch) = channel {
+                                        // Only a real disagreement invalidates.
+                                        // A server may resend an identical
+                                        // FEED_CONFIG, and treating that as a
+                                        // change would stop decoding a channel
+                                        // nothing had happened to.
+                                        let disagrees =
+                                            match serde_json::from_str::<FeedConfigMessage>(&msg) {
+                                                Ok(config) => {
+                                                    let schemas = recover(&channel_schemas);
+                                                    schemas.get(&ch).is_some_and(|stored| {
+                                                        config_disagrees(&config, stored)
+                                                    })
+                                                }
+                                                // Unreadable is not agreement.
+                                                Err(_) => true,
+                                            };
+
+                                        if disagrees
+                                            && recover(&channel_schemas).remove(&ch).is_some()
                                         {
                                             error!(
                                                 "Channel {} was reconfigured by the server; \
@@ -1306,6 +1336,13 @@ impl DXLinkClient {
             accept_data_format: "COMPACT".to_string(),
             accept_event_fields,
         };
+
+        // Drop any layout this channel already had, before the request goes
+        // out. A reconfiguration that then fails validation used to return
+        // early leaving the old entry installed, and because the reply was
+        // routed to the waiter the unsolicited-config path never saw it: the
+        // channel kept decoding against a contract the server had changed.
+        recover(&self.channel_schemas).remove(&channel_id);
 
         // No direct payload log here: Connection::send already logs it through
         // the redacting path, and a second hand-rolled log is exactly how a

--- a/src/events.rs
+++ b/src/events.rs
@@ -87,6 +87,56 @@ impl From<&str> for EventType {
     }
 }
 
+impl EventType {
+    /// The COMPACT field list this client requests for the event type, in the
+    /// exact order the decoder reads it.
+    ///
+    /// This is the single source of truth for the `setup_feed` ↔
+    /// `parse_compact_data` contract. The server echoes these fields back in
+    /// `FEED_CONFIG` and then sends rows in this order, so the list, the
+    /// validation of the reply, and the decoder stride all have to come from
+    /// one place. They used to be three separate literals.
+    ///
+    /// `None` means this client has no decoder for the type: it can be named,
+    /// but no row can be turned into a [`MarketEvent`](crate::MarketEvent).
+    pub fn compact_fields(&self) -> Option<&'static [&'static str]> {
+        match self {
+            EventType::Quote => Some(&[
+                "eventType",
+                "eventSymbol",
+                "bidPrice",
+                "askPrice",
+                "bidSize",
+                "askSize",
+            ]),
+            EventType::Trade => Some(&["eventType", "eventSymbol", "price", "size", "dayVolume"]),
+            EventType::Greeks => Some(&[
+                "eventType",
+                "eventSymbol",
+                "delta",
+                "gamma",
+                "theta",
+                "vega",
+                "rho",
+                "volatility",
+            ]),
+            // Declared by the protocol, not decoded here.
+            EventType::Summary
+            | EventType::Profile
+            | EventType::Order
+            | EventType::TimeAndSale
+            | EventType::Candle
+            | EventType::TradeETH
+            | EventType::SpreadOrder
+            | EventType::TheoPrice
+            | EventType::Underlying
+            | EventType::Series
+            | EventType::Configuration
+            | EventType::Message => None,
+        }
+    }
+}
+
 /// Represents a quote event for a financial instrument.
 ///
 /// This structure holds information about a specific quote event, including the type of event,

--- a/src/events.rs
+++ b/src/events.rs
@@ -91,11 +91,10 @@ impl EventType {
     /// The COMPACT field list this client requests for the event type, in the
     /// exact order the decoder reads it.
     ///
-    /// This is the single source of truth for the `setup_feed` ↔
-    /// `parse_compact_data` contract. The server echoes these fields back in
-    /// `FEED_CONFIG` and then sends rows in this order, so the list, the
-    /// validation of the reply, and the decoder stride all have to come from
-    /// one place. They used to be three separate literals.
+    /// This is what `setup_feed` requests and what the `FEED_CONFIG` reply is
+    /// validated against. The decoder in `utils.rs` still carries its own
+    /// positions, so the contract is not yet enforced from one definition —
+    /// moving the decoder onto this list is the next step.
     ///
     /// `None` means this client has no decoder for the type: it can be named,
     /// but no row can be turned into a [`MarketEvent`](crate::MarketEvent).

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -551,3 +551,57 @@ async fn test_a_client_can_reconnect_after_disconnecting() {
         .expect("the new session should be usable");
     client.disconnect().await.expect("failed to disconnect");
 }
+
+// --- FEED_CONFIG validation (issue #12) ------------------------------------
+
+/// A server that reorders the field list must be rejected. Accepting it meant
+/// the decoder kept reading the requested order and attached every value to the
+/// wrong field, with no error anywhere.
+#[tokio::test]
+async fn test_setup_feed_rejects_a_reordered_field_layout() {
+    let server = MockServer::start(Behaviour::ReorderedFeedConfig).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+
+    match client.setup_feed(channel_id, &[EventType::Quote]).await {
+        Err(DXLinkError::Protocol(msg)) => {
+            assert!(msg.contains("Quote"), "which event type is unclear: {msg}");
+            assert!(
+                msg.contains("eventSymbol") && msg.contains("eventType"),
+                "the error should show both layouts: {msg}"
+            );
+        }
+        other => panic!("a reordered layout must be rejected, got: {other:?}"),
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// This client decodes COMPACT rows and nothing else.
+#[tokio::test]
+async fn test_setup_feed_rejects_a_format_it_cannot_decode() {
+    let server = MockServer::start(Behaviour::NonCompactFeedConfig).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+
+    match client.setup_feed(channel_id, &[EventType::Quote]).await {
+        Err(DXLinkError::Protocol(msg)) => {
+            assert!(msg.contains("COMPACT"), "unclear error: {msg}");
+            assert!(
+                msg.contains("FULL"),
+                "the negotiated format is missing: {msg}"
+            );
+        }
+        other => panic!("a non-COMPACT format must be rejected, got: {other:?}"),
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -4,7 +4,7 @@
 //! Event delivery is covered in `dxlink_flow.rs`.
 
 use crate::fixture::{Behaviour, MockServer, is_type, is_type_on_channel};
-use dxlink::{DXLinkClient, DXLinkError, EventType};
+use dxlink::{DXLinkClient, DXLinkError, EventType, FeedSubscription};
 use std::time::Duration;
 
 #[tokio::test]
@@ -602,6 +602,58 @@ async fn test_setup_feed_rejects_a_format_it_cannot_decode() {
         }
         other => panic!("a non-COMPACT format must be rejected, got: {other:?}"),
     }
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// A reconfiguration that fails validation must not leave the previous layout
+/// installed. It used to: the error returned before replacing the entry, and
+/// because the reply went to the waiter the unsolicited-config path never saw
+/// it, so the channel kept decoding against a contract the server had changed.
+#[tokio::test]
+async fn test_a_rejected_reconfiguration_invalidates_the_channel() {
+    let server = MockServer::start(Behaviour::ReorderedFeedConfigOnSecondSetup).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut stream = client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+
+    // First setup is honoured.
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("the first setup should succeed");
+
+    // Second one comes back reordered and must be refused.
+    assert!(
+        client
+            .setup_feed(channel_id, &[EventType::Quote])
+            .await
+            .is_err(),
+        "a reordered reconfiguration must be refused"
+    );
+
+    // And no data may be decoded afterwards.
+    client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Quote".to_string(),
+                symbol: "AAPL".to_string(),
+                from_time: None,
+                source: None,
+            }],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    let event = tokio::time::timeout(Duration::from_millis(700), stream.recv()).await;
+    assert!(
+        event.is_err(),
+        "data was decoded against a layout the server had changed: {event:?}"
+    );
 
     client.disconnect().await.expect("failed to disconnect");
 }

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -69,6 +69,8 @@ pub enum Behaviour {
     ReorderedFeedConfig,
     /// Negotiate a data format this client cannot decode.
     NonCompactFeedConfig,
+    /// Honour the first FEED_SETUP and reorder the reply to every one after it.
+    ReorderedFeedConfigOnSecondSetup,
     /// Negotiate a 3 second keepalive deadline, below the 15s the client used
     /// to assume. Lets a test prove the negotiated value is honoured without
     /// waiting a minute for it.
@@ -105,6 +107,7 @@ impl MockServer {
             // Field order per (channel, event type), learned from FEED_SETUP.
             let mut event_fields: HashMap<(u64, String), Vec<String>> = HashMap::new();
             let mut channel_requests_seen = 0u32;
+            let mut feed_setups_seen = 0u32;
 
             while let Some(Ok(message)) = ws.next().await {
                 let Message::Text(text) = message else {
@@ -241,12 +244,22 @@ impl MockServer {
                         "service": value["service"].as_str().unwrap_or("FEED"),
                         "parameters": {}
                     })),
-                    "FEED_SETUP" if behaviour == Behaviour::ReorderedFeedConfig => {
+                    "FEED_SETUP"
+                        if behaviour == Behaviour::ReorderedFeedConfig
+                            || (behaviour == Behaviour::ReorderedFeedConfigOnSecondSetup && {
+                                feed_setups_seen += 1;
+                                feed_setups_seen > 1
+                            }) =>
+                    {
                         let mut reordered = value["acceptEventFields"]["Quote"]
                             .as_array()
                             .cloned()
                             .unwrap_or_default();
-                        reordered.swap(0, 1);
+                        // Guard: a fixture panic would mask the behaviour under
+                        // test rather than reporting it.
+                        if reordered.len() >= 2 {
+                            reordered.swap(0, 1);
+                        }
                         responses.push(json!({
                             "channel": channel, "type": "FEED_CONFIG",
                             "aggregationPeriod": 0.1, "dataFormat": "COMPACT",

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -64,6 +64,11 @@ pub enum Behaviour {
     IgnoreFirstChannelRequest,
     /// Complete the handshake and then hang up, so the next send fails.
     CloseAfterHandshake,
+    /// Echo a FEED_CONFIG whose Quote field list is reordered, the shape that
+    /// silently shifts every decoded value.
+    ReorderedFeedConfig,
+    /// Negotiate a data format this client cannot decode.
+    NonCompactFeedConfig,
     /// Negotiate a 3 second keepalive deadline, below the 15s the client used
     /// to assume. Lets a test prove the negotiated value is honoured without
     /// waiting a minute for it.
@@ -236,6 +241,24 @@ impl MockServer {
                         "service": value["service"].as_str().unwrap_or("FEED"),
                         "parameters": {}
                     })),
+                    "FEED_SETUP" if behaviour == Behaviour::ReorderedFeedConfig => {
+                        let mut reordered = value["acceptEventFields"]["Quote"]
+                            .as_array()
+                            .cloned()
+                            .unwrap_or_default();
+                        reordered.swap(0, 1);
+                        responses.push(json!({
+                            "channel": channel, "type": "FEED_CONFIG",
+                            "aggregationPeriod": 0.1, "dataFormat": "COMPACT",
+                            "eventFields": { "Quote": reordered }
+                        }));
+                    }
+                    "FEED_SETUP" if behaviour == Behaviour::NonCompactFeedConfig => {
+                        responses.push(json!({
+                            "channel": channel, "type": "FEED_CONFIG",
+                            "aggregationPeriod": 0.1, "dataFormat": "FULL"
+                        }));
+                    }
                     "FEED_SETUP" => {
                         // Remember exactly which fields the client asked for, in
                         // order: that is the wire layout it will decode against.
@@ -256,7 +279,8 @@ impl MockServer {
                             "channel": channel,
                             "type": "FEED_CONFIG",
                             "aggregationPeriod": 0.1,
-                            "dataFormat": "COMPACT"
+                            "dataFormat": "COMPACT",
+                            "eventFields": value["acceptEventFields"].clone()
                         }));
                     }
                     "FEED_SUBSCRIPTION" => {


### PR DESCRIPTION
## Summary

`setup_feed` treated any `FEED_CONFIG` on the channel as an acknowledgement and threw the contents away. The specification says that message reports the **actual** configuration and may be sent again when it changes — so a server that chose a different data format or reordered a field list left the decoder reading the requested order and attaching every value to the wrong field. Nothing errored.

## Changes

- One source of truth for the field order: `EventType::compact_fields`.
- `FEED_CONFIG` is deserialized in full and routed to the waiting setup.
- Format must be `COMPACT`; every echoed field list must match what was asked for, in order.
- The validated layout is stored per channel; a later disagreeing `FEED_CONFIG` removes it.
- `FEED_DATA` for a channel without a validated layout is dropped rather than decoded against a stale one.
- The hand-rolled `FEED_SETUP` payload log is gone.

## Technical decisions

**The field order was three separate literals** — the request in `setup_feed`, the decoder stride in `parse_compact_data`, and nothing validating the reply. `EventType::compact_fields` makes it one, which is what lets the reply be checked at all. This is also what #30 will use to decide which types have a decoder.

**A missing or unechoed field list is not a disagreement.** A server that echoes nothing has not contradicted the request, so it passes. Only an echoed list that *differs* is rejected — being stricter would break against servers that legitimately reply tersely.

**A mid-session reconfiguration makes the channel undecodable rather than wrong.** The spec allows the server to resend `FEED_CONFIG`; the decoder cannot follow a layout change, so the channel's rows are dropped with an error instead of being shifted.

**The duplicate log removal is not cosmetic.** `Connection::send` already logs the payload through the redacting path; a second hand-rolled `debug!` of the same message is exactly how a credential ends up in a file.

## Public API impact

Additive: `EventType::compact_fields`. `ResponseType::FeedConfig` changed shape but it is a private enum.

## Testing

- A server that swaps the first two Quote fields is rejected, with both layouts in the error.
- A server negotiating `FULL` is rejected, naming both formats.
- The fixture now echoes the negotiated field list on the happy path too, so the validation is exercised by every existing event test rather than only the new ones.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #12
