### PR TITLE
Decode COMPACT rows strictly and report what fails (#14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ to DXLink servers, subscribing to market events, and processing real-time market
   can be requested — but the rows that come back are not decoded yet.
 - Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
   lost connection from one bad message.
+- Strict decoding: [`try_parse_compact_data`] reports a short row, a wrong
+  column type or an unknown event type instead of returning fewer events and
+  letting a consumer read that as a quiet market.
 - A lost connection is observable: the event stream closes, and
   [`DXLinkClient::disconnect_reason`] says why.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,8 +12,8 @@ use crate::messages::{
     FeedConfigMessage, FeedDataMessage, FeedSetupMessage, FeedSubscription,
     FeedSubscriptionMessage, KeepaliveMessage, ServerSetupMessage, SetupMessage,
 };
+use crate::try_parse_compact_data;
 
-use crate::parse_compact_data;
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::sync::{Arc, Mutex};
@@ -1083,7 +1083,18 @@ impl DXLinkClient {
                                         // one slow callback or a full consumer
                                         // stream stop the socket reads that every
                                         // channel operation depends on.
-                                        for event in parse_compact_data(&data_msg.data) {
+                                        let decoded = match try_parse_compact_data(&data_msg.data) {
+                                            Ok(events) => events,
+                                            Err(e) => {
+                                                // Report it rather than
+                                                // delivering a partial batch
+                                                // that looks complete.
+                                                error!("Malformed COMPACT data: {e}");
+                                                continue;
+                                            }
+                                        };
+
+                                        for event in decoded {
                                             match delivery_tx.try_send(event) {
                                                 Ok(()) => {}
                                                 Err(mpsc::error::TrySendError::Full(_)) => {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1089,7 +1089,10 @@ impl DXLinkClient {
                                                 // Report it rather than
                                                 // delivering a partial batch
                                                 // that looks complete.
-                                                error!("Malformed COMPACT data: {e}");
+                                                error!(
+                                                    "Malformed COMPACT data on channel {:?}: {e}",
+                                                    channel
+                                                );
                                                 continue;
                                             }
                                         };

--- a/src/events.rs
+++ b/src/events.rs
@@ -88,6 +88,33 @@ impl From<&str> for EventType {
 }
 
 impl EventType {
+    /// Parses a wire name, answering `None` for anything unknown.
+    ///
+    /// Unlike the [`From<&str>`] impl, which answers `Quote` for any
+    /// unrecognised name, this reports that it does not know it. A decoder
+    /// cannot use the lenient conversion: silently treating an unknown type as
+    /// `Quote` means reading its row with the wrong layout.
+    pub fn from_wire_name(value: &str) -> Option<Self> {
+        match value {
+            "Quote" => Some(EventType::Quote),
+            "Trade" => Some(EventType::Trade),
+            "Summary" => Some(EventType::Summary),
+            "Profile" => Some(EventType::Profile),
+            "Order" => Some(EventType::Order),
+            "TimeAndSale" => Some(EventType::TimeAndSale),
+            "Candle" => Some(EventType::Candle),
+            "TradeETH" => Some(EventType::TradeETH),
+            "SpreadOrder" => Some(EventType::SpreadOrder),
+            "Greeks" => Some(EventType::Greeks),
+            "TheoPrice" => Some(EventType::TheoPrice),
+            "Underlying" => Some(EventType::Underlying),
+            "Series" => Some(EventType::Series),
+            "Configuration" => Some(EventType::Configuration),
+            "Message" => Some(EventType::Message),
+            _ => None,
+        }
+    }
+
     /// The COMPACT field list this client requests for the event type, in the
     /// exact order the decoder reads it.
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@
 //!   can be requested — but the rows that come back are not decoded yet.
 //! - Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
 //!   lost connection from one bad message.
+//! - Strict decoding: [`try_parse_compact_data`] reports a short row, a wrong
+//!   column type or an unknown event type instead of returning fewer events and
+//!   letting a consumer read that as a quiet market.
 //! - A lost connection is observable: the event stream closes, and
 //!   [`DXLinkClient::disconnect_reason`] says why.
 //!
@@ -366,4 +369,4 @@ pub use client::DXLinkClient;
 pub use error::DXLinkError;
 pub use events::{EventType, MarketEvent};
 pub use messages::FeedSubscription;
-pub use utils::parse_compact_data;
+pub use utils::{parse_compact_data, try_parse_compact_data};

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,26 +9,12 @@ use crate::events::{CompactData, EventType, GreeksEvent, QuoteEvent, TradeEvent}
 use serde_json::Value;
 use tracing::warn;
 
-/// Parses a vector of `CompactData` and returns a vector of `MarketEvent`s.
+/// Decodes COMPACT rows, dropping the whole batch if any of it is malformed.
 ///
-/// The function iterates through the `data` vector, expecting pairs of `CompactData`
-/// elements. The first element of the pair should be a `CompactData::EventType`
-/// containing the event type as a string. The second element should be a
-/// `CompactData::Values` containing a vector of `serde_json::Value`s representing
-/// the event data.
-///
-/// The function supports three event types: "Quote", "Trade", and "Greeks".  For each
-/// recognized event type, it attempts to parse the corresponding data values and
-/// create a `MarketEvent` variant. If the data for an event is incomplete or in an
-/// unexpected format, the event is skipped.
-///
-/// # Arguments
-///
-/// * `data` - A slice of `CompactData` to parse.
-///
-/// # Returns
-///
-/// A vector of `MarketEvent`s successfully parsed from the input data.
+/// **Lossy on purpose, and kept for source compatibility.** It stops at the
+/// first thing it cannot read, logs a warning, and returns the events decoded
+/// before that point — so a consumer cannot tell corrupt protocol data from a
+/// quiet market. Use [`try_parse_compact_data`] for anything that needs to know.
 ///
 /// # Example
 ///
@@ -50,7 +36,6 @@ use tracing::warn;
 /// ];
 ///
 /// let events = parse_compact_data(&data);
-///
 /// assert_eq!(events.len(), 1);
 ///
 /// if let MarketEvent::Quote(quote) = &events[0] {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,10 @@
    Date: 8/3/25
 ******************************************************************************/
 use crate::MarketEvent;
-use crate::events::{CompactData, GreeksEvent, QuoteEvent, TradeEvent};
+use crate::error::{DXLinkError, DXLinkResult};
+use crate::events::{CompactData, EventType, GreeksEvent, QuoteEvent, TradeEvent};
+use serde_json::Value;
+use tracing::warn;
 
 /// Parses a vector of `CompactData` and returns a vector of `MarketEvent`s.
 ///
@@ -56,118 +59,239 @@ use crate::events::{CompactData, GreeksEvent, QuoteEvent, TradeEvent};
 /// }
 /// ```
 pub fn parse_compact_data(data: &[CompactData]) -> Vec<MarketEvent> {
-    let mut events = Vec::new();
-    let mut i = 0;
+    let (events, error) = decode(data);
+    if let Some(error) = error {
+        warn!("Dropping malformed COMPACT data: {error}");
+    }
+    events
+}
 
-    while i < data.len() {
-        if let CompactData::EventType(event_type) = &data[i] {
-            i += 1;
-            if i < data.len()
-                && let CompactData::Values(values) = &data[i]
-            {
-                match event_type.as_str() {
-                    "Quote" => {
-                        let mut j = 0;
-                        while j + 5 < values.len() {
-                            if let (
-                                Some(_), // event_type
-                                Some(symbol),
-                                Some(bid_price),
-                                Some(ask_price),
-                                Some(bid_size),
-                                Some(ask_size),
-                            ) = (
-                                values.get(j).and_then(|v| v.as_str()),
-                                values.get(j + 1).and_then(|v| v.as_str()),
-                                values.get(j + 2).and_then(|v| v.as_f64()),
-                                values.get(j + 3).and_then(|v| v.as_f64()),
-                                values.get(j + 4).and_then(|v| v.as_f64()),
-                                values.get(j + 5).and_then(|v| v.as_f64()),
-                            ) {
-                                events.push(MarketEvent::Quote(QuoteEvent {
-                                    event_type: "Quote".to_string(),
-                                    event_symbol: symbol.to_string(),
-                                    bid_price,
-                                    ask_price,
-                                    bid_size,
-                                    ask_size,
-                                }));
-                            }
-                            j += 6;
-                        }
-                    }
-                    "Trade" => {
-                        // Parsear valores de Trade
-                        let mut j = 0;
-                        while j + 4 < values.len() {
-                            if let (
-                                Some(_), // event_type
-                                Some(symbol),
-                                Some(price),
-                                Some(size),
-                                Some(day_volume),
-                            ) = (
-                                values.get(j).and_then(|v| v.as_str()),
-                                values.get(j + 1).and_then(|v| v.as_str()),
-                                values.get(j + 2).and_then(|v| v.as_f64()),
-                                values.get(j + 3).and_then(|v| v.as_f64()),
-                                values.get(j + 4).and_then(|v| v.as_f64()),
-                            ) {
-                                events.push(MarketEvent::Trade(TradeEvent {
-                                    event_type: "Trade".to_string(),
-                                    event_symbol: symbol.to_string(),
-                                    price,
-                                    size,
-                                    day_volume,
-                                }));
-                            }
-                            j += 5;
-                        }
-                    }
-                    "Greeks" => {
-                        let mut j = 0;
-                        while j + 7 < values.len() {
-                            if let (
-                                Some(_), // event_type
-                                Some(symbol),
-                                Some(delta),
-                                Some(gamma),
-                                Some(theta),
-                                Some(vega),
-                                Some(rho),
-                                Some(volatility),
-                            ) = (
-                                values.get(j).and_then(|v| v.as_str()),
-                                values.get(j + 1).and_then(|v| v.as_str()),
-                                values.get(j + 2).and_then(|v| v.as_f64()),
-                                values.get(j + 3).and_then(|v| v.as_f64()),
-                                values.get(j + 4).and_then(|v| v.as_f64()),
-                                values.get(j + 5).and_then(|v| v.as_f64()),
-                                values.get(j + 6).and_then(|v| v.as_f64()),
-                                values.get(j + 7).and_then(|v| v.as_f64()),
-                            ) {
-                                events.push(MarketEvent::Greeks(GreeksEvent {
-                                    event_type: "Greeks".to_string(),
-                                    event_symbol: symbol.to_string(),
-                                    delta,
-                                    gamma,
-                                    theta,
-                                    vega,
-                                    rho,
-                                    volatility,
-                                }));
-                            }
-                            j += 8;
-                        }
-                    }
-                    _ => {}
-                }
+/// Decodes COMPACT rows, reporting the first thing it cannot decode.
+///
+/// Prefer this over [`parse_compact_data`], which cannot tell a consumer the
+/// difference between "no events" and "the server sent something this client
+/// does not understand". Errors name the event type, the row, the field, what
+/// was expected and what arrived.
+///
+/// # Errors
+///
+/// [`DXLinkError::Protocol`] for an unsupported event type, a row count that is
+/// not a whole number of rows, a column of the wrong type, or an inner
+/// `eventType` that disagrees with the batch header.
+///
+/// # Example
+///
+/// ```rust
+/// use dxlink::events::CompactData;
+/// use dxlink::try_parse_compact_data;
+/// use serde_json::Value;
+///
+/// let data = vec![
+///     CompactData::EventType("Quote".to_string()),
+///     CompactData::Values(vec![
+///         Value::from("Quote"),
+///         Value::from("AAPL"),
+///         Value::from(150.25),
+///         Value::from(150.35),
+///         Value::from(1000.0),
+///         Value::from(2000.0),
+///     ]),
+/// ];
+///
+/// let events = try_parse_compact_data(&data).expect("well formed");
+/// assert_eq!(events.len(), 1);
+/// ```
+pub fn try_parse_compact_data(data: &[CompactData]) -> DXLinkResult<Vec<MarketEvent>> {
+    match decode(data) {
+        (events, None) => Ok(events),
+        (_, Some(error)) => Err(error),
+    }
+}
+
+/// Reads one COMPACT column as a DXLink JSONDouble.
+///
+/// The protocol encodes non-finite doubles as the strings `"NaN"`, `"Infinity"`
+/// and `"-Infinity"`, because JSON has no literal for them. Treating those as a
+/// wrong column type would reject data the server is entitled to send: an option
+/// with no bid has a `NaN` price, which is ordinary rather than exceptional.
+fn as_json_double(value: &Value) -> Option<f64> {
+    if let Some(number) = value.as_f64() {
+        return Some(number);
+    }
+    match value.as_str()? {
+        "NaN" => Some(f64::NAN),
+        "Infinity" => Some(f64::INFINITY),
+        "-Infinity" => Some(f64::NEG_INFINITY),
+        _ => None,
+    }
+}
+
+/// A column that must be text.
+fn as_text<'a>(
+    values: &'a [Value],
+    index: usize,
+    event_type: &str,
+    row: usize,
+    field: &str,
+) -> DXLinkResult<&'a str> {
+    values[index].as_str().ok_or_else(|| {
+        DXLinkError::Protocol(format!(
+            "{event_type} row {row}: field `{field}` should be a string, got {}",
+            values[index]
+        ))
+    })
+}
+
+/// A column that must be a double.
+fn as_double(
+    values: &[Value],
+    index: usize,
+    event_type: &str,
+    row: usize,
+    field: &str,
+) -> DXLinkResult<f64> {
+    as_json_double(&values[index]).ok_or_else(|| {
+        DXLinkError::Protocol(format!(
+            "{event_type} row {row}: field `{field}` should be a number, got {}",
+            values[index]
+        ))
+    })
+}
+
+/// Decodes what it can and reports the first problem it hit.
+///
+/// The layout comes from [`EventType::compact_fields`], the same list
+/// `setup_feed` asked the server for, so the stride cannot drift away from the
+/// request the way three separate literals could.
+fn decode(data: &[CompactData]) -> (Vec<MarketEvent>, Option<DXLinkError>) {
+    let mut events = Vec::new();
+    let mut index = 0;
+
+    while index < data.len() {
+        let CompactData::EventType(header) = &data[index] else {
+            return (
+                events,
+                Some(DXLinkError::Protocol(format!(
+                    "expected an event type at position {index}, got a value array"
+                ))),
+            );
+        };
+        index += 1;
+
+        let Some(CompactData::Values(values)) = data.get(index) else {
+            return (
+                events,
+                Some(DXLinkError::Protocol(format!(
+                    "event type `{header}` at position {} has no values after it",
+                    index - 1
+                ))),
+            );
+        };
+        index += 1;
+
+        let Some(event_type) = EventType::from_wire_name(header) else {
+            return (
+                events,
+                Some(DXLinkError::Protocol(format!(
+                    "unknown event type `{header}` in COMPACT data"
+                ))),
+            );
+        };
+
+        let Some(fields) = event_type.compact_fields() else {
+            return (
+                events,
+                Some(DXLinkError::Protocol(format!(
+                    "event type `{header}` has no decoder in this client, so its rows \
+                     cannot be read"
+                ))),
+            );
+        };
+
+        let stride = fields.len();
+        if values.len() % stride != 0 {
+            return (
+                events,
+                Some(DXLinkError::Protocol(format!(
+                    "{header}: {} value(s) is not a whole number of rows of {stride} \
+                     field(s); a truncated row would shift every field that follows",
+                    values.len()
+                ))),
+            );
+        }
+
+        for (row, chunk) in values.chunks_exact(stride).enumerate() {
+            // The batch header and the row's own eventType must agree, or the
+            // row belongs to a layout other than the one being applied.
+            let inner = match as_text(chunk, 0, header, row, fields[0]) {
+                Ok(inner) => inner,
+                Err(e) => return (events, Some(e)),
+            };
+            if inner != header {
+                return (
+                    events,
+                    Some(DXLinkError::Protocol(format!(
+                        "{header} row {row}: the row says it is a `{inner}`, so it is not \
+                         laid out the way this batch claims"
+                    ))),
+                );
+            }
+
+            match build_event(event_type, chunk, header, row, fields) {
+                Ok(event) => events.push(event),
+                Err(e) => return (events, Some(e)),
             }
         }
-        i += 1;
     }
 
-    events
+    (events, None)
+}
+
+/// Builds one event from a row whose length already matches the layout.
+fn build_event(
+    event_type: EventType,
+    row_values: &[Value],
+    header: &str,
+    row: usize,
+    fields: &[&str],
+) -> DXLinkResult<MarketEvent> {
+    let symbol = as_text(row_values, 1, header, row, fields[1])?.to_string();
+    let number = |index: usize| as_double(row_values, index, header, row, fields[index]);
+
+    Ok(match event_type {
+        EventType::Quote => MarketEvent::Quote(QuoteEvent {
+            event_type: header.to_string(),
+            event_symbol: symbol,
+            bid_price: number(2)?,
+            ask_price: number(3)?,
+            bid_size: number(4)?,
+            ask_size: number(5)?,
+        }),
+        EventType::Trade => MarketEvent::Trade(TradeEvent {
+            event_type: header.to_string(),
+            event_symbol: symbol,
+            price: number(2)?,
+            size: number(3)?,
+            day_volume: number(4)?,
+        }),
+        EventType::Greeks => MarketEvent::Greeks(GreeksEvent {
+            event_type: header.to_string(),
+            event_symbol: symbol,
+            delta: number(2)?,
+            gamma: number(3)?,
+            theta: number(4)?,
+            vega: number(5)?,
+            rho: number(6)?,
+            volatility: number(7)?,
+        }),
+        // compact_fields returned Some for this type, so a missing arm here is a
+        // bug in this match rather than a protocol problem.
+        other => {
+            return Err(DXLinkError::Protocol(format!(
+                "event type `{other}` has a field layout but no decoder arm"
+            )));
+        }
+    })
 }
 
 #[cfg(test)]
@@ -371,5 +495,148 @@ mod tests {
             }
             _ => panic!("Expected GreeksEvent"),
         }
+    }
+}
+
+#[cfg(test)]
+mod strict_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn quote_row(symbol: &str) -> Vec<Value> {
+        vec![
+            json!("Quote"),
+            json!(symbol),
+            json!(150.25),
+            json!(150.5),
+            json!(100.0),
+            json!(150.0),
+        ]
+    }
+
+    fn batch(header: &str, values: Vec<Value>) -> Vec<CompactData> {
+        vec![
+            CompactData::EventType(header.to_string()),
+            CompactData::Values(values),
+        ]
+    }
+
+    #[test]
+    fn test_two_rows_decode_with_the_right_stride() {
+        let mut values = quote_row("AAPL");
+        values.extend(quote_row("MSFT"));
+
+        let events = try_parse_compact_data(&batch("Quote", values)).expect("well formed");
+
+        assert_eq!(events.len(), 2);
+        match (&events[0], &events[1]) {
+            (MarketEvent::Quote(first), MarketEvent::Quote(second)) => {
+                // The symbols prove the stride: off by one and the second row
+                // reads a price as its symbol.
+                assert_eq!(first.event_symbol, "AAPL");
+                assert_eq!(second.event_symbol, "MSFT");
+                assert_eq!(second.bid_price, 150.25);
+            }
+            other => panic!("expected two quotes, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_truncated_row_is_rejected_not_skipped() {
+        let mut values = quote_row("AAPL");
+        values.pop();
+
+        let error = try_parse_compact_data(&batch("Quote", values))
+            .expect_err("a short row must not decode");
+        let text = error.to_string();
+        assert!(text.contains("whole number of rows"), "unclear: {text}");
+    }
+
+    #[test]
+    fn test_trailing_values_are_rejected() {
+        let mut values = quote_row("AAPL");
+        values.push(json!(1.0));
+
+        assert!(
+            try_parse_compact_data(&batch("Quote", values)).is_err(),
+            "an extra value shifts every row after it and must not pass"
+        );
+    }
+
+    #[test]
+    fn test_a_wrong_column_type_names_the_field() {
+        let mut values = quote_row("AAPL");
+        values[2] = json!("not a price");
+
+        let error =
+            try_parse_compact_data(&batch("Quote", values)).expect_err("a text price is invalid");
+        let text = error.to_string();
+        assert!(text.contains("bidPrice"), "the field is missing: {text}");
+        assert!(text.contains("row 0"), "the row is missing: {text}");
+        assert!(text.contains("not a price"), "the value is missing: {text}");
+    }
+
+    #[test]
+    fn test_a_row_disagreeing_with_its_header_is_rejected() {
+        let mut values = quote_row("AAPL");
+        values[0] = json!("Trade");
+
+        let error = try_parse_compact_data(&batch("Quote", values))
+            .expect_err("the row is not laid out as the header claims");
+        assert!(error.to_string().contains("Trade"), "{error}");
+    }
+
+    #[test]
+    fn test_an_undecodable_event_type_is_reported() {
+        // Declared by the protocol, no decoder here.
+        let error = try_parse_compact_data(&batch("Candle", vec![json!("Candle"), json!("AAPL")]))
+            .expect_err("Candle has no decoder");
+        assert!(error.to_string().contains("no decoder"), "{error}");
+    }
+
+    #[test]
+    fn test_an_unknown_event_type_is_reported() {
+        let error = try_parse_compact_data(&batch("Nonsense", vec![json!("Nonsense")]))
+            .expect_err("an unknown name must not be silently treated as Quote");
+        assert!(error.to_string().contains("Nonsense"), "{error}");
+    }
+
+    #[test]
+    fn test_json_double_specials_are_values_not_errors() {
+        // An option with no bid has a NaN price. The protocol sends it as a
+        // string because JSON has no literal for it.
+        let mut values = quote_row("AAPL");
+        values[2] = json!("NaN");
+        values[3] = json!("Infinity");
+        values[4] = json!("-Infinity");
+
+        let events = try_parse_compact_data(&batch("Quote", values)).expect("specials are valid");
+        match &events[0] {
+            MarketEvent::Quote(quote) => {
+                assert!(quote.bid_price.is_nan());
+                assert_eq!(quote.ask_price, f64::INFINITY);
+                assert_eq!(quote.bid_size, f64::NEG_INFINITY);
+            }
+            other => panic!("expected a quote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_header_with_no_values_is_reported() {
+        let data = vec![CompactData::EventType("Quote".to_string())];
+        assert!(try_parse_compact_data(&data).is_err());
+    }
+
+    #[test]
+    fn test_the_lossy_wrapper_keeps_what_it_could_decode() {
+        let mut values = quote_row("AAPL");
+        values.extend(quote_row("MSFT"));
+        values.pop();
+
+        // Strict rejects the batch; the lossy wrapper is documented to return
+        // only what it managed, which is nothing here because the row count is
+        // what is wrong.
+        assert!(try_parse_compact_data(&batch("Quote", values.clone())).is_err());
+        assert!(parse_compact_data(&batch("Quote", values)).is_empty());
     }
 }


### PR DESCRIPTION
## Summary

`parse_compact_data` dropped unsupported types, truncated rows, wrong column types and trailing values without a word, so a consumer could not tell corrupt protocol data from a quiet market. Every arm advanced the stride even when a column was invalid — which is how one bad value shifts every row after it.

Stacked on #47.

## On #23: partly here, and deliberately not closed

The issue asks the strict parser to "reuse the protocol-correct JSONDouble decoder so valid `NaN`, `Infinity` and `-Infinity` are not classified as wrong column types". That is not an optional extra here: **an option with no bid has a `NaN` price**, sent as a string because JSON has no literal for it. A strict parser without JSONDouble support would reject data the server is entitled to send — a regression, not a fix.

So the COMPACT decoder handles them, and it had to.

**But that is not all of #23.** ,  and  still derive ordinary serde for their  fields, so a FULL-format payload carrying  cannot deserialize and serializing a non-finite value does not emit the string DXLink expects. Claiming to close #23 would have been wrong. #23 stays open for the serde work on the event structs.

## Changes

- `try_parse_compact_data` reports the first thing it cannot read, naming event type, row, field and the offending value.
- `parse_compact_data` stays as a documented lossy wrapper, so existing callers keep compiling.
- The layout comes from `EventType::compact_fields` — the same list `setup_feed` asks for.
- Rows are validated against their batch header.
- `EventType::from_wire_name` parses fallibly.
- The message task no longer swallows `FEED_DATA` deserialization failures.

## Technical decisions

**The stride is no longer a literal.** It comes from the same source `setup_feed` uses, so the contract that this repo calls its worst failure mode is now single-sourced end to end: request, validation of the reply (#47), and decode.

**`from_wire_name` exists because `From<&str>` is unusable here.** It answers `Quote` for any unrecognised name; a decoder using that reads an unknown type's row with the Quote layout and produces plausible nonsense. I did not change the `From` impl — that is #21's call, and changing it here would be an unannounced breaking change.

**Errors are `DXLinkError::Protocol` with detailed text rather than a new variant.** Adding a variant breaks downstream exhaustive matches. If you would rather have a dedicated `Decode` variant, it belongs in a deliberate semver bump rather than smuggled in here.

## Public API impact

Additive: `try_parse_compact_data`, `EventType::compact_fields` (from #47), `EventType::from_wire_name`. Nothing renamed or removed; `parse_compact_data` keeps its signature and behaviour.

## Testing

Ten boundary tests: two-row stride (the symbols prove it — off by one and the second row reads a price as its symbol), truncated row, trailing value, wrong column type, row disagreeing with its header, undecodable type, unknown type, JSONDouble specials, header with no values, and the lossy wrapper's documented behaviour.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #14
