### PR TITLE
Parse event type names fallibly on protocol paths (#21)

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -287,6 +287,19 @@ fn validate_feed_config(
     Ok(())
 }
 
+/// Parses every subscription's event type, rejecting the whole batch if any is
+/// unknown.
+///
+/// All or nothing on purpose: sending half a batch and recording the other half
+/// leaves the client and the server disagreeing about what is subscribed, which
+/// is worse than refusing the call.
+fn parse_subscription_types(subscriptions: &[FeedSubscription]) -> DXLinkResult<Vec<EventType>> {
+    subscriptions
+        .iter()
+        .map(|sub| sub.event_type.parse::<EventType>())
+        .collect()
+}
+
 /// The symbol an event refers to, borrowed rather than cloned.
 fn symbol_of(event: &MarketEvent) -> &str {
     match event {
@@ -1411,13 +1424,10 @@ impl DXLinkClient {
         // Validate channel exists and is a FEED channel
         self.validate_channel(channel_id, "FEED")?;
 
-        // Update internal subscriptions tracking
-        {
-            let mut subs = recover(&self.subscriptions);
-            for sub in &subscriptions {
-                subs.insert((EventType::from(sub.event_type.as_str()), sub.symbol.clone()));
-            }
-        }
+        // Reject before sending, not after. A misspelled type used to go out on
+        // the wire verbatim while being recorded locally as Quote, so the client
+        // believed in a subscription it had never made.
+        let parsed = parse_subscription_types(&subscriptions)?;
 
         let subscription_msg = FeedSubscriptionMessage {
             channel: channel_id,
@@ -1427,8 +1437,25 @@ impl DXLinkClient {
             reset: None,
         };
 
+        // Take the symbols back before the message is moved into the send.
+        let symbols: Vec<String> = subscription_msg
+            .add
+            .as_ref()
+            .map(|subs| subs.iter().map(|sub| sub.symbol.clone()).collect())
+            .unwrap_or_default();
+
         let conn = self.get_connection_mut()?;
         conn.send(&subscription_msg).await?;
+
+        // Only now. Recording before the send meant a failed send left the
+        // client believing in a subscription the server never received, which
+        // is the same divergence this method was fixed to avoid.
+        {
+            let mut subs = recover(&self.subscriptions);
+            for (event_type, symbol) in parsed.iter().zip(symbols) {
+                subs.insert((*event_type, symbol));
+            }
+        }
 
         info!("Subscriptions added to channel {}", channel_id);
 
@@ -1445,12 +1472,8 @@ impl DXLinkClient {
         self.validate_channel(channel_id, "FEED")?;
 
         // Update internal subscriptions tracking
-        {
-            let mut subs = recover(&self.subscriptions);
-            for sub in &subscriptions {
-                subs.remove(&(EventType::from(sub.event_type.as_str()), sub.symbol.clone()));
-            }
-        }
+        let parsed = parse_subscription_types(&subscriptions)?;
+        let symbols: Vec<String> = subscriptions.iter().map(|s| s.symbol.clone()).collect();
 
         let subscription_msg = FeedSubscriptionMessage {
             channel: channel_id,
@@ -1462,6 +1485,15 @@ impl DXLinkClient {
 
         let conn = self.get_connection_mut()?;
         conn.send(&subscription_msg).await?;
+
+        // After the send, for the same reason as subscribe: a failed send must
+        // not leave the client believing it unsubscribed.
+        {
+            let mut subs = recover(&self.subscriptions);
+            for (event_type, symbol) in parsed.iter().zip(symbols) {
+                subs.remove(&(*event_type, symbol));
+            }
+        }
 
         info!("Subscriptions removed from channel {}", channel_id);
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -64,6 +64,16 @@ impl fmt::Display for EventType {
     }
 }
 
+/// Parses a wire name, answering `Quote` for anything it does not recognise.
+///
+/// **This conversion loses information and should not be used on a protocol
+/// path.** A typo such as `"Qutoe"` becomes `Quote`, so the client records a
+/// subscription it never made while sending the misspelling to the server.
+/// Use [`EventType::from_str`] or [`EventType::from_wire_name`] instead, both
+/// of which say they do not know the name.
+///
+/// It is kept for source compatibility and is scheduled for removal in the
+/// next minor release of the 0.x line; nothing inside this crate uses it.
 impl From<&str> for EventType {
     fn from(s: &str) -> Self {
         match s {
@@ -84,6 +94,36 @@ impl From<&str> for EventType {
             "Message" => EventType::Message,
             _ => EventType::Quote, // Default
         }
+    }
+}
+
+impl std::str::FromStr for EventType {
+    type Err = crate::DXLinkError;
+
+    /// Parses a wire name, rejecting anything the protocol does not declare.
+    ///
+    /// # Errors
+    ///
+    /// [`DXLinkError::Protocol`](crate::DXLinkError::Protocol) naming the
+    /// string that was not recognised.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use dxlink::EventType;
+    ///
+    /// assert_eq!("Quote".parse::<EventType>().unwrap(), EventType::Quote);
+    /// // The lenient From impl would answer Quote for this.
+    /// assert!("Qutoe".parse::<EventType>().is_err());
+    /// ```
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        EventType::from_wire_name(s).ok_or_else(|| {
+            crate::DXLinkError::Protocol(format!(
+                "`{s}` is not a DXLink event type; the protocol declares Quote, Trade, \
+                 Summary, Profile, Order, TimeAndSale, Candle, TradeETH, SpreadOrder, \
+                 Greeks, TheoPrice, Underlying, Series, Configuration and Message"
+            ))
+        })
     }
 }
 

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -657,3 +657,98 @@ async fn test_a_rejected_reconfiguration_invalidates_the_channel() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+// --- Fallible event type parsing (issue #21) -------------------------------
+
+/// A misspelled event type used to go out on the wire verbatim while being
+/// recorded locally as Quote, so the client believed in a subscription it had
+/// never made and the server had never acknowledged.
+#[tokio::test]
+async fn test_subscribing_with_an_unknown_event_type_is_rejected() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+
+    let result = client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Qutoe".to_string(),
+                symbol: "AAPL".to_string(),
+                from_time: None,
+                source: None,
+            }],
+        )
+        .await;
+
+    match result {
+        Err(DXLinkError::Protocol(msg)) => {
+            assert!(
+                msg.contains("Qutoe"),
+                "the offending name is missing: {msg}"
+            );
+        }
+        other => panic!("a misspelled event type must be rejected, got: {other:?}"),
+    }
+
+    // And nothing reached the wire.
+    let sent = server
+        .received()
+        .iter()
+        .filter(|m| m["type"] == "FEED_SUBSCRIPTION")
+        .count();
+    assert_eq!(sent, 0, "a rejected subscription still went out");
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// One bad entry rejects the batch: sending half and recording the other half
+/// leaves the client and the server disagreeing about what is subscribed.
+#[tokio::test]
+async fn test_a_batch_with_one_bad_type_is_rejected_whole() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+
+    let good = FeedSubscription {
+        event_type: "Quote".to_string(),
+        symbol: "AAPL".to_string(),
+        from_time: None,
+        source: None,
+    };
+    let bad = FeedSubscription {
+        event_type: "Nonsense".to_string(),
+        symbol: "MSFT".to_string(),
+        from_time: None,
+        source: None,
+    };
+
+    assert!(client.subscribe(channel_id, vec![good, bad]).await.is_err());
+    assert_eq!(
+        server
+            .received()
+            .iter()
+            .filter(|m| m["type"] == "FEED_SUBSCRIPTION")
+            .count(),
+        0,
+        "a partially valid batch still went out"
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}


### PR DESCRIPTION
## Summary

`subscribe` and `unsubscribe` converted the wire name with `From<&str>`, which answers `Quote` for anything it does not recognise. A misspelling such as `"Qutoe"` went out on the wire verbatim while being **recorded locally as a Quote subscription** — so the client believed in something the server had never acknowledged.

Stacked on #48.

## Changes

- `EventType` implements `FromStr` with a typed error naming the string and the names the protocol declares.
- `subscribe`/`unsubscribe` parse before sending and reject the whole batch if any entry is unknown.
- The lenient `From<&str>` is documented as lossy and scheduled for removal; nothing in the crate uses it any more.

## Technical decisions

**All or nothing on a batch.** Sending the valid half and recording it while dropping the rest leaves the client and the server disagreeing about what is subscribed — a quieter, longer-lived version of the same bug. Refusing the call is the honest answer.

**`From<&str>` is kept, not removed.** `CLAUDE.md` marks changing that fallback as a breaking design discussion, and the issue asks for a compatible first step. It is now documented as unsuitable for protocol paths with a removal plan for the next 0.x minor.

I could not `#[deprecate]` it: rustc ignores the attribute on trait impl items and warns that it has no effect. The documentation carries the warning instead — worth knowing if you expected a compiler nudge at call sites.

**No wildcard in the enum match.** `from_wire_name` matches `&str` arms explicitly, so adding an `EventType` variant does not silently fall through — it just fails to parse until someone adds the arm, which is the safe direction.

## Public API impact

Additive: `impl FromStr for EventType`. `From<&str>` keeps its behaviour and signature; only its documentation changed. Non-breaking.

## Testing

- A misspelled type is rejected **and nothing reaches the wire** — a rejection that still sent the message would be the same bug wearing an error.
- A batch of one valid and one invalid entry is rejected whole, with nothing sent.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #21
