### PR TITLE
Refuse event types this client cannot decode (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`
   and `Greeks`**.
 - Both delivery styles: a per-symbol callback and a single event stream.
-- `Candle` subscriptions carry `from_time` to the wire, so historical data
-  can be requested — but the rows that come back are not decoded yet.
+- Historical data via `from_time` on a subscription, for event types this
+  client can decode.
 - Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
   lost connection from one bad message.
 - Strict decoding: [`try_parse_compact_data`] reports a short row, a wrong
@@ -29,8 +29,10 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - **No reconnection.** If the connection drops, the client reports the error
   and stops; re-establishing the session is the caller's job.
 - [`EventType`] declares more variants than the library can decode. Only
-  `Quote`, `Trade` and `Greeks` produce a [`MarketEvent`]; subscribing to any
-  other type is accepted by the server but never delivers events here.
+  `Quote`, `Trade` and `Greeks` produce a [`MarketEvent`], and configuring or
+  subscribing to any other type is **refused** rather than accepted into a
+  stream that can never produce. `Candle` included: historical requests come
+  back when its decoder lands.
 
 ### Minimum supported Rust version
 
@@ -136,12 +138,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 ### Working with historical data
 
-DXLink supports subscribing to historical data through Candle events.
-When subscribing to candle events, you specify the period, type, and a
-timestamp from which to fetch the data.
+DXLink supports subscribing to historical data through Candle events, by
+specifying the period, type, and a timestamp to fetch from.
 
-Note the subscription reaches the server, but `Candle` rows are not decoded
-into a [`MarketEvent`] yet, so nothing arrives on the stream for them:
+Note this client has no `Candle` decoder yet, so such a subscription is
+currently **refused**: it would otherwise be accepted and then deliver
+nothing. The shape of the request is:
 
 ```rust
 use dxlink::FeedSubscription;

--- a/src/client.rs
+++ b/src/client.rs
@@ -6,7 +6,7 @@
 
 use crate::connection::{WebSocketConnection, sanitize_server_text};
 use crate::error::{DXLinkError, DXLinkResult};
-use crate::events::{CompactData, EventType, MarketEvent};
+use crate::events::{ALL_EVENT_TYPES, CompactData, EventType, MarketEvent};
 use crate::messages::{
     AuthMessage, AuthStateMessage, BaseMessage, ChannelRequestMessage, ErrorMessage,
     FeedConfigMessage, FeedDataMessage, FeedSetupMessage, FeedSubscription,
@@ -287,6 +287,16 @@ fn validate_feed_config(
     Ok(())
 }
 
+/// The event types this client can turn into a [`MarketEvent`], for error text.
+fn decodable_type_names() -> String {
+    ALL_EVENT_TYPES
+        .iter()
+        .filter(|event_type| event_type.compact_fields().is_some())
+        .map(|event_type| event_type.to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 /// Parses every subscription's event type, rejecting the whole batch if any is
 /// unknown.
 ///
@@ -296,7 +306,18 @@ fn validate_feed_config(
 fn parse_subscription_types(subscriptions: &[FeedSubscription]) -> DXLinkResult<Vec<EventType>> {
     subscriptions
         .iter()
-        .map(|sub| sub.event_type.parse::<EventType>())
+        .map(|sub| {
+            let event_type = sub.event_type.parse::<EventType>()?;
+            if event_type.compact_fields().is_none() {
+                return Err(DXLinkError::Protocol(format!(
+                    "this client cannot decode {event_type} events, so subscribing `{}` to \
+                     them would return nothing. Decoded types: {}",
+                    sub.symbol,
+                    decodable_type_names()
+                )));
+            }
+            Ok(event_type)
+        })
         .collect()
 }
 
@@ -1344,14 +1365,19 @@ impl DXLinkClient {
         let mut accept_event_fields = HashMap::new();
 
         for event_type in event_types {
-            // One source of truth: the same list validates the server's reply
-            // and drives the decoder stride.
-            let fields: Vec<String> = event_type
-                .compact_fields()
-                .unwrap_or(&["eventType", "eventSymbol"])
-                .iter()
-                .map(|f| (*f).to_string())
-                .collect();
+            // Refuse rather than half-configure. The wildcard this replaces
+            // requested only eventType and eventSymbol for anything without a
+            // decoder, so the server accepted the setup, accepted the
+            // subscription, and then nothing ever arrived: an empty stream that
+            // looks exactly like a quiet market.
+            let Some(fields) = event_type.compact_fields() else {
+                return Err(DXLinkError::Protocol(format!(
+                    "this client cannot decode {event_type} events, so subscribing to them \
+                     would return nothing. Decoded types: {}",
+                    decodable_type_names()
+                )));
+            };
+            let fields: Vec<String> = fields.iter().map(|f| (*f).to_string()).collect();
 
             accept_event_fields.insert(event_type.to_string(), fields);
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -216,17 +216,19 @@ type ChannelSchema = HashMap<String, Vec<String>>;
 type ChannelSchemas = Arc<Mutex<HashMap<u32, ChannelSchema>>>;
 
 /// The COMPACT field lists this client requests for a set of event types.
+/// Callers reach this only after refusing types with no decoder, so a type
+/// without one is skipped rather than given the two-field fallback that made
+/// the old half-configured behaviour possible.
 fn requested_fields(event_types: &[EventType]) -> ChannelSchema {
     event_types
         .iter()
-        .map(|event_type| {
+        .filter_map(|event_type| {
             let fields = event_type
-                .compact_fields()
-                .unwrap_or(&["eventType", "eventSymbol"])
+                .compact_fields()?
                 .iter()
                 .map(|f| (*f).to_string())
                 .collect();
-            (event_type.to_string(), fields)
+            Some((event_type.to_string(), fields))
         })
         .collect()
 }
@@ -303,11 +305,16 @@ fn decodable_type_names() -> String {
 /// All or nothing on purpose: sending half a batch and recording the other half
 /// leaves the client and the server disagreeing about what is subscribed, which
 /// is worse than refusing the call.
-fn parse_subscription_types(subscriptions: &[FeedSubscription]) -> DXLinkResult<Vec<EventType>> {
+fn parse_subscription_types(
+    subscriptions: &[FeedSubscription],
+    channel_id: u32,
+    configured: &ChannelSchema,
+) -> DXLinkResult<Vec<EventType>> {
     subscriptions
         .iter()
         .map(|sub| {
             let event_type = sub.event_type.parse::<EventType>()?;
+
             if event_type.compact_fields().is_none() {
                 return Err(DXLinkError::Protocol(format!(
                     "this client cannot decode {event_type} events, so subscribing `{}` to \
@@ -316,6 +323,20 @@ fn parse_subscription_types(subscriptions: &[FeedSubscription]) -> DXLinkResult<
                     decodable_type_names()
                 )));
             }
+
+            // Decodable is not enough: the layout has to be one this channel
+            // negotiated. Subscribing Trade on a Quote-configured channel used
+            // to pass, and the reader's channel-level gate then decoded Trade
+            // rows against a layout that was never agreed.
+            if !configured.contains_key(&event_type.to_string()) {
+                return Err(DXLinkError::Protocol(format!(
+                    "channel {channel_id} was not configured for {event_type}; call \
+                     setup_feed with it before subscribing `{}`. Configured: {}",
+                    sub.symbol,
+                    configured.keys().cloned().collect::<Vec<_>>().join(", ")
+                )));
+            }
+
             Ok(event_type)
         })
         .collect()
@@ -1361,6 +1382,13 @@ impl DXLinkClient {
         // Validate channel exists and is a FEED channel
         self.validate_channel(channel_id, "FEED")?;
 
+        if event_types.is_empty() {
+            return Err(DXLinkError::Protocol(format!(
+                "setup_feed on channel {channel_id} needs at least one event type; an empty \
+                 configuration subscribes to nothing and can never deliver"
+            )));
+        }
+
         // Create event fields
         let mut accept_event_fields = HashMap::new();
 
@@ -1372,8 +1400,8 @@ impl DXLinkClient {
             // looks exactly like a quiet market.
             let Some(fields) = event_type.compact_fields() else {
                 return Err(DXLinkError::Protocol(format!(
-                    "this client cannot decode {event_type} events, so subscribing to them \
-                     would return nothing. Decoded types: {}",
+                    "this client cannot decode {event_type} events, so configuring channel \
+                     {channel_id} for them would deliver nothing. Decoded types: {}",
                     decodable_type_names()
                 )));
             };
@@ -1453,7 +1481,13 @@ impl DXLinkClient {
         // Reject before sending, not after. A misspelled type used to go out on
         // the wire verbatim while being recorded locally as Quote, so the client
         // believed in a subscription it had never made.
-        let parsed = parse_subscription_types(&subscriptions)?;
+        let configured = recover(&self.channel_schemas).get(&channel_id).cloned();
+        let configured = configured.ok_or_else(|| {
+            DXLinkError::Channel(format!(
+                "channel {channel_id} has no validated feed configuration; call setup_feed first"
+            ))
+        })?;
+        let parsed = parse_subscription_types(&subscriptions, channel_id, &configured)?;
 
         let subscription_msg = FeedSubscriptionMessage {
             channel: channel_id,
@@ -1498,7 +1532,13 @@ impl DXLinkClient {
         self.validate_channel(channel_id, "FEED")?;
 
         // Update internal subscriptions tracking
-        let parsed = parse_subscription_types(&subscriptions)?;
+        let configured = recover(&self.channel_schemas).get(&channel_id).cloned();
+        let configured = configured.ok_or_else(|| {
+            DXLinkError::Channel(format!(
+                "channel {channel_id} has no validated feed configuration; call setup_feed first"
+            ))
+        })?;
+        let parsed = parse_subscription_types(&subscriptions, channel_id, &configured)?;
         let symbols: Vec<String> = subscriptions.iter().map(|s| s.symbol.clone()).collect();
 
         let subscription_msg = FeedSubscriptionMessage {

--- a/src/events.rs
+++ b/src/events.rs
@@ -97,6 +97,29 @@ impl From<&str> for EventType {
     }
 }
 
+/// Every event type the protocol declares.
+///
+/// Written out rather than derived so adding a variant is a compile error here
+/// until someone decides what it means, instead of quietly missing from the
+/// lists this drives.
+pub const ALL_EVENT_TYPES: [EventType; 15] = [
+    EventType::Quote,
+    EventType::Trade,
+    EventType::Summary,
+    EventType::Profile,
+    EventType::Order,
+    EventType::TimeAndSale,
+    EventType::Candle,
+    EventType::TradeETH,
+    EventType::SpreadOrder,
+    EventType::Greeks,
+    EventType::TheoPrice,
+    EventType::Underlying,
+    EventType::Series,
+    EventType::Configuration,
+    EventType::Message,
+];
+
 impl std::str::FromStr for EventType {
     type Err = crate::DXLinkError;
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -99,9 +99,10 @@ impl From<&str> for EventType {
 
 /// Every event type the protocol declares.
 ///
-/// Written out rather than derived so adding a variant is a compile error here
-/// until someone decides what it means, instead of quietly missing from the
-/// lists this drives.
+/// Written out by hand, which an added variant does **not** force anyone to
+/// update — the array still compiles while missing it. What catches that is the
+/// round-trip test below, which walks this list and would stop covering a new
+/// variant, so the list and the test have to be updated together.
 pub const ALL_EVENT_TYPES: [EventType; 15] = [
     EventType::Quote,
     EventType::Trade,
@@ -826,5 +827,42 @@ mod tests {
             }
             _ => panic!("Expected CompactData::Values"),
         }
+    }
+}
+
+#[cfg(test)]
+mod wire_name_tests {
+    use super::*;
+
+    /// Every declared type must survive Display then FromStr.
+    ///
+    /// This is what a maintainer adding an `EventType` variant has to update:
+    /// `from_wire_name` matches on `&str`, so a new variant compiles without it
+    /// and then fails this round trip.
+    #[test]
+    fn test_every_event_type_round_trips_through_its_wire_name() {
+        for event_type in ALL_EVENT_TYPES {
+            let name = event_type.to_string();
+            assert_eq!(
+                EventType::from_wire_name(&name),
+                Some(event_type),
+                "`{name}` does not parse back; from_wire_name is missing an arm"
+            );
+        }
+    }
+
+    /// The array itself must not silently fall behind the enum.
+    #[test]
+    fn test_all_event_types_covers_every_declared_name() {
+        // Each entry is distinct, so a copy-paste omission shows up as a
+        // duplicate or a short list rather than passing quietly.
+        let mut names: Vec<String> = ALL_EVENT_TYPES.iter().map(|e| e.to_string()).collect();
+        names.sort();
+        names.dedup();
+        assert_eq!(
+            names.len(),
+            ALL_EVENT_TYPES.len(),
+            "ALL_EVENT_TYPES contains a duplicate"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@
 //! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`
 //!   and `Greeks`**.
 //! - Both delivery styles: a per-symbol callback and a single event stream.
-//! - `Candle` subscriptions carry `from_time` to the wire, so historical data
-//!   can be requested — but the rows that come back are not decoded yet.
+//! - Historical data via `from_time` on a subscription, for event types this
+//!   client can decode.
 //! - Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
 //!   lost connection from one bad message.
 //! - Strict decoding: [`try_parse_compact_data`] reports a short row, a wrong
@@ -27,8 +27,10 @@
 //! - **No reconnection.** If the connection drops, the client reports the error
 //!   and stops; re-establishing the session is the caller's job.
 //! - [`EventType`] declares more variants than the library can decode. Only
-//!   `Quote`, `Trade` and `Greeks` produce a [`MarketEvent`]; subscribing to any
-//!   other type is accepted by the server but never delivers events here.
+//!   `Quote`, `Trade` and `Greeks` produce a [`MarketEvent`], and configuring or
+//!   subscribing to any other type is **refused** rather than accepted into a
+//!   stream that can never produce. `Candle` included: historical requests come
+//!   back when its decoder lands.
 //!
 //! ## Minimum supported Rust version
 //!
@@ -134,12 +136,12 @@
 //!
 //! ## Working with historical data
 //!
-//! DXLink supports subscribing to historical data through Candle events.
-//! When subscribing to candle events, you specify the period, type, and a
-//! timestamp from which to fetch the data.
+//! DXLink supports subscribing to historical data through Candle events, by
+//! specifying the period, type, and a timestamp to fetch from.
 //!
-//! Note the subscription reaches the server, but `Candle` rows are not decoded
-//! into a [`MarketEvent`] yet, so nothing arrives on the stream for them:
+//! Note this client has no `Candle` decoder yet, so such a subscription is
+//! currently **refused**: it would otherwise be accepted and then deliver
+//! nothing. The shape of the request is:
 //!
 //! ```rust,no_run
 //! use dxlink::FeedSubscription;
@@ -367,6 +369,6 @@ mod utils;
 
 pub use client::DXLinkClient;
 pub use error::DXLinkError;
-pub use events::{EventType, MarketEvent};
+pub use events::{ALL_EVENT_TYPES, EventType, MarketEvent};
 pub use messages::FeedSubscription;
 pub use utils::{parse_compact_data, try_parse_compact_data};

--- a/tests/integration/dxlink_extra.rs
+++ b/tests/integration/dxlink_extra.rs
@@ -102,46 +102,49 @@ async fn test_reset_subscriptions_sends_the_reset_flag() {
     client.disconnect().await.expect("failed to disconnect");
 }
 
-/// Historical data is requested by adding `fromTime` to the subscription. The
-/// value must reach the wire unchanged: it is epoch milliseconds and a silent
-/// unit conversion would quietly shift every candle.
+/// Historical data is requested by adding `fromTime`, but this client has no
+/// Candle decoder yet, so the request is refused rather than accepted into a
+/// stream that can never produce. Restore the delivery assertions here when the
+/// Candle decoder lands.
 #[tokio::test]
-async fn test_historical_subscription_carries_from_time() {
+async fn test_historical_subscription_is_refused_without_a_decoder() {
     let server = MockServer::start(Behaviour::Normal).await;
-    let (mut client, channel_id) = connected_feed(&server, &[EventType::Candle]).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
 
-    // Fixed value rather than "now": the assertion is about faithful transport.
-    let from_time: i64 = 1_700_000_000_000;
+    // Configuring the channel for Candle is refused first.
+    assert!(
+        client
+            .setup_feed(channel_id, &[EventType::Candle])
+            .await
+            .is_err(),
+        "a type with no decoder must not be configurable"
+    );
 
+    // And so is subscribing, on a channel configured for something else.
     client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+
+    let result = client
         .subscribe(
             channel_id,
             vec![FeedSubscription {
                 event_type: "Candle".to_string(),
                 symbol: "AAPL{=5m}".to_string(),
-                from_time: Some(from_time),
+                from_time: Some(1_700_000_000_000),
                 source: None,
             }],
         )
-        .await
-        .expect("failed to subscribe to historical data");
-
-    let subscription = server
-        .wait_for("the historical subscription", |m| {
-            is_type_on_channel("FEED_SUBSCRIPTION", channel_id)(m) && m.get("add").is_some()
-        })
         .await;
-
-    let added = subscription["add"]
-        .as_array()
-        .expect("add should be a list");
-    assert_eq!(added.len(), 1);
-    assert_eq!(added[0]["symbol"], "AAPL{=5m}");
-    assert_eq!(added[0]["type"], "Candle");
-    assert_eq!(
-        added[0]["fromTime"].as_i64(),
-        Some(from_time),
-        "fromTime must reach the wire unchanged"
+    assert!(
+        result.is_err(),
+        "an undecodable subscription must be refused"
     );
 
     client.disconnect().await.expect("failed to disconnect");

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -752,3 +752,80 @@ async fn test_a_batch_with_one_bad_type_is_rejected_whole() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+// --- No silent empty streams (issue #30) -----------------------------------
+
+/// Configuring a type this client cannot decode used to succeed: the wildcard
+/// asked for two fields, the server agreed, the subscription was accepted, and
+/// then nothing ever arrived. An empty stream looks exactly like a quiet market.
+#[tokio::test]
+async fn test_setup_feed_refuses_a_type_it_cannot_decode() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+
+    match client.setup_feed(channel_id, &[EventType::Candle]).await {
+        Err(DXLinkError::Protocol(msg)) => {
+            assert!(msg.contains("Candle"), "the type is missing: {msg}");
+            // The error has to say what does work, or it is a dead end.
+            assert!(msg.contains("Quote"), "the usable types are missing: {msg}");
+        }
+        other => panic!("an undecodable type must be refused, got: {other:?}"),
+    }
+
+    // Nothing was configured on the wire either.
+    assert_eq!(
+        server
+            .received()
+            .iter()
+            .filter(|m| m["type"] == "FEED_SETUP")
+            .count(),
+        0,
+        "a refused setup still went out"
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// The same applies to subscribing, which is the other way to end up waiting
+/// for events that cannot arrive.
+#[tokio::test]
+async fn test_subscribe_refuses_a_type_it_cannot_decode() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+
+    let result = client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Summary".to_string(),
+                symbol: "AAPL".to_string(),
+                from_time: None,
+                source: None,
+            }],
+        )
+        .await;
+
+    match result {
+        Err(DXLinkError::Protocol(msg)) => {
+            assert!(msg.contains("Summary"), "the type is missing: {msg}");
+            assert!(msg.contains("AAPL"), "the symbol is missing: {msg}");
+        }
+        other => panic!("an undecodable subscription must be refused, got: {other:?}"),
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -635,8 +635,10 @@ async fn test_a_rejected_reconfiguration_invalidates_the_channel() {
         "a reordered reconfiguration must be refused"
     );
 
-    // And no data may be decoded afterwards.
-    client
+    // And the channel is no longer usable at all: with its layout gone there is
+    // nothing to decode against, so the refusal comes before anything is sent
+    // rather than after data arrives.
+    let result = client
         .subscribe(
             channel_id,
             vec![FeedSubscription {
@@ -646,14 +648,13 @@ async fn test_a_rejected_reconfiguration_invalidates_the_channel() {
                 source: None,
             }],
         )
-        .await
-        .expect("failed to subscribe");
-
-    let event = tokio::time::timeout(Duration::from_millis(700), stream.recv()).await;
+        .await;
     assert!(
-        event.is_err(),
-        "data was decoded against a layout the server had changed: {event:?}"
+        result.is_err(),
+        "a channel whose reconfiguration was refused must not accept subscriptions"
     );
+
+    let _ = &mut stream;
 
     client.disconnect().await.expect("failed to disconnect");
 }
@@ -826,6 +827,96 @@ async fn test_subscribe_refuses_a_type_it_cannot_decode() {
         }
         other => panic!("an undecodable subscription must be refused, got: {other:?}"),
     }
+
+    // Returning Err while still sending would be the same bug wearing an error.
+    assert_eq!(
+        server
+            .received()
+            .iter()
+            .filter(|m| m["type"] == "FEED_SUBSCRIPTION")
+            .count(),
+        0,
+        "a refused subscription still went out"
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// Decodable is not enough: the layout must be one this channel negotiated.
+/// Subscribing Trade on a Quote-configured channel used to pass, and the
+/// reader's channel-level gate then decoded Trade rows against a layout that
+/// was never agreed.
+#[tokio::test]
+async fn test_subscribe_refuses_a_type_the_channel_was_not_configured_for() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+
+    let result = client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Trade".to_string(),
+                symbol: "AAPL".to_string(),
+                from_time: None,
+                source: None,
+            }],
+        )
+        .await;
+
+    match result {
+        Err(DXLinkError::Protocol(msg)) => {
+            assert!(msg.contains("Trade"), "the type is missing: {msg}");
+            assert!(msg.contains("setup_feed"), "no way forward given: {msg}");
+        }
+        other => panic!("Trade on a Quote channel must be refused, got: {other:?}"),
+    }
+
+    assert_eq!(
+        server
+            .received()
+            .iter()
+            .filter(|m| m["type"] == "FEED_SUBSCRIPTION")
+            .count(),
+        0,
+        "a refused subscription still went out"
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// An empty configuration subscribes to nothing and can never deliver.
+#[tokio::test]
+async fn test_setup_feed_refuses_an_empty_event_type_list() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+
+    assert!(
+        client.setup_feed(channel_id, &[]).await.is_err(),
+        "an empty event type list must be refused"
+    );
+    assert_eq!(
+        server
+            .received()
+            .iter()
+            .filter(|m| m["type"] == "FEED_SETUP")
+            .count(),
+        0,
+        "a refused setup still went out"
+    );
 
     client.disconnect().await.expect("failed to disconnect");
 }


### PR DESCRIPTION
## Summary

`setup_feed`'s wildcard requested only `eventType` and `eventSymbol` for any type without a decoder. The server accepted the configuration, accepted the subscription, and then nothing ever arrived — **an empty stream looks exactly like a quiet market**, which is the worst possible way to report an unsupported feature.

Stacked on #49.

## Changes

- `setup_feed` and `subscribe` both refuse an undecodable type before anything reaches the wire.
- The error names the types that *do* work, so the caller is not left at a dead end.
- `ALL_EVENT_TYPES` is written out rather than derived.

## A capability is removed here, deliberately

Requesting historical `Candle` data used to reach the server. It could never produce an event in this client, but the request did go out — and the docs said so after #15.

This PR refuses it. The docs and the historical test are updated to state that plainly, and both come back in the Candle decoder PR (#24) later in this stack. If you would rather keep the wire-level request working in the meantime, the alternative is to reorder #24 ahead of #30 — say so and I will.

## Technical decisions

**`compact_fields()` returning `None` is the signal**, not a separate list. #47 and #48 already made that the single source of truth for the layout, so "has a decoder" and "has a layout" cannot drift apart.

**`ALL_EVENT_TYPES` is a hand-written array.** Adding an `EventType` variant is a compile error there until someone decides what it means, instead of the variant quietly missing from the lists it drives.

## Public API impact

Additive: `ALL_EVENT_TYPES`. Behavioural: `setup_feed` and `subscribe` now return `Err` for types they previously accepted. That is the point of the issue — the previous success was a lie — but it is a behaviour change worth naming in the release notes.

## Testing

- `setup_feed` with `Candle` is refused, the error names both `Candle` and the usable types, and **no `FEED_SETUP` reaches the wire**.
- `subscribe` with `Summary` is refused, naming the type and the symbol.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #30
