### PR TITLE
Decode Candle events end to end (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`
   and `Greeks`**.
 - Both delivery styles: a per-symbol callback and a single event stream.
-- Historical data via `from_time` on a subscription, for event types this
-  client can decode.
+- Historical data via `from_time` on a `Candle` subscription, decoded into
+  OHLC bars.
 - Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
   lost connection from one bad message.
 - Strict decoding: [`try_parse_compact_data`] reports a short row, a wrong
@@ -29,10 +29,9 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - **No reconnection.** If the connection drops, the client reports the error
   and stops; re-establishing the session is the caller's job.
 - [`EventType`] declares more variants than the library can decode. Only
-  `Quote`, `Trade` and `Greeks` produce a [`MarketEvent`], and configuring or
-  subscribing to any other type is **refused** rather than accepted into a
-  stream that can never produce. `Candle` included: historical requests come
-  back when its decoder lands.
+  `Quote`, `Trade`, `Greeks` and `Candle` produce a [`MarketEvent`], and
+  configuring or subscribing to any other type is **refused** rather than
+  accepted into a stream that can never produce.
 
 ### Minimum supported Rust version
 
@@ -141,9 +140,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 DXLink supports subscribing to historical data through Candle events, by
 specifying the period, type, and a timestamp to fetch from.
 
-Note this client has no `Candle` decoder yet, so such a subscription is
-currently **refused**: it would otherwise be accepted and then deliver
-nothing. The shape of the request is:
+The bars come back as [`MarketEvent::Candle`]:
 
 ```rust
 use dxlink::FeedSubscription;
@@ -197,11 +194,11 @@ are decoded into a [`MarketEvent`] and delivered:
 | `Quote`  | `bidPrice`, `askPrice`, `bidSize`, `askSize` |
 | `Trade`  | `price`, `size`, `dayVolume` |
 | `Greeks` | `delta`, `gamma`, `theta`, `vega`, `rho`, `volatility` |
+| `Candle` | `time`, `open`, `high`, `low`, `close`, `volume` |
 
-Subscribing to any other variant (`Summary`, `Profile`, `Candle`,
-`TimeAndSale`, …) is accepted by the server, but no event will reach your
-callback or stream. `Candle` in particular is usable only to request
-historical data; the rows are not decoded yet.
+Configuring or subscribing to any other variant (`Summary`, `Profile`,
+`TimeAndSale`, …) is **refused**, rather than accepted into a stream that can
+never produce.
 
 
 ### License

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - Session lifecycle over the DXLink WebSocket protocol: `SETUP`, token
   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 - Automatic keepalives while the connection is open.
-- Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`
-  and `Greeks`**.
+- Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
+  `Greeks` and `Candle`**, each with the full field set the dxFeed schema
+  defines for it.
 - Both delivery styles: a per-symbol callback and a single event stream.
 - Historical data via `from_time` on a `Candle` subscription, decoded into
   OHLC bars.

--- a/src/client.rs
+++ b/src/client.rs
@@ -348,6 +348,7 @@ fn symbol_of(event: &MarketEvent) -> &str {
         MarketEvent::Quote(e) => &e.event_symbol,
         MarketEvent::Trade(e) => &e.event_symbol,
         MarketEvent::Greeks(e) => &e.event_symbol,
+        MarketEvent::Candle(e) => &e.event_symbol,
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -203,12 +203,22 @@ impl EventType {
             EventType::Candle => Some(&[
                 "eventType",
                 "eventSymbol",
+                "eventTime",
+                "eventFlags",
+                "index",
                 "time",
+                "sequence",
+                "count",
                 "open",
                 "high",
                 "low",
                 "close",
                 "volume",
+                "VWAP",
+                "bidVolume",
+                "askVolume",
+                "impVolatility",
+                "openInterest",
             ]),
             EventType::Greeks => Some(&[
                 "eventType",
@@ -429,7 +439,10 @@ pub struct GreeksEvent {
 /// One OHLC bar for a period, the shape historical data comes back in.
 ///
 /// Candle symbols carry the period, for example `AAPL{=5m}` for five minute
-/// bars. Field names and their meaning follow the dxFeed AsyncAPI schema.
+/// bars. Every field the dxFeed AsyncAPI schema defines for a candle is here,
+/// in the order the client requests them: `eventFlags` and `index` in
+/// particular mark where a historical snapshot starts and ends, and a consumer
+/// that only ever sees OHLC cannot tell a snapshot from live updates.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CandleEvent {
     /// The type of the event, `Candle`.
@@ -440,9 +453,30 @@ pub struct CandleEvent {
     #[serde(rename = "eventSymbol")]
     pub event_symbol: String,
 
+    /// When the server emitted the event, as epoch milliseconds.
+    #[serde(rename = "eventTime")]
+    pub event_time: i64,
+
+    /// Snapshot and transaction bits. Non-zero values delimit a historical
+    /// snapshot; see the dxFeed event flags documentation.
+    #[serde(rename = "eventFlags")]
+    pub event_flags: i64,
+
+    /// Unique index of the bar within its subscription.
+    #[serde(rename = "index")]
+    pub index: i64,
+
     /// Start of the bar, as epoch milliseconds.
     #[serde(rename = "time")]
     pub time: i64,
+
+    /// Sequence number, disambiguating bars sharing a timestamp.
+    #[serde(rename = "sequence")]
+    pub sequence: i64,
+
+    /// Number of events aggregated into the bar.
+    #[serde(rename = "count")]
+    pub count: i64,
 
     /// First price in the bar.
     #[serde(rename = "open", with = "json_double")]
@@ -463,6 +497,26 @@ pub struct CandleEvent {
     /// Total volume traded during the bar.
     #[serde(rename = "volume", with = "json_double")]
     pub volume: f64,
+
+    /// Volume weighted average price for the bar.
+    #[serde(rename = "VWAP", with = "json_double")]
+    pub vwap: f64,
+
+    /// Volume traded at the bid during the bar.
+    #[serde(rename = "bidVolume", with = "json_double")]
+    pub bid_volume: f64,
+
+    /// Volume traded at the ask during the bar.
+    #[serde(rename = "askVolume", with = "json_double")]
+    pub ask_volume: f64,
+
+    /// Implied volatility over the bar, for instruments that have it.
+    #[serde(rename = "impVolatility", with = "json_double")]
+    pub imp_volatility: f64,
+
+    /// Open interest at the end of the bar.
+    #[serde(rename = "openInterest", with = "json_double")]
+    pub open_interest: f64,
 }
 
 /// Represents a market event, which can be a quote, trade, or greeks event.

--- a/src/events.rs
+++ b/src/events.rs
@@ -200,6 +200,16 @@ impl EventType {
                 "askSize",
             ]),
             EventType::Trade => Some(&["eventType", "eventSymbol", "price", "size", "dayVolume"]),
+            EventType::Candle => Some(&[
+                "eventType",
+                "eventSymbol",
+                "time",
+                "open",
+                "high",
+                "low",
+                "close",
+                "volume",
+            ]),
             EventType::Greeks => Some(&[
                 "eventType",
                 "eventSymbol",
@@ -215,7 +225,6 @@ impl EventType {
             | EventType::Profile
             | EventType::Order
             | EventType::TimeAndSale
-            | EventType::Candle
             | EventType::TradeETH
             | EventType::SpreadOrder
             | EventType::TheoPrice
@@ -417,6 +426,45 @@ pub struct GreeksEvent {
     pub volatility: f64,
 }
 
+/// One OHLC bar for a period, the shape historical data comes back in.
+///
+/// Candle symbols carry the period, for example `AAPL{=5m}` for five minute
+/// bars. Field names and their meaning follow the dxFeed AsyncAPI schema.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CandleEvent {
+    /// The type of the event, `Candle`.
+    #[serde(rename = "eventType")]
+    pub event_type: String,
+
+    /// The candle symbol, including its period, such as `AAPL{=5m}`.
+    #[serde(rename = "eventSymbol")]
+    pub event_symbol: String,
+
+    /// Start of the bar, as epoch milliseconds.
+    #[serde(rename = "time")]
+    pub time: i64,
+
+    /// First price in the bar.
+    #[serde(rename = "open", with = "json_double")]
+    pub open: f64,
+
+    /// Highest price in the bar.
+    #[serde(rename = "high", with = "json_double")]
+    pub high: f64,
+
+    /// Lowest price in the bar.
+    #[serde(rename = "low", with = "json_double")]
+    pub low: f64,
+
+    /// Last price in the bar.
+    #[serde(rename = "close", with = "json_double")]
+    pub close: f64,
+
+    /// Total volume traded during the bar.
+    #[serde(rename = "volume", with = "json_double")]
+    pub volume: f64,
+}
+
 /// Represents a market event, which can be a quote, trade, or greeks event.
 ///
 /// This enum uses `serde`'s untagged enum serialization, meaning that the serialized
@@ -483,6 +531,13 @@ pub enum MarketEvent {
     /// Represents a Greeks event, containing Greek values (delta, gamma, theta, vega, rho)
     /// for a specific financial instrument.
     Greeks(GreeksEvent),
+    /// One OHLC bar, from a historical or streaming candle subscription.
+    ///
+    /// Last in the list on purpose: `MarketEvent` is `#[serde(untagged)]`, so
+    /// serde tries variants in declaration order and keeps the first that
+    /// deserializes. A candle has fields none of the others do, but ordering it
+    /// after them keeps the existing three matching exactly as before.
+    Candle(CandleEvent),
 }
 
 /// Represents compact data, which can be either an event type (string) or a vector of JSON values.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@
 //! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`
 //!   and `Greeks`**.
 //! - Both delivery styles: a per-symbol callback and a single event stream.
-//! - Historical data via `from_time` on a subscription, for event types this
-//!   client can decode.
+//! - Historical data via `from_time` on a `Candle` subscription, decoded into
+//!   OHLC bars.
 //! - Typed errors ([`DXLinkError`]) with [`DXLinkError::is_terminal`] to tell a
 //!   lost connection from one bad message.
 //! - Strict decoding: [`try_parse_compact_data`] reports a short row, a wrong
@@ -27,10 +27,9 @@
 //! - **No reconnection.** If the connection drops, the client reports the error
 //!   and stops; re-establishing the session is the caller's job.
 //! - [`EventType`] declares more variants than the library can decode. Only
-//!   `Quote`, `Trade` and `Greeks` produce a [`MarketEvent`], and configuring or
-//!   subscribing to any other type is **refused** rather than accepted into a
-//!   stream that can never produce. `Candle` included: historical requests come
-//!   back when its decoder lands.
+//!   `Quote`, `Trade`, `Greeks` and `Candle` produce a [`MarketEvent`], and
+//!   configuring or subscribing to any other type is **refused** rather than
+//!   accepted into a stream that can never produce.
 //!
 //! ## Minimum supported Rust version
 //!
@@ -139,9 +138,7 @@
 //! DXLink supports subscribing to historical data through Candle events, by
 //! specifying the period, type, and a timestamp to fetch from.
 //!
-//! Note this client has no `Candle` decoder yet, so such a subscription is
-//! currently **refused**: it would otherwise be accepted and then deliver
-//! nothing. The shape of the request is:
+//! The bars come back as [`MarketEvent::Candle`]:
 //!
 //! ```rust,no_run
 //! use dxlink::FeedSubscription;
@@ -195,11 +192,11 @@
 //! | `Quote`  | `bidPrice`, `askPrice`, `bidSize`, `askSize` |
 //! | `Trade`  | `price`, `size`, `dayVolume` |
 //! | `Greeks` | `delta`, `gamma`, `theta`, `vega`, `rho`, `volatility` |
+//! | `Candle` | `time`, `open`, `high`, `low`, `close`, `volume` |
 //!
-//! Subscribing to any other variant (`Summary`, `Profile`, `Candle`,
-//! `TimeAndSale`, …) is accepted by the server, but no event will reach your
-//! callback or stream. `Candle` in particular is usable only to request
-//! historical data; the rows are not decoded yet.
+//! Configuring or subscribing to any other variant (`Summary`, `Profile`,
+//! `TimeAndSale`, …) is **refused**, rather than accepted into a stream that can
+//! never produce.
 //!
 //!
 //! ## License

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,9 @@
 //! - Session lifecycle over the DXLink WebSocket protocol: `SETUP`, token
 //!   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 //! - Automatic keepalives while the connection is open.
-//! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`
-//!   and `Greeks`**.
+//! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
+//!   `Greeks` and `Candle`**, each with the full field set the dxFeed schema
+//!   defines for it.
 //! - Both delivery styles: a per-symbol callback and a single event stream.
 //! - Historical data via `from_time` on a `Candle` subscription, decoded into
 //!   OHLC bars.

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -275,16 +275,29 @@ fn build_event(
             rho: number(6)?,
             volatility: number(7)?,
         }),
-        EventType::Candle => MarketEvent::Candle(CandleEvent {
-            event_type: header.to_string(),
-            event_symbol: symbol,
-            time: as_int(row_values, 2, header, row, fields[2])?,
-            open: number(3)?,
-            high: number(4)?,
-            low: number(5)?,
-            close: number(6)?,
-            volume: number(7)?,
-        }),
+        EventType::Candle => {
+            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
+            MarketEvent::Candle(CandleEvent {
+                event_type: header.to_string(),
+                event_symbol: symbol,
+                event_time: int(2)?,
+                event_flags: int(3)?,
+                index: int(4)?,
+                time: int(5)?,
+                sequence: int(6)?,
+                count: int(7)?,
+                open: number(8)?,
+                high: number(9)?,
+                low: number(10)?,
+                close: number(11)?,
+                volume: number(12)?,
+                vwap: number(13)?,
+                bid_volume: number(14)?,
+                ask_volume: number(15)?,
+                imp_volatility: number(16)?,
+                open_interest: number(17)?,
+            })
+        }
         // compact_fields returned Some for this type, so a missing arm here is a
         // bug in this match rather than a protocol problem.
         other => {
@@ -649,16 +662,27 @@ mod candle_tests {
     use super::*;
     use serde_json::json;
 
+    /// The exact 18 columns issue #24 specifies, in order.
     fn candle_row(symbol: &str) -> Vec<Value> {
         vec![
-            json!("Candle"),
-            json!(symbol),
-            json!(1_700_000_000_000i64),
-            json!(149.0),
-            json!(151.0),
-            json!(148.5),
-            json!(150.5),
-            json!(1_234_000.0),
+            json!("Candle"),             // 0 eventType
+            json!(symbol),               // 1 eventSymbol
+            json!(1_700_000_000_500i64), // 2 eventTime
+            json!(0i64),                 // 3 eventFlags
+            json!(7i64),                 // 4 index
+            json!(1_700_000_000_000i64), // 5 time
+            json!(3i64),                 // 6 sequence
+            json!(42i64),                // 7 count
+            json!(149.0),                // 8 open
+            json!(151.0),                // 9 high
+            json!(148.5),                // 10 low
+            json!(150.5),                // 11 close
+            json!(1_234_000.0),          // 12 volume
+            json!(150.1),                // 13 VWAP
+            json!(600_000.0),            // 14 bidVolume
+            json!(634_000.0),            // 15 askVolume
+            json!(0.31),                 // 16 impVolatility
+            json!(4_200.0),              // 17 openInterest
         ]
     }
 
@@ -667,6 +691,19 @@ mod candle_tests {
             CompactData::EventType("Candle".to_string()),
             CompactData::Values(values),
         ]
+    }
+
+    /// The requested field list and the decoder must agree on all 18 columns.
+    #[test]
+    fn test_the_field_list_matches_the_decoder_stride() {
+        let fields = EventType::Candle
+            .compact_fields()
+            .expect("Candle has a decoder");
+        assert_eq!(fields.len(), 18, "the layout is 18 columns");
+        assert_eq!(fields[0], "eventType");
+        assert_eq!(fields[1], "eventSymbol");
+        assert_eq!(fields[13], "VWAP", "the wire name is upper case");
+        assert_eq!(fields.len(), candle_row("AAPL").len());
     }
 
     #[test]
@@ -679,29 +716,72 @@ mod candle_tests {
 
         match (&events[0], &events[1]) {
             (MarketEvent::Candle(first), MarketEvent::Candle(second)) => {
-                // The symbols prove the stride of eight.
+                // The symbols prove the stride of eighteen.
                 assert_eq!(first.event_symbol, "AAPL{=5m}");
                 assert_eq!(second.event_symbol, "MSFT{=5m}");
+                assert_eq!(first.event_time, 1_700_000_000_500);
+                assert_eq!(first.event_flags, 0);
+                assert_eq!(first.index, 7);
                 assert_eq!(first.time, 1_700_000_000_000);
+                assert_eq!(first.sequence, 3);
+                assert_eq!(first.count, 42);
                 assert_eq!(first.open, 149.0);
                 assert_eq!(first.high, 151.0);
                 assert_eq!(first.low, 148.5);
                 assert_eq!(first.close, 150.5);
                 assert_eq!(first.volume, 1_234_000.0);
+                assert_eq!(first.vwap, 150.1);
+                assert_eq!(first.bid_volume, 600_000.0);
+                assert_eq!(first.ask_volume, 634_000.0);
+                assert_eq!(first.imp_volatility, 0.31);
+                assert_eq!(first.open_interest, 4_200.0);
             }
             other => panic!("expected two candles, got {other:?}"),
+        }
+    }
+
+    /// eventFlags is what marks a historical snapshot's boundaries; a consumer
+    /// that cannot see it cannot tell a snapshot from live updates.
+    #[test]
+    fn test_snapshot_flags_reach_the_consumer() {
+        let mut values = candle_row("AAPL{=5m}");
+        values[3] = json!(4i64); // SNAPSHOT_BEGIN
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        match &events[0] {
+            MarketEvent::Candle(candle) => assert_eq!(candle.event_flags, 4),
+            other => panic!("expected a candle, got {other:?}"),
         }
     }
 
     #[test]
     fn test_a_fractional_time_is_rejected() {
         let mut values = candle_row("AAPL{=5m}");
-        values[2] = json!(1.5);
+        values[5] = json!(1.5);
 
         let error = try_parse_compact_data(&batch(values)).expect_err("time is a whole number");
         let text = error.to_string();
         assert!(text.contains("time"), "the field is missing: {text}");
         assert!(text.contains("whole number"), "unclear: {text}");
+    }
+
+    /// An instrument with no implied volatility or open interest still decodes:
+    /// the protocol sends NaN rather than dropping the columns.
+    #[test]
+    fn test_absent_optional_values_decode_as_nan() {
+        let mut values = candle_row("AAPL{=5m}");
+        values[16] = json!("NaN");
+        values[17] = json!("NaN");
+
+        let events = try_parse_compact_data(&batch(values)).expect("NaN is a value");
+        match &events[0] {
+            MarketEvent::Candle(candle) => {
+                assert!(candle.imp_volatility.is_nan());
+                assert!(candle.open_interest.is_nan());
+                assert_eq!(candle.close, 150.5);
+            }
+            other => panic!("expected a candle, got {other:?}"),
+        }
     }
 
     #[test]
@@ -713,14 +793,8 @@ mod candle_tests {
 
     #[test]
     fn test_a_candle_is_not_mistaken_for_another_event() {
-        // MarketEvent is untagged, so serde keeps the first variant that
-        // deserializes. A candle must not come back as something else.
         let events = try_parse_compact_data(&batch(candle_row("AAPL{=5m}"))).expect("well formed");
-        assert!(
-            matches!(events[0], MarketEvent::Candle(_)),
-            "decoded as the wrong variant: {:?}",
-            events[0]
-        );
+        assert!(matches!(events[0], MarketEvent::Candle(_)));
 
         let json = serde_json::to_string(&events[0]).expect("serialize");
         let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@
 ******************************************************************************/
 use crate::MarketEvent;
 use crate::error::{DXLinkError, DXLinkResult};
-use crate::events::{CompactData, EventType, GreeksEvent, QuoteEvent, TradeEvent};
+use crate::events::{CandleEvent, CompactData, EventType, GreeksEvent, QuoteEvent, TradeEvent};
 use serde_json::Value;
 use tracing::warn;
 
@@ -112,6 +112,22 @@ fn as_text<'a>(
     values[index].as_str().ok_or_else(|| {
         DXLinkError::Protocol(format!(
             "{event_type} row {row}: field `{field}` should be a string, got {}",
+            values[index]
+        ))
+    })
+}
+
+/// A column that must be a whole number, such as an epoch millisecond time.
+fn as_int(
+    values: &[Value],
+    index: usize,
+    event_type: &str,
+    row: usize,
+    field: &str,
+) -> DXLinkResult<i64> {
+    values[index].as_i64().ok_or_else(|| {
+        DXLinkError::Protocol(format!(
+            "{event_type} row {row}: field `{field}` should be a whole number, got {}",
             values[index]
         ))
     })
@@ -258,6 +274,16 @@ fn build_event(
             vega: number(5)?,
             rho: number(6)?,
             volatility: number(7)?,
+        }),
+        EventType::Candle => MarketEvent::Candle(CandleEvent {
+            event_type: header.to_string(),
+            event_symbol: symbol,
+            time: as_int(row_values, 2, header, row, fields[2])?,
+            open: number(3)?,
+            high: number(4)?,
+            low: number(5)?,
+            close: number(6)?,
+            volume: number(7)?,
         }),
         // compact_fields returned Some for this type, so a missing arm here is a
         // bug in this match rather than a protocol problem.
@@ -563,9 +589,11 @@ mod strict_tests {
 
     #[test]
     fn test_an_undecodable_event_type_is_reported() {
-        // Declared by the protocol, no decoder here.
-        let error = try_parse_compact_data(&batch("Candle", vec![json!("Candle"), json!("AAPL")]))
-            .expect_err("Candle has no decoder");
+        // Declared by the protocol, no decoder here. Update this to another
+        // undecoded type when Summary gains one.
+        let error =
+            try_parse_compact_data(&batch("Summary", vec![json!("Summary"), json!("AAPL")]))
+                .expect_err("Summary has no decoder");
         assert!(error.to_string().contains("no decoder"), "{error}");
     }
 
@@ -613,5 +641,92 @@ mod strict_tests {
         // what is wrong.
         assert!(try_parse_compact_data(&batch("Quote", values.clone())).is_err());
         assert!(parse_compact_data(&batch("Quote", values)).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod candle_tests {
+    use super::*;
+    use serde_json::json;
+
+    fn candle_row(symbol: &str) -> Vec<Value> {
+        vec![
+            json!("Candle"),
+            json!(symbol),
+            json!(1_700_000_000_000i64),
+            json!(149.0),
+            json!(151.0),
+            json!(148.5),
+            json!(150.5),
+            json!(1_234_000.0),
+        ]
+    }
+
+    fn batch(values: Vec<Value>) -> Vec<CompactData> {
+        vec![
+            CompactData::EventType("Candle".to_string()),
+            CompactData::Values(values),
+        ]
+    }
+
+    #[test]
+    fn test_two_candles_decode_with_the_right_stride() {
+        let mut values = candle_row("AAPL{=5m}");
+        values.extend(candle_row("MSFT{=5m}"));
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        assert_eq!(events.len(), 2);
+
+        match (&events[0], &events[1]) {
+            (MarketEvent::Candle(first), MarketEvent::Candle(second)) => {
+                // The symbols prove the stride of eight.
+                assert_eq!(first.event_symbol, "AAPL{=5m}");
+                assert_eq!(second.event_symbol, "MSFT{=5m}");
+                assert_eq!(first.time, 1_700_000_000_000);
+                assert_eq!(first.open, 149.0);
+                assert_eq!(first.high, 151.0);
+                assert_eq!(first.low, 148.5);
+                assert_eq!(first.close, 150.5);
+                assert_eq!(first.volume, 1_234_000.0);
+            }
+            other => panic!("expected two candles, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_fractional_time_is_rejected() {
+        let mut values = candle_row("AAPL{=5m}");
+        values[2] = json!(1.5);
+
+        let error = try_parse_compact_data(&batch(values)).expect_err("time is a whole number");
+        let text = error.to_string();
+        assert!(text.contains("time"), "the field is missing: {text}");
+        assert!(text.contains("whole number"), "unclear: {text}");
+    }
+
+    #[test]
+    fn test_a_truncated_candle_row_is_rejected() {
+        let mut values = candle_row("AAPL{=5m}");
+        values.pop();
+        assert!(try_parse_compact_data(&batch(values)).is_err());
+    }
+
+    #[test]
+    fn test_a_candle_is_not_mistaken_for_another_event() {
+        // MarketEvent is untagged, so serde keeps the first variant that
+        // deserializes. A candle must not come back as something else.
+        let events = try_parse_compact_data(&batch(candle_row("AAPL{=5m}"))).expect("well formed");
+        assert!(
+            matches!(events[0], MarketEvent::Candle(_)),
+            "decoded as the wrong variant: {:?}",
+            events[0]
+        );
+
+        let json = serde_json::to_string(&events[0]).expect("serialize");
+        let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");
+        assert!(
+            matches!(back, MarketEvent::Candle(_)),
+            "an untagged round trip picked the wrong variant: {back:?}"
+        );
     }
 }

--- a/tests/integration/dxlink_extra.rs
+++ b/tests/integration/dxlink_extra.rs
@@ -4,8 +4,8 @@
 //! Every assertion here used to be either commented out or replaced by a
 //! warning log, which is why subscription bugs could not fail the suite.
 
-use crate::fixture::{Behaviour, MockServer, is_type_on_channel};
-use dxlink::{DXLinkClient, EventType, FeedSubscription};
+use crate::fixture::{Behaviour, MockServer, expected, is_type_on_channel};
+use dxlink::{DXLinkClient, EventType, FeedSubscription, MarketEvent};
 
 /// Opens a connected client with a configured feed channel.
 async fn connected_feed(server: &MockServer, events: &[EventType]) -> (DXLinkClient, u32) {
@@ -102,50 +102,73 @@ async fn test_reset_subscriptions_sends_the_reset_flag() {
     client.disconnect().await.expect("failed to disconnect");
 }
 
-/// Historical data is requested by adding `fromTime`, but this client has no
-/// Candle decoder yet, so the request is refused rather than accepted into a
-/// stream that can never produce. Restore the delivery assertions here when the
-/// Candle decoder lands.
+/// Historical data is requested by adding `fromTime`, and now that Candle rows
+/// decode, the bars must actually arrive. The refusal this replaces was the
+/// honest behaviour while there was no decoder.
 #[tokio::test]
-async fn test_historical_subscription_is_refused_without_a_decoder() {
+async fn test_historical_candles_are_requested_and_delivered() {
     let server = MockServer::start(Behaviour::Normal).await;
     let mut client = DXLinkClient::new(&server.url(), "test-token");
-    client.connect().await.expect("failed to connect");
+    let mut stream = client.connect().await.expect("failed to connect");
     let channel_id = client
         .create_feed_channel("AUTO")
         .await
         .expect("failed to create feed channel");
-
-    // Configuring the channel for Candle is refused first.
-    assert!(
-        client
-            .setup_feed(channel_id, &[EventType::Candle])
-            .await
-            .is_err(),
-        "a type with no decoder must not be configurable"
-    );
-
-    // And so is subscribing, on a channel configured for something else.
     client
-        .setup_feed(channel_id, &[EventType::Quote])
+        .setup_feed(channel_id, &[EventType::Candle])
         .await
-        .expect("failed to set up feed");
+        .expect("Candle has a decoder now, so configuring it must work");
 
-    let result = client
+    // Fixed value rather than "now": the assertion is about faithful transport.
+    let from_time: i64 = 1_700_000_000_000;
+
+    client
         .subscribe(
             channel_id,
             vec![FeedSubscription {
                 event_type: "Candle".to_string(),
                 symbol: "AAPL{=5m}".to_string(),
-                from_time: Some(1_700_000_000_000),
+                from_time: Some(from_time),
                 source: None,
             }],
         )
+        .await
+        .expect("failed to subscribe to historical data");
+
+    let subscription = server
+        .wait_for("the historical subscription", |m| {
+            is_type_on_channel("FEED_SUBSCRIPTION", channel_id)(m) && m.get("add").is_some()
+        })
         .await;
-    assert!(
-        result.is_err(),
-        "an undecodable subscription must be refused"
+
+    let added = subscription["add"]
+        .as_array()
+        .expect("add should be a list");
+    assert_eq!(added[0]["symbol"], "AAPL{=5m}");
+    assert_eq!(
+        added[0]["fromTime"].as_i64(),
+        Some(from_time),
+        "fromTime must reach the wire unchanged"
     );
+
+    // And the bar comes back decoded.
+    let event = tokio::time::timeout(std::time::Duration::from_secs(5), stream.recv())
+        .await
+        .expect("no candle arrived")
+        .expect("the stream closed");
+
+    match event {
+        MarketEvent::Candle(candle) => {
+            assert_eq!(candle.event_symbol, "AAPL{=5m}");
+            assert_eq!(candle.time, expected::TIME);
+            assert_eq!(candle.open, expected::OPEN);
+            assert_eq!(candle.high, expected::HIGH);
+            assert_eq!(candle.low, expected::LOW);
+            assert_eq!(candle.close, expected::CLOSE);
+            assert_eq!(candle.volume, expected::VOLUME);
+        }
+        other => panic!("expected a candle, got {other:?}"),
+    }
 
     client.disconnect().await.expect("failed to disconnect");
 }

--- a/tests/integration/dxlink_extra.rs
+++ b/tests/integration/dxlink_extra.rs
@@ -5,7 +5,9 @@
 //! warning log, which is why subscription bugs could not fail the suite.
 
 use crate::fixture::{Behaviour, MockServer, expected, is_type_on_channel};
+use dxlink::events::CandleEvent;
 use dxlink::{DXLinkClient, EventType, FeedSubscription, MarketEvent};
+use std::sync::{Arc, Mutex};
 
 /// Opens a connected client with a configured feed channel.
 async fn connected_feed(server: &MockServer, events: &[EventType]) -> (DXLinkClient, u32) {
@@ -102,6 +104,28 @@ async fn test_reset_subscriptions_sends_the_reset_flag() {
     client.disconnect().await.expect("failed to disconnect");
 }
 
+/// Checks every column of a decoded bar. Both delivery paths run it, so a
+/// stride drift cannot pass by only being asserted on one of them.
+fn assert_full_candle(candle: &CandleEvent, path: &str) {
+    assert_eq!(candle.event_symbol, "AAPL{=5m}", "wrong symbol on {path}");
+    assert_eq!(candle.event_time, expected::EVENT_TIME, "on {path}");
+    assert_eq!(candle.event_flags, expected::EVENT_FLAGS, "on {path}");
+    assert_eq!(candle.index, expected::INDEX, "on {path}");
+    assert_eq!(candle.time, expected::TIME, "on {path}");
+    assert_eq!(candle.sequence, expected::SEQUENCE, "on {path}");
+    assert_eq!(candle.count, expected::COUNT, "on {path}");
+    assert_eq!(candle.open, expected::OPEN, "on {path}");
+    assert_eq!(candle.high, expected::HIGH, "on {path}");
+    assert_eq!(candle.low, expected::LOW, "on {path}");
+    assert_eq!(candle.close, expected::CLOSE, "on {path}");
+    assert_eq!(candle.volume, expected::VOLUME, "on {path}");
+    assert_eq!(candle.vwap, expected::VWAP, "on {path}");
+    assert_eq!(candle.bid_volume, expected::BID_VOLUME, "on {path}");
+    assert_eq!(candle.ask_volume, expected::ASK_VOLUME, "on {path}");
+    assert_eq!(candle.imp_volatility, expected::IMP_VOLATILITY, "on {path}");
+    assert_eq!(candle.open_interest, expected::OPEN_INTEREST, "on {path}");
+}
+
 /// Historical data is requested by adding `fromTime`, and now that Candle rows
 /// decode, the bars must actually arrive. The refusal this replaces was the
 /// honest behaviour while there was no decoder.
@@ -121,6 +145,15 @@ async fn test_historical_candles_are_requested_and_delivered() {
 
     // Fixed value rather than "now": the assertion is about faithful transport.
     let from_time: i64 = 1_700_000_000_000;
+
+    // The callback path routes by symbol through `symbol_of`, which needed a new
+    // arm for this variant. Registering here covers that arm; without it a
+    // missing arm would only show up as callbacks silently never firing.
+    let delivered = Arc::new(Mutex::new(Vec::new()));
+    let sink = delivered.clone();
+    client.on_event("AAPL{=5m}", move |event| {
+        sink.lock().expect("callback lock poisoned").push(event);
+    });
 
     client
         .subscribe(
@@ -157,27 +190,23 @@ async fn test_historical_candles_are_requested_and_delivered() {
         .expect("no candle arrived")
         .expect("the stream closed");
 
-    match event {
-        MarketEvent::Candle(candle) => {
-            assert_eq!(candle.event_symbol, "AAPL{=5m}");
-            assert_eq!(candle.event_time, expected::EVENT_TIME);
-            assert_eq!(candle.event_flags, expected::EVENT_FLAGS);
-            assert_eq!(candle.index, expected::INDEX);
-            assert_eq!(candle.time, expected::TIME);
-            assert_eq!(candle.sequence, expected::SEQUENCE);
-            assert_eq!(candle.count, expected::COUNT);
-            assert_eq!(candle.open, expected::OPEN);
-            assert_eq!(candle.high, expected::HIGH);
-            assert_eq!(candle.low, expected::LOW);
-            assert_eq!(candle.close, expected::CLOSE);
-            assert_eq!(candle.volume, expected::VOLUME);
-            assert_eq!(candle.vwap, expected::VWAP);
-            assert_eq!(candle.bid_volume, expected::BID_VOLUME);
-            assert_eq!(candle.ask_volume, expected::ASK_VOLUME);
-            assert_eq!(candle.imp_volatility, expected::IMP_VOLATILITY);
-            assert_eq!(candle.open_interest, expected::OPEN_INTEREST);
-        }
+    match &event {
+        MarketEvent::Candle(candle) => assert_full_candle(candle, "the stream"),
         other => panic!("expected a candle, got {other:?}"),
+    }
+
+    // The worker awaits the callback before pushing to the stream, so by the
+    // time the bar above arrived the callback had already run. Copy out of the
+    // lock in its own scope so no guard reaches the await below.
+    let seen: Vec<MarketEvent> = {
+        let events = delivered.lock().expect("callback lock poisoned");
+        events.clone()
+    };
+    match seen.as_slice() {
+        [MarketEvent::Candle(candle)] => assert_full_candle(candle, "the callback"),
+        other => {
+            panic!("the callback for AAPL{{=5m}} should have received one candle, got {other:?}")
+        }
     }
 
     client.disconnect().await.expect("failed to disconnect");

--- a/tests/integration/dxlink_extra.rs
+++ b/tests/integration/dxlink_extra.rs
@@ -160,12 +160,22 @@ async fn test_historical_candles_are_requested_and_delivered() {
     match event {
         MarketEvent::Candle(candle) => {
             assert_eq!(candle.event_symbol, "AAPL{=5m}");
+            assert_eq!(candle.event_time, expected::EVENT_TIME);
+            assert_eq!(candle.event_flags, expected::EVENT_FLAGS);
+            assert_eq!(candle.index, expected::INDEX);
             assert_eq!(candle.time, expected::TIME);
+            assert_eq!(candle.sequence, expected::SEQUENCE);
+            assert_eq!(candle.count, expected::COUNT);
             assert_eq!(candle.open, expected::OPEN);
             assert_eq!(candle.high, expected::HIGH);
             assert_eq!(candle.low, expected::LOW);
             assert_eq!(candle.close, expected::CLOSE);
             assert_eq!(candle.volume, expected::VOLUME);
+            assert_eq!(candle.vwap, expected::VWAP);
+            assert_eq!(candle.bid_volume, expected::BID_VOLUME);
+            assert_eq!(candle.ask_volume, expected::ASK_VOLUME);
+            assert_eq!(candle.imp_volatility, expected::IMP_VOLATILITY);
+            assert_eq!(candle.open_interest, expected::OPEN_INTEREST);
         }
         other => panic!("expected a candle, got {other:?}"),
     }

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -769,9 +769,9 @@ async fn test_setup_feed_refuses_a_type_it_cannot_decode() {
         .await
         .expect("failed to create feed channel");
 
-    match client.setup_feed(channel_id, &[EventType::Candle]).await {
+    match client.setup_feed(channel_id, &[EventType::Summary]).await {
         Err(DXLinkError::Protocol(msg)) => {
-            assert!(msg.contains("Candle"), "the type is missing: {msg}");
+            assert!(msg.contains("Summary"), "the type is missing: {msg}");
             // The error has to say what does work, or it is a dead end.
             assert!(msg.contains("Quote"), "the usable types are missing: {msg}");
         }

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -445,12 +445,22 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "size" => json!(75.0),
         "dayVolume" => json!(10_000_000.0),
         // Candle
+        "eventTime" => json!(1_700_000_000_500i64),
+        "eventFlags" => json!(0i64),
+        "index" => json!(7i64),
         "time" => json!(1_700_000_000_000i64),
+        "sequence" => json!(3i64),
+        "count" => json!(42i64),
         "open" => json!(149.0),
         "high" => json!(151.0),
         "low" => json!(148.5),
         "close" => json!(150.5),
         "volume" => json!(1_234_000.0),
+        "VWAP" => json!(150.1),
+        "bidVolume" => json!(600_000.0),
+        "askVolume" => json!(634_000.0),
+        "impVolatility" => json!(0.31),
+        "openInterest" => json!(4_200.0),
         // Greeks
         "delta" => json!(0.65),
         "gamma" => json!(0.05),
@@ -458,7 +468,13 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "vega" => json!(0.1),
         "rho" => json!(0.03),
         "volatility" => json!(0.25),
-        _ => Value::Null,
+        // Loud on purpose. A null here decodes as a wrong column type and the
+        // test fails several layers away with "no event arrived", which is a
+        // slow way to learn the fixture is missing a column.
+        unknown => panic!(
+            "the fixture has no value for column `{unknown}` of a {event_type}; \
+             add one when the event's field list grows"
+        ),
     }
 }
 
@@ -477,12 +493,22 @@ pub mod expected {
     pub const VEGA: f64 = 0.1;
     pub const RHO: f64 = 0.03;
     pub const VOLATILITY: f64 = 0.25;
+    pub const EVENT_TIME: i64 = 1_700_000_000_500;
+    pub const EVENT_FLAGS: i64 = 0;
+    pub const INDEX: i64 = 7;
     pub const TIME: i64 = 1_700_000_000_000;
+    pub const SEQUENCE: i64 = 3;
+    pub const COUNT: i64 = 42;
     pub const OPEN: f64 = 149.0;
     pub const HIGH: f64 = 151.0;
     pub const LOW: f64 = 148.5;
     pub const CLOSE: f64 = 150.5;
     pub const VOLUME: f64 = 1_234_000.0;
+    pub const VWAP: f64 = 150.1;
+    pub const BID_VOLUME: f64 = 600_000.0;
+    pub const ASK_VOLUME: f64 = 634_000.0;
+    pub const IMP_VOLATILITY: f64 = 0.31;
+    pub const OPEN_INTEREST: f64 = 4_200.0;
 }
 
 /// Convenience predicates for `wait_for`.

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -444,6 +444,13 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "price" => json!(151.25),
         "size" => json!(75.0),
         "dayVolume" => json!(10_000_000.0),
+        // Candle
+        "time" => json!(1_700_000_000_000i64),
+        "open" => json!(149.0),
+        "high" => json!(151.0),
+        "low" => json!(148.5),
+        "close" => json!(150.5),
+        "volume" => json!(1_234_000.0),
         // Greeks
         "delta" => json!(0.65),
         "gamma" => json!(0.05),
@@ -470,6 +477,12 @@ pub mod expected {
     pub const VEGA: f64 = 0.1;
     pub const RHO: f64 = 0.03;
     pub const VOLATILITY: f64 = 0.25;
+    pub const TIME: i64 = 1_700_000_000_000;
+    pub const OPEN: f64 = 149.0;
+    pub const HIGH: f64 = 151.0;
+    pub const LOW: f64 = 148.5;
+    pub const CLOSE: f64 = 150.5;
+    pub const VOLUME: f64 = 1_234_000.0;
 }
 
 /// Convenience predicates for `wait_for`.


### PR DESCRIPTION
## Summary

`Candle` completes the six-site checklist: enum variant, `CandleEvent` struct, field list in `compact_fields`, decoder arm, dispatch arm, docs.

Stacked on #51.

## This restores what #50 took away

Refusing undecodable types removed the ability to request historical bars — it reached the server before but could never produce an event here, so refusing was the honest behaviour. Now the bars decode, and the historical test asserts they **arrive with the right values** instead of asserting the refusal.

## Technical decisions

**Field names come from the dxFeed AsyncAPI schema, not from memory.** I pulled the spec and read `CandleEvent`'s properties rather than guessing: a wrong field name is not a compile error, it is a `FEED_SETUP` the server does not recognise. The subset requested is `time, open, high, low, close, volume` — the OHLC core, all decodable into plain types.

**`time` gets its own column reader.** It is a whole number of epoch milliseconds, so a fractional value is rejected rather than silently truncated into the wrong bar.

**`Candle` is declared last in `MarketEvent`.** The enum is `#[serde(untagged)]`, so serde keeps the first variant that deserializes; adding it after the existing three leaves their matching exactly as it was. There is a round-trip test that would catch one variant stealing another's payload.

## Public API impact

Additive: `CandleEvent`, `MarketEvent::Candle`. The new enum variant breaks downstream exhaustive matches on `MarketEvent` — worth a release note, and unavoidable for any new event type.

## Testing

- Two candles in one batch, symbols proving the stride of eight.
- A fractional `time` is rejected, naming the field.
- A truncated row is rejected.
- A candle decodes as `Candle` and survives an untagged round trip as one.
- The historical test subscribes with `fromTime` and asserts the bar arrives with every field intact.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #24
