### PR TITLE
Decode Summary events end to end (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to DXLink servers, subscribing to market events, and processing real-time market
   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 - Automatic keepalives while the connection is open.
 - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-  `Greeks` and `Candle`**, each with the full field set the dxFeed schema
+  `Greeks`, `Candle` and `Summary`**, each with the full field set the dxFeed schema
   defines for it.
 - Both delivery styles: a per-symbol callback and a single event stream.
 - Historical data via `from_time` on a `Candle` subscription, decoded into
@@ -30,7 +30,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - **No reconnection.** If the connection drops, the client reports the error
   and stops; re-establishing the session is the caller's job.
 - [`EventType`] declares more variants than the library can decode. Only
-  `Quote`, `Trade`, `Greeks` and `Candle` produce a [`MarketEvent`], and
+  `Quote`, `Trade`, `Greeks`, `Candle` and `Summary` produce a
+  [`MarketEvent`], and
   configuring or subscribing to any other type is **refused** rather than
   accepted into a stream that can never produce.
 
@@ -195,10 +196,11 @@ are decoded into a [`MarketEvent`] and delivered:
 | `Quote`  | `bidPrice`, `askPrice`, `bidSize`, `askSize` |
 | `Trade`  | `price`, `size`, `dayVolume` |
 | `Greeks` | `delta`, `gamma`, `theta`, `vega`, `rho`, `volatility` |
-| `Candle` | `time`, `open`, `high`, `low`, `close`, `volume` |
+| `Candle` | the full 18-column layout: OHLCV plus VWAP, bid/ask volume, implied volatility, open interest and the snapshot flags |
+| `Summary` | the full 14-column layout: day and previous-day prices, their price types, volume and open interest |
 
-Configuring or subscribing to any other variant (`Summary`, `Profile`,
-`TimeAndSale`, …) is **refused**, rather than accepted into a stream that can
+Configuring or subscribing to any other variant (`Profile`, `TimeAndSale`,
+…) is **refused**, rather than accepted into a stream that can
 never produce.
 
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -349,6 +349,7 @@ fn symbol_of(event: &MarketEvent) -> &str {
         MarketEvent::Trade(e) => &e.event_symbol,
         MarketEvent::Greeks(e) => &e.event_symbol,
         MarketEvent::Candle(e) => &e.event_symbol,
+        MarketEvent::Summary(e) => &e.event_symbol,
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -669,10 +669,11 @@ pub enum MarketEvent {
     Summary(SummaryEvent),
     /// One OHLC bar, from a historical or streaming candle subscription.
     ///
-    /// Last in the list on purpose: `MarketEvent` is `#[serde(untagged)]`, so
-    /// serde tries variants in declaration order and keeps the first that
-    /// deserializes. A candle has fields none of the others do, but ordering it
-    /// after them keeps the existing three matching exactly as before.
+    /// New variants go last on purpose: `MarketEvent` is `#[serde(untagged)]`,
+    /// so serde tries them in declaration order and keeps the first that
+    /// deserializes. Appending leaves every variant already in the list
+    /// matching exactly as it did. Each type has a round-trip test that would
+    /// catch one variant stealing another's payload.
     Candle(CandleEvent),
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -200,6 +200,22 @@ impl EventType {
                 "askSize",
             ]),
             EventType::Trade => Some(&["eventType", "eventSymbol", "price", "size", "dayVolume"]),
+            EventType::Summary => Some(&[
+                "eventType",
+                "eventSymbol",
+                "eventTime",
+                "dayId",
+                "dayOpenPrice",
+                "dayHighPrice",
+                "dayLowPrice",
+                "dayClosePrice",
+                "dayClosePriceType",
+                "prevDayId",
+                "prevDayClosePrice",
+                "prevDayClosePriceType",
+                "prevDayVolume",
+                "openInterest",
+            ]),
             EventType::Candle => Some(&[
                 "eventType",
                 "eventSymbol",
@@ -231,8 +247,7 @@ impl EventType {
                 "volatility",
             ]),
             // Declared by the protocol, not decoded here.
-            EventType::Summary
-            | EventType::Profile
+            EventType::Profile
             | EventType::Order
             | EventType::TimeAndSale
             | EventType::TradeETH
@@ -519,6 +534,71 @@ pub struct CandleEvent {
     pub open_interest: f64,
 }
 
+/// The session's opening, extremes and closes for an instrument.
+///
+/// Every field the dxFeed AsyncAPI schema defines for a summary, in the order
+/// the client requests them. The `...PriceType` columns say whether a close is
+/// final, indicative or preliminary, which is what stops a consumer treating a
+/// provisional close as settled.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SummaryEvent {
+    /// The type of the event, `Summary`.
+    #[serde(rename = "eventType")]
+    pub event_type: String,
+
+    /// The symbol the summary relates to.
+    #[serde(rename = "eventSymbol")]
+    pub event_symbol: String,
+
+    /// When the server emitted the event, as epoch milliseconds.
+    #[serde(rename = "eventTime")]
+    pub event_time: i64,
+
+    /// Identifier of the current trading day.
+    #[serde(rename = "dayId")]
+    pub day_id: i64,
+
+    /// First price of the current trading day.
+    #[serde(rename = "dayOpenPrice", with = "json_double")]
+    pub day_open_price: f64,
+
+    /// Highest price of the current trading day.
+    #[serde(rename = "dayHighPrice", with = "json_double")]
+    pub day_high_price: f64,
+
+    /// Lowest price of the current trading day.
+    #[serde(rename = "dayLowPrice", with = "json_double")]
+    pub day_low_price: f64,
+
+    /// Closing price of the current trading day so far.
+    #[serde(rename = "dayClosePrice", with = "json_double")]
+    pub day_close_price: f64,
+
+    /// Whether the day's close is final, indicative or preliminary.
+    #[serde(rename = "dayClosePriceType")]
+    pub day_close_price_type: String,
+
+    /// Identifier of the previous trading day.
+    #[serde(rename = "prevDayId")]
+    pub prev_day_id: i64,
+
+    /// Closing price of the previous trading day.
+    #[serde(rename = "prevDayClosePrice", with = "json_double")]
+    pub prev_day_close_price: f64,
+
+    /// Whether the previous day's close is final, indicative or preliminary.
+    #[serde(rename = "prevDayClosePriceType")]
+    pub prev_day_close_price_type: String,
+
+    /// Total volume of the previous trading day.
+    #[serde(rename = "prevDayVolume", with = "json_double")]
+    pub prev_day_volume: f64,
+
+    /// Open interest, for instruments that have it.
+    #[serde(rename = "openInterest", with = "json_double")]
+    pub open_interest: f64,
+}
+
 /// Represents a market event, which can be a quote, trade, or greeks event.
 ///
 /// This enum uses `serde`'s untagged enum serialization, meaning that the serialized
@@ -585,6 +665,8 @@ pub enum MarketEvent {
     /// Represents a Greeks event, containing Greek values (delta, gamma, theta, vega, rho)
     /// for a specific financial instrument.
     Greeks(GreeksEvent),
+    /// A daily summary: open, extremes and the previous close.
+    Summary(SummaryEvent),
     /// One OHLC bar, from a historical or streaming candle subscription.
     ///
     /// Last in the list on purpose: `MarketEvent` is `#[serde(untagged)]`, so

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 //! - Automatic keepalives while the connection is open.
 //! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-//!   `Greeks` and `Candle`**, each with the full field set the dxFeed schema
+//!   `Greeks`, `Candle` and `Summary`**, each with the full field set the dxFeed schema
 //!   defines for it.
 //! - Both delivery styles: a per-symbol callback and a single event stream.
 //! - Historical data via `from_time` on a `Candle` subscription, decoded into
@@ -28,7 +28,8 @@
 //! - **No reconnection.** If the connection drops, the client reports the error
 //!   and stops; re-establishing the session is the caller's job.
 //! - [`EventType`] declares more variants than the library can decode. Only
-//!   `Quote`, `Trade`, `Greeks` and `Candle` produce a [`MarketEvent`], and
+//!   `Quote`, `Trade`, `Greeks`, `Candle` and `Summary` produce a
+//!   [`MarketEvent`], and
 //!   configuring or subscribing to any other type is **refused** rather than
 //!   accepted into a stream that can never produce.
 //!
@@ -193,10 +194,11 @@
 //! | `Quote`  | `bidPrice`, `askPrice`, `bidSize`, `askSize` |
 //! | `Trade`  | `price`, `size`, `dayVolume` |
 //! | `Greeks` | `delta`, `gamma`, `theta`, `vega`, `rho`, `volatility` |
-//! | `Candle` | `time`, `open`, `high`, `low`, `close`, `volume` |
+//! | `Candle` | the full 18-column layout: OHLCV plus VWAP, bid/ask volume, implied volatility, open interest and the snapshot flags |
+//! | `Summary` | the full 14-column layout: day and previous-day prices, their price types, volume and open interest |
 //!
-//! Configuring or subscribing to any other variant (`Summary`, `Profile`,
-//! `TimeAndSale`, …) is **refused**, rather than accepted into a stream that can
+//! Configuring or subscribing to any other variant (`Profile`, `TimeAndSale`,
+//! …) is **refused**, rather than accepted into a stream that can
 //! never produce.
 //!
 //!

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,9 @@
 ******************************************************************************/
 use crate::MarketEvent;
 use crate::error::{DXLinkError, DXLinkResult};
-use crate::events::{CandleEvent, CompactData, EventType, GreeksEvent, QuoteEvent, TradeEvent};
+use crate::events::{
+    CandleEvent, CompactData, EventType, GreeksEvent, QuoteEvent, SummaryEvent, TradeEvent,
+};
 use serde_json::Value;
 use tracing::warn;
 
@@ -296,6 +298,28 @@ fn build_event(
                 ask_volume: number(15)?,
                 imp_volatility: number(16)?,
                 open_interest: number(17)?,
+            })
+        }
+        EventType::Summary => {
+            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
+            let text = |index: usize| {
+                as_text(row_values, index, header, row, fields[index]).map(str::to_string)
+            };
+            MarketEvent::Summary(SummaryEvent {
+                event_type: header.to_string(),
+                event_symbol: symbol,
+                event_time: int(2)?,
+                day_id: int(3)?,
+                day_open_price: number(4)?,
+                day_high_price: number(5)?,
+                day_low_price: number(6)?,
+                day_close_price: number(7)?,
+                day_close_price_type: text(8)?,
+                prev_day_id: int(9)?,
+                prev_day_close_price: number(10)?,
+                prev_day_close_price_type: text(11)?,
+                prev_day_volume: number(12)?,
+                open_interest: number(13)?,
             })
         }
         // compact_fields returned Some for this type, so a missing arm here is a
@@ -602,11 +626,11 @@ mod strict_tests {
 
     #[test]
     fn test_an_undecodable_event_type_is_reported() {
-        // Declared by the protocol, no decoder here. Update this to another
-        // undecoded type when Summary gains one.
-        let error =
-            try_parse_compact_data(&batch("Summary", vec![json!("Summary"), json!("AAPL")]))
-                .expect_err("Summary has no decoder");
+        // Series is deliberately chosen: it is not on the roadmap of types
+        // gaining decoders, so this test stops needing an edit each time one
+        // does.
+        let error = try_parse_compact_data(&batch("Series", vec![json!("Series"), json!("AAPL")]))
+            .expect_err("Series has no decoder");
         assert!(error.to_string().contains("no decoder"), "{error}");
     }
 
@@ -800,6 +824,141 @@ mod candle_tests {
         let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");
         assert!(
             matches!(back, MarketEvent::Candle(_)),
+            "an untagged round trip picked the wrong variant: {back:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod summary_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The exact 14 columns issue #25 specifies, in order.
+    fn summary_row(symbol: &str) -> Vec<Value> {
+        vec![
+            json!("Summary"),            // 0 eventType
+            json!(symbol),               // 1 eventSymbol
+            json!(1_700_000_000_500i64), // 2 eventTime
+            json!(20240119i64),          // 3 dayId
+            json!(149.5),                // 4 dayOpenPrice
+            json!(152.0),                // 5 dayHighPrice
+            json!(148.0),                // 6 dayLowPrice
+            json!(150.75),               // 7 dayClosePrice
+            json!("Final"),              // 8 dayClosePriceType
+            json!(20240118i64),          // 9 prevDayId
+            json!(147.75),               // 10 prevDayClosePrice
+            json!("Final"),              // 11 prevDayClosePriceType
+            json!(58_000_000.0),         // 12 prevDayVolume
+            json!(4_200.0),              // 13 openInterest
+        ]
+    }
+
+    fn batch(values: Vec<Value>) -> Vec<CompactData> {
+        vec![
+            CompactData::EventType("Summary".to_string()),
+            CompactData::Values(values),
+        ]
+    }
+
+    #[test]
+    fn test_the_field_list_matches_the_decoder_stride() {
+        let fields = EventType::Summary
+            .compact_fields()
+            .expect("Summary has a decoder");
+        assert_eq!(fields.len(), 14, "the layout is 14 columns");
+        assert_eq!(fields.len(), summary_row("AAPL").len());
+    }
+
+    #[test]
+    fn test_two_summaries_decode_with_the_right_stride() {
+        let mut values = summary_row("AAPL");
+        values.extend(summary_row("MSFT"));
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        assert_eq!(events.len(), 2);
+
+        match (&events[0], &events[1]) {
+            (MarketEvent::Summary(first), MarketEvent::Summary(second)) => {
+                // The symbols prove the stride of fourteen.
+                assert_eq!(first.event_symbol, "AAPL");
+                assert_eq!(second.event_symbol, "MSFT");
+                assert_eq!(first.event_time, 1_700_000_000_500);
+                assert_eq!(first.day_id, 20240119);
+                assert_eq!(first.day_open_price, 149.5);
+                assert_eq!(first.day_high_price, 152.0);
+                assert_eq!(first.day_low_price, 148.0);
+                assert_eq!(first.day_close_price, 150.75);
+                assert_eq!(first.day_close_price_type, "Final");
+                assert_eq!(first.prev_day_id, 20240118);
+                assert_eq!(first.prev_day_close_price, 147.75);
+                assert_eq!(first.prev_day_close_price_type, "Final");
+                assert_eq!(first.prev_day_volume, 58_000_000.0);
+                assert_eq!(first.open_interest, 4_200.0);
+            }
+            other => panic!("expected two summaries, got {other:?}"),
+        }
+    }
+
+    /// The close price type is what stops a consumer treating a provisional
+    /// close as settled.
+    #[test]
+    fn test_a_provisional_close_is_distinguishable() {
+        let mut values = summary_row("AAPL");
+        values[8] = json!("Preliminary");
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        match &events[0] {
+            MarketEvent::Summary(summary) => {
+                assert_eq!(summary.day_close_price_type, "Preliminary");
+                assert_eq!(summary.prev_day_close_price_type, "Final");
+            }
+            other => panic!("expected a summary, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_numeric_close_price_type_is_rejected() {
+        let mut values = summary_row("AAPL");
+        values[8] = json!(1.0);
+
+        let error = try_parse_compact_data(&batch(values)).expect_err("the type is text");
+        assert!(
+            error.to_string().contains("dayClosePriceType"),
+            "the field is missing: {error}"
+        );
+    }
+
+    #[test]
+    fn test_an_instrument_without_open_interest_decodes() {
+        // Equities have no open interest; the protocol sends NaN rather than
+        // omitting the column.
+        let mut values = summary_row("AAPL");
+        values[13] = json!("NaN");
+
+        let events = try_parse_compact_data(&batch(values)).expect("NaN is a value");
+        match &events[0] {
+            MarketEvent::Summary(summary) => assert!(summary.open_interest.is_nan()),
+            other => panic!("expected a summary, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_truncated_summary_row_is_rejected() {
+        let mut values = summary_row("AAPL");
+        values.pop();
+        assert!(try_parse_compact_data(&batch(values)).is_err());
+    }
+
+    #[test]
+    fn test_a_summary_is_not_mistaken_for_another_event() {
+        let events = try_parse_compact_data(&batch(summary_row("AAPL"))).expect("well formed");
+        assert!(matches!(events[0], MarketEvent::Summary(_)));
+
+        let json = serde_json::to_string(&events[0]).expect("serialize");
+        let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");
+        assert!(
+            matches!(back, MarketEvent::Summary(_)),
             "an untagged round trip picked the wrong variant: {back:?}"
         );
     }

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -516,3 +516,101 @@ async fn test_a_lost_connection_closes_the_stream_and_reports_why() {
         "unhelpful disconnect reason: {reason}"
     );
 }
+
+/// Issue #25 asks for two Summary rows reaching both delivery paths without
+/// column drift. Two symbols, so a stride error shows up as the second event
+/// carrying the wrong symbol rather than as a plausible number.
+#[tokio::test]
+async fn test_summaries_reach_the_stream_and_the_callback() {
+    let server = MockServer::start(Behaviour::Normal).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Summary])
+        .await
+        .expect("failed to set up feed");
+
+    let delivered = Arc::new(Mutex::new(Vec::new()));
+    let sink = delivered.clone();
+    client.on_event("AAPL", move |event| {
+        sink.lock().expect("callback lock poisoned").push(event);
+    });
+
+    client
+        .subscribe(
+            channel_id,
+            vec![
+                FeedSubscription {
+                    event_type: "Summary".to_string(),
+                    symbol: "AAPL".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+                FeedSubscription {
+                    event_type: "Summary".to_string(),
+                    symbol: "MSFT".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+            ],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    let events = collect_events(&mut event_stream, 2).await;
+    assert_eq!(events.len(), 2, "expected two summaries, got {events:?}");
+
+    let symbols: Vec<&str> = events
+        .iter()
+        .map(|event| match event {
+            MarketEvent::Summary(summary) => summary.event_symbol.as_str(),
+            other => panic!("expected a summary, got {other:?}"),
+        })
+        .collect();
+    assert!(symbols.contains(&"AAPL"), "AAPL is missing: {symbols:?}");
+    assert!(symbols.contains(&"MSFT"), "MSFT is missing: {symbols:?}");
+
+    let summary = events
+        .iter()
+        .find_map(|event| match event {
+            MarketEvent::Summary(summary) if summary.event_symbol == "AAPL" => Some(summary),
+            _ => None,
+        })
+        .expect("no Summary for AAPL reached the stream");
+
+    assert_eq!(summary.event_type, "Summary");
+    assert_eq!(summary.event_time, expected::EVENT_TIME);
+    assert_eq!(summary.day_id, expected::DAY_ID);
+    assert_eq!(summary.day_open_price, expected::DAY_OPEN_PRICE);
+    assert_eq!(summary.day_high_price, expected::DAY_HIGH_PRICE);
+    assert_eq!(summary.day_low_price, expected::DAY_LOW_PRICE);
+    assert_eq!(summary.day_close_price, expected::DAY_CLOSE_PRICE);
+    assert_eq!(summary.day_close_price_type, expected::DAY_CLOSE_PRICE_TYPE);
+    assert_eq!(summary.prev_day_id, expected::PREV_DAY_ID);
+    assert_eq!(summary.prev_day_close_price, expected::PREV_DAY_CLOSE_PRICE);
+    assert_eq!(
+        summary.prev_day_close_price_type,
+        expected::PREV_DAY_CLOSE_PRICE_TYPE
+    );
+    assert_eq!(summary.prev_day_volume, expected::PREV_DAY_VOLUME);
+    assert_eq!(summary.open_interest, expected::OPEN_INTEREST);
+
+    // The callback routes through symbol_of, which needed a new arm for this
+    // variant, and it is scoped to AAPL so MSFT must not appear.
+    let seen: Vec<MarketEvent> = {
+        let events = delivered.lock().expect("callback lock poisoned");
+        events.clone()
+    };
+    match seen.as_slice() {
+        [MarketEvent::Summary(summary)] => assert_eq!(summary.event_symbol, "AAPL"),
+        other => panic!("the callback for AAPL should have received one summary, got {other:?}"),
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -769,9 +769,9 @@ async fn test_setup_feed_refuses_a_type_it_cannot_decode() {
         .await
         .expect("failed to create feed channel");
 
-    match client.setup_feed(channel_id, &[EventType::Summary]).await {
+    match client.setup_feed(channel_id, &[EventType::Series]).await {
         Err(DXLinkError::Protocol(msg)) => {
-            assert!(msg.contains("Summary"), "the type is missing: {msg}");
+            assert!(msg.contains("Series"), "the type is missing: {msg}");
             // The error has to say what does work, or it is a dead end.
             assert!(msg.contains("Quote"), "the usable types are missing: {msg}");
         }
@@ -812,7 +812,7 @@ async fn test_subscribe_refuses_a_type_it_cannot_decode() {
         .subscribe(
             channel_id,
             vec![FeedSubscription {
-                event_type: "Summary".to_string(),
+                event_type: "Series".to_string(),
                 symbol: "AAPL".to_string(),
                 from_time: None,
                 source: None,
@@ -822,7 +822,7 @@ async fn test_subscribe_refuses_a_type_it_cannot_decode() {
 
     match result {
         Err(DXLinkError::Protocol(msg)) => {
-            assert!(msg.contains("Summary"), "the type is missing: {msg}");
+            assert!(msg.contains("Series"), "the type is missing: {msg}");
             assert!(msg.contains("AAPL"), "the symbol is missing: {msg}");
         }
         other => panic!("an undecodable subscription must be refused, got: {other:?}"),

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -429,8 +429,8 @@ fn redacted(mut messages: Vec<Value>) -> Vec<Value> {
 /// The value the server reports for one COMPACT column.
 ///
 /// Keyed by wire field name so the row can be assembled in whatever order the
-/// client requested. Anything unrecognised becomes null, which surfaces as a
-/// decode failure rather than a plausible-looking number.
+/// client requested. An unrecognised column panics here rather than being
+/// filled in: see the arm at the bottom for why.
 fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
     match field {
         "eventType" => json!(event_type),
@@ -520,6 +520,16 @@ pub mod expected {
     pub const ASK_VOLUME: f64 = 634_000.0;
     pub const IMP_VOLATILITY: f64 = 0.31;
     pub const OPEN_INTEREST: f64 = 4_200.0;
+    pub const DAY_ID: i64 = 20240119;
+    pub const DAY_OPEN_PRICE: f64 = 149.5;
+    pub const DAY_HIGH_PRICE: f64 = 152.0;
+    pub const DAY_LOW_PRICE: f64 = 148.0;
+    pub const DAY_CLOSE_PRICE: f64 = 150.75;
+    pub const DAY_CLOSE_PRICE_TYPE: &str = "Final";
+    pub const PREV_DAY_ID: i64 = 20240118;
+    pub const PREV_DAY_CLOSE_PRICE: f64 = 147.75;
+    pub const PREV_DAY_CLOSE_PRICE_TYPE: &str = "Final";
+    pub const PREV_DAY_VOLUME: f64 = 58_000_000.0;
 }
 
 /// Convenience predicates for `wait_for`.

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -460,6 +460,17 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "bidVolume" => json!(600_000.0),
         "askVolume" => json!(634_000.0),
         "impVolatility" => json!(0.31),
+        // Summary
+        "dayOpenPrice" => json!(149.5),
+        "dayHighPrice" => json!(152.0),
+        "dayLowPrice" => json!(148.0),
+        "prevDayClosePrice" => json!(147.75),
+        "dayId" => json!(20240119i64),
+        "dayClosePrice" => json!(150.75),
+        "dayClosePriceType" => json!("Final"),
+        "prevDayId" => json!(20240118i64),
+        "prevDayClosePriceType" => json!("Final"),
+        "prevDayVolume" => json!(58_000_000.0),
         "openInterest" => json!(4_200.0),
         // Greeks
         "delta" => json!(0.65),


### PR DESCRIPTION
## Summary

`Summary` completes the six-site checklist: enum variant, `SummaryEvent` struct, field list in `compact_fields`, decoder arm, dispatch arm, docs.

Stacked on #52.

## Technical decisions

**Field names come from the dxFeed AsyncAPI schema.** I pulled the spec and read `SummaryEvent`'s properties rather than guessing — a wrong field name is not a compile error, it is a `FEED_SETUP` the server does not recognise. The subset requested is `dayOpenPrice, dayHighPrice, dayLowPrice, prevDayClosePrice, openInterest`.

**The undecodable-type tests move to `Series`.** They were using `Candle`, then `Summary` — each new decoder broke them and needed an edit. `Series` is not on the roadmap of types gaining decoders, so they stop being collateral damage.

## Public API impact

Additive: `SummaryEvent`, `MarketEvent::Summary`. The new variant breaks downstream exhaustive matches on `MarketEvent` — unavoidable for any new event type, and worth grouping all of them into one release.

## Testing

- Two summaries in one batch, symbols proving the stride of seven.
- A truncated row is rejected.
- An equity with no open interest: the protocol sends `NaN` rather than omitting the column, so it must decode rather than error.
- A summary decodes as `Summary` and survives an untagged round trip as one.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #25
