### PR TITLE
Decode TimeAndSale events end to end (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 - Automatic keepalives while the connection is open.
 - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-  `Greeks`, `Candle` and `Summary`**, each with the full field set the dxFeed schema
-  defines for it.
+  `Greeks`, `Candle`, `Summary` and `TimeAndSale`**, each with the full field set
+  the dxFeed schema defines for it.
 - Both delivery styles: a per-symbol callback and a single event stream.
 - Historical data via `from_time` on a `Candle` subscription, decoded into
   OHLC bars.
@@ -30,7 +30,7 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - **No reconnection.** If the connection drops, the client reports the error
   and stops; re-establishing the session is the caller's job.
 - [`EventType`] declares more variants than the library can decode. Only
-  `Quote`, `Trade`, `Greeks`, `Candle` and `Summary` produce a
+  `Quote`, `Trade`, `Greeks`, `Candle`, `Summary` and `TimeAndSale` produce a
   [`MarketEvent`], and
   configuring or subscribing to any other type is **refused** rather than
   accepted into a stream that can never produce.
@@ -198,8 +198,9 @@ are decoded into a [`MarketEvent`] and delivered:
 | `Greeks` | `delta`, `gamma`, `theta`, `vega`, `rho`, `volatility` |
 | `Candle` | the full 18-column layout: OHLCV plus VWAP, bid/ask volume, implied volatility, open interest and the snapshot flags |
 | `Summary` | the full 14-column layout: day and previous-day prices, their price types, volume and open interest |
+| `TimeAndSale` | the full 22-column layout: price, size and the surrounding quote plus exchange, sale conditions, aggressor side and the print flags |
 
-Configuring or subscribing to any other variant (`Profile`, `TimeAndSale`,
+Configuring or subscribing to any other variant (`Profile`, `Underlying`,
 …) is **refused**, rather than accepted into a stream that can
 never produce.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -350,6 +350,7 @@ fn symbol_of(event: &MarketEvent) -> &str {
         MarketEvent::Greeks(e) => &e.event_symbol,
         MarketEvent::Candle(e) => &e.event_symbol,
         MarketEvent::Summary(e) => &e.event_symbol,
+        MarketEvent::TimeAndSale(e) => &e.event_symbol,
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -182,10 +182,10 @@ impl EventType {
     /// The COMPACT field list this client requests for the event type, in the
     /// exact order the decoder reads it.
     ///
-    /// This is what `setup_feed` requests and what the `FEED_CONFIG` reply is
-    /// validated against. The decoder in `utils.rs` still carries its own
-    /// positions, so the contract is not yet enforced from one definition —
-    /// moving the decoder onto this list is the next step.
+    /// This is what `setup_feed` requests, what the `FEED_CONFIG` reply is
+    /// validated against, and what drives the decoder's stride in `utils.rs` —
+    /// one definition, so the request and the layout being read cannot drift
+    /// apart.
     ///
     /// `None` means this client has no decoder for the type: it can be named,
     /// but no row can be turned into a [`MarketEvent`](crate::MarketEvent).
@@ -236,6 +236,30 @@ impl EventType {
                 "impVolatility",
                 "openInterest",
             ]),
+            EventType::TimeAndSale => Some(&[
+                "eventType",
+                "eventSymbol",
+                "eventTime",
+                "eventFlags",
+                "index",
+                "time",
+                "timeNanoPart",
+                "sequence",
+                "exchangeCode",
+                "price",
+                "size",
+                "bidPrice",
+                "askPrice",
+                "exchangeSaleConditions",
+                "tradeThroughExempt",
+                "aggressorSide",
+                "spreadLeg",
+                "extendedTradingHours",
+                "validTick",
+                "type",
+                "buyer",
+                "seller",
+            ]),
             EventType::Greeks => Some(&[
                 "eventType",
                 "eventSymbol",
@@ -249,7 +273,6 @@ impl EventType {
             // Declared by the protocol, not decoded here.
             EventType::Profile
             | EventType::Order
-            | EventType::TimeAndSale
             | EventType::TradeETH
             | EventType::SpreadOrder
             | EventType::TheoPrice
@@ -599,6 +622,105 @@ pub struct SummaryEvent {
     pub open_interest: f64,
 }
 
+/// One execution as it printed, with the quote that stood around it.
+///
+/// Every field the dxFeed AsyncAPI schema defines for a trade print, in the
+/// order the client requests them. The metadata is the reason to use this
+/// instead of `Trade`: `exchange_sale_conditions` and `sale_type` say whether a
+/// print is eligible for the consolidated tape or is a correction of an earlier
+/// one, and `valid_tick` says whether it should move the last price at all.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TimeAndSaleEvent {
+    /// The type of the event, `TimeAndSale`.
+    #[serde(rename = "eventType")]
+    pub event_type: String,
+
+    /// The symbol that traded.
+    #[serde(rename = "eventSymbol")]
+    pub event_symbol: String,
+
+    /// When the server emitted the event, as epoch milliseconds.
+    #[serde(rename = "eventTime")]
+    pub event_time: i64,
+
+    /// Transactional and snapshot bits for this print.
+    ///
+    /// Time and sale is an indexed event, so a subscription with `fromTime`
+    /// replays history as a snapshot delimited by these flags.
+    #[serde(rename = "eventFlags")]
+    pub event_flags: i64,
+
+    /// Unique index of the print, ordering it within the stream.
+    pub index: i64,
+
+    /// When the print happened, as epoch milliseconds.
+    pub time: i64,
+
+    /// Sub-millisecond part of `time`, in nanoseconds.
+    #[serde(rename = "timeNanoPart")]
+    pub time_nano_part: i64,
+
+    /// Sequence number, separating prints that share a millisecond.
+    pub sequence: i64,
+
+    /// Exchange the print came from, as its single-character code.
+    #[serde(rename = "exchangeCode")]
+    pub exchange_code: String,
+
+    /// Execution price.
+    #[serde(with = "json_double")]
+    pub price: f64,
+
+    /// Executed size.
+    #[serde(with = "json_double")]
+    pub size: f64,
+
+    /// Bid at the time of the print, `NaN` when it was not known.
+    #[serde(rename = "bidPrice", with = "json_double")]
+    pub bid_price: f64,
+
+    /// Ask at the time of the print, `NaN` when it was not known.
+    #[serde(rename = "askPrice", with = "json_double")]
+    pub ask_price: f64,
+
+    /// Sale conditions the exchange reported, as their raw codes.
+    #[serde(rename = "exchangeSaleConditions")]
+    pub exchange_sale_conditions: String,
+
+    /// Trade-through exempt flag, as the single-character regulatory code.
+    #[serde(rename = "tradeThroughExempt")]
+    pub trade_through_exempt: String,
+
+    /// Which side initiated the trade: `Buy`, `Sell` or `Undefined`.
+    #[serde(rename = "aggressorSide")]
+    pub aggressor_side: String,
+
+    /// Whether the print is one leg of a spread.
+    #[serde(rename = "spreadLeg")]
+    pub spread_leg: bool,
+
+    /// Whether the print happened outside regular trading hours.
+    #[serde(rename = "extendedTradingHours")]
+    pub extended_trading_hours: bool,
+
+    /// Whether the print is eligible to update the last price.
+    #[serde(rename = "validTick")]
+    pub valid_tick: bool,
+
+    /// Whether this is a new print, a correction, or a cancellation.
+    ///
+    /// Named `sale_type` because the wire name `type` is a Rust keyword; the
+    /// serialized field is still `type`.
+    #[serde(rename = "type")]
+    pub sale_type: String,
+
+    /// Buying party, when the venue discloses it.
+    pub buyer: String,
+
+    /// Selling party, when the venue discloses it.
+    pub seller: String,
+}
+
 /// Represents a market event, which can be a quote, trade, or greeks event.
 ///
 /// This enum uses `serde`'s untagged enum serialization, meaning that the serialized
@@ -668,13 +790,15 @@ pub enum MarketEvent {
     /// A daily summary: open, extremes and the previous close.
     Summary(SummaryEvent),
     /// One OHLC bar, from a historical or streaming candle subscription.
+    Candle(CandleEvent),
+    /// One execution as it printed, with the surrounding quote.
     ///
     /// New variants go last on purpose: `MarketEvent` is `#[serde(untagged)]`,
     /// so serde tries them in declaration order and keeps the first that
     /// deserializes. Appending leaves every variant already in the list
     /// matching exactly as it did. Each type has a round-trip test that would
     /// catch one variant stealing another's payload.
-    Candle(CandleEvent),
+    TimeAndSale(TimeAndSaleEvent),
 }
 
 /// Represents compact data, which can be either an event type (string) or a vector of JSON values.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 //!   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 //! - Automatic keepalives while the connection is open.
 //! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-//!   `Greeks`, `Candle` and `Summary`**, each with the full field set the dxFeed schema
-//!   defines for it.
+//!   `Greeks`, `Candle`, `Summary` and `TimeAndSale`**, each with the full field set
+//!   the dxFeed schema defines for it.
 //! - Both delivery styles: a per-symbol callback and a single event stream.
 //! - Historical data via `from_time` on a `Candle` subscription, decoded into
 //!   OHLC bars.
@@ -28,7 +28,7 @@
 //! - **No reconnection.** If the connection drops, the client reports the error
 //!   and stops; re-establishing the session is the caller's job.
 //! - [`EventType`] declares more variants than the library can decode. Only
-//!   `Quote`, `Trade`, `Greeks`, `Candle` and `Summary` produce a
+//!   `Quote`, `Trade`, `Greeks`, `Candle`, `Summary` and `TimeAndSale` produce a
 //!   [`MarketEvent`], and
 //!   configuring or subscribing to any other type is **refused** rather than
 //!   accepted into a stream that can never produce.
@@ -196,8 +196,9 @@
 //! | `Greeks` | `delta`, `gamma`, `theta`, `vega`, `rho`, `volatility` |
 //! | `Candle` | the full 18-column layout: OHLCV plus VWAP, bid/ask volume, implied volatility, open interest and the snapshot flags |
 //! | `Summary` | the full 14-column layout: day and previous-day prices, their price types, volume and open interest |
+//! | `TimeAndSale` | the full 22-column layout: price, size and the surrounding quote plus exchange, sale conditions, aggressor side and the print flags |
 //!
-//! Configuring or subscribing to any other variant (`Profile`, `TimeAndSale`,
+//! Configuring or subscribing to any other variant (`Profile`, `Underlying`,
 //! …) is **refused**, rather than accepted into a stream that can
 //! never produce.
 //!

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,7 +6,8 @@
 use crate::MarketEvent;
 use crate::error::{DXLinkError, DXLinkResult};
 use crate::events::{
-    CandleEvent, CompactData, EventType, GreeksEvent, QuoteEvent, SummaryEvent, TradeEvent,
+    CandleEvent, CompactData, EventType, GreeksEvent, QuoteEvent, SummaryEvent, TimeAndSaleEvent,
+    TradeEvent,
 };
 use serde_json::Value;
 use tracing::warn;
@@ -146,6 +147,27 @@ fn as_double(
     as_json_double(&values[index]).ok_or_else(|| {
         DXLinkError::Protocol(format!(
             "{event_type} row {row}: field `{field}` should be a number, got {}",
+            values[index]
+        ))
+    })
+}
+
+/// A column that must be a boolean.
+///
+/// Strict on purpose: the protocol sends JSON `true`/`false` here, and treating
+/// `0`, `"false"` or `null` as false would turn a layout error into a plausible
+/// flag. A print wrongly marked `validTick` moves a last price that should not
+/// have moved.
+fn as_bool(
+    values: &[Value],
+    index: usize,
+    event_type: &str,
+    row: usize,
+    field: &str,
+) -> DXLinkResult<bool> {
+    values[index].as_bool().ok_or_else(|| {
+        DXLinkError::Protocol(format!(
+            "{event_type} row {row}: field `{field}` should be a boolean, got {}",
             values[index]
         ))
     })
@@ -320,6 +342,37 @@ fn build_event(
                 prev_day_close_price_type: text(11)?,
                 prev_day_volume: number(12)?,
                 open_interest: number(13)?,
+            })
+        }
+        EventType::TimeAndSale => {
+            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
+            let text = |index: usize| {
+                as_text(row_values, index, header, row, fields[index]).map(str::to_string)
+            };
+            let flag = |index: usize| as_bool(row_values, index, header, row, fields[index]);
+            MarketEvent::TimeAndSale(TimeAndSaleEvent {
+                event_type: header.to_string(),
+                event_symbol: symbol,
+                event_time: int(2)?,
+                event_flags: int(3)?,
+                index: int(4)?,
+                time: int(5)?,
+                time_nano_part: int(6)?,
+                sequence: int(7)?,
+                exchange_code: text(8)?,
+                price: number(9)?,
+                size: number(10)?,
+                bid_price: number(11)?,
+                ask_price: number(12)?,
+                exchange_sale_conditions: text(13)?,
+                trade_through_exempt: text(14)?,
+                aggressor_side: text(15)?,
+                spread_leg: flag(16)?,
+                extended_trading_hours: flag(17)?,
+                valid_tick: flag(18)?,
+                sale_type: text(19)?,
+                buyer: text(20)?,
+                seller: text(21)?,
             })
         }
         // compact_fields returned Some for this type, so a missing arm here is a
@@ -959,6 +1012,193 @@ mod summary_tests {
         let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");
         assert!(
             matches!(back, MarketEvent::Summary(_)),
+            "an untagged round trip picked the wrong variant: {back:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod time_and_sale_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The exact 22 columns issue #26 specifies, in order.
+    fn print_row(symbol: &str) -> Vec<Value> {
+        vec![
+            json!("TimeAndSale"),        // 0 eventType
+            json!(symbol),               // 1 eventSymbol
+            json!(1_700_000_000_500i64), // 2 eventTime
+            json!(0i64),                 // 3 eventFlags
+            json!(11i64),                // 4 index
+            json!(1_700_000_000_000i64), // 5 time
+            json!(250_000i64),           // 6 timeNanoPart
+            json!(3i64),                 // 7 sequence
+            json!("Q"),                  // 8 exchangeCode
+            json!(151.25),               // 9 price
+            json!(75.0),                 // 10 size
+            json!(151.2),                // 11 bidPrice
+            json!(151.3),                // 12 askPrice
+            json!("@ TI"),               // 13 exchangeSaleConditions
+            json!("X"),                  // 14 tradeThroughExempt
+            json!("Buy"),                // 15 aggressorSide
+            json!(false),                // 16 spreadLeg
+            json!(true),                 // 17 extendedTradingHours
+            json!(true),                 // 18 validTick
+            json!("NEW"),                // 19 type
+            json!("NSDQ"),               // 20 buyer
+            json!("NYSE"),               // 21 seller
+        ]
+    }
+
+    fn batch(values: Vec<Value>) -> Vec<CompactData> {
+        vec![
+            CompactData::EventType("TimeAndSale".to_string()),
+            CompactData::Values(values),
+        ]
+    }
+
+    #[test]
+    fn test_the_field_list_matches_the_decoder_stride() {
+        let fields = EventType::TimeAndSale
+            .compact_fields()
+            .expect("TimeAndSale has a decoder");
+        assert_eq!(fields.len(), 22, "the layout is 22 columns");
+        assert_eq!(fields.len(), print_row("AAPL").len());
+    }
+
+    #[test]
+    fn test_two_prints_decode_with_the_right_stride() {
+        let mut values = print_row("AAPL");
+        values.extend(print_row("MSFT"));
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        assert_eq!(events.len(), 2);
+
+        match (&events[0], &events[1]) {
+            (MarketEvent::TimeAndSale(first), MarketEvent::TimeAndSale(second)) => {
+                // The symbols prove the stride of twenty-two.
+                assert_eq!(first.event_symbol, "AAPL");
+                assert_eq!(second.event_symbol, "MSFT");
+                assert_eq!(first.event_time, 1_700_000_000_500);
+                assert_eq!(first.event_flags, 0);
+                assert_eq!(first.index, 11);
+                assert_eq!(first.time, 1_700_000_000_000);
+                assert_eq!(first.time_nano_part, 250_000);
+                assert_eq!(first.sequence, 3);
+                assert_eq!(first.exchange_code, "Q");
+                assert_eq!(first.price, 151.25);
+                assert_eq!(first.size, 75.0);
+                assert_eq!(first.bid_price, 151.2);
+                assert_eq!(first.ask_price, 151.3);
+                assert_eq!(first.exchange_sale_conditions, "@ TI");
+                assert_eq!(first.trade_through_exempt, "X");
+                assert_eq!(first.aggressor_side, "Buy");
+                assert!(!first.spread_leg);
+                assert!(first.extended_trading_hours);
+                assert!(first.valid_tick);
+                assert_eq!(first.sale_type, "NEW");
+                assert_eq!(first.buyer, "NSDQ");
+                assert_eq!(first.seller, "NYSE");
+            }
+            other => panic!("expected two prints, got {other:?}"),
+        }
+    }
+
+    /// The three booleans sit next to each other, so a one-column shift keeps
+    /// decoding and only changes which flag is which.
+    #[test]
+    fn test_the_flags_keep_their_own_columns() {
+        let mut values = print_row("AAPL");
+        values[16] = json!(true); // spreadLeg
+        values[17] = json!(false); // extendedTradingHours
+        values[18] = json!(false); // validTick
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        match &events[0] {
+            MarketEvent::TimeAndSale(print) => {
+                assert!(print.spread_leg);
+                assert!(!print.extended_trading_hours);
+                assert!(!print.valid_tick);
+            }
+            other => panic!("expected a print, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_numeric_flag_is_rejected() {
+        let mut values = print_row("AAPL");
+        // A layout that shifted a price into a flag column would land here.
+        values[18] = json!(1);
+
+        let error = try_parse_compact_data(&batch(values)).expect_err("the column is a boolean");
+        assert!(
+            error.to_string().contains("validTick"),
+            "the field is missing: {error}"
+        );
+        assert!(
+            error.to_string().contains("boolean"),
+            "the expected type is missing: {error}"
+        );
+    }
+
+    #[test]
+    fn test_a_numeric_sale_condition_is_rejected() {
+        let mut values = print_row("AAPL");
+        values[13] = json!(4.0);
+
+        let error = try_parse_compact_data(&batch(values)).expect_err("the column is text");
+        assert!(
+            error.to_string().contains("exchangeSaleConditions"),
+            "the field is missing: {error}"
+        );
+    }
+
+    #[test]
+    fn test_a_print_without_a_surrounding_quote_decodes() {
+        // Off-exchange prints arrive with no bid or ask; the protocol sends NaN
+        // rather than omitting the columns.
+        let mut values = print_row("AAPL");
+        values[11] = json!("NaN");
+        values[12] = json!("NaN");
+
+        let events = try_parse_compact_data(&batch(values)).expect("NaN is a value");
+        match &events[0] {
+            MarketEvent::TimeAndSale(print) => {
+                assert!(print.bid_price.is_nan());
+                assert!(print.ask_price.is_nan());
+                // The price itself still has to be a real number.
+                assert_eq!(print.price, 151.25);
+            }
+            other => panic!("expected a print, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_truncated_print_row_is_rejected() {
+        let mut values = print_row("AAPL");
+        values.pop();
+        assert!(try_parse_compact_data(&batch(values)).is_err());
+    }
+
+    #[test]
+    fn test_a_print_is_not_mistaken_for_another_event() {
+        let events = try_parse_compact_data(&batch(print_row("AAPL"))).expect("well formed");
+        assert!(matches!(events[0], MarketEvent::TimeAndSale(_)));
+
+        let json = serde_json::to_string(&events[0]).expect("serialize");
+        // The wire names have to survive the round trip, `type` included.
+        assert!(
+            json.contains("\"type\":\"NEW\""),
+            "wrong field name: {json}"
+        );
+        assert!(
+            json.contains("\"exchangeSaleConditions\""),
+            "wrong field name: {json}"
+        );
+
+        let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");
+        assert!(
+            matches!(back, MarketEvent::TimeAndSale(_)),
             "an untagged round trip picked the wrong variant: {back:?}"
         );
     }

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -614,3 +614,117 @@ async fn test_summaries_reach_the_stream_and_the_callback() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+/// Issue #26 asks for two prints reaching both delivery paths with their sale
+/// conditions, timestamps, prices and booleans intact.
+#[tokio::test]
+async fn test_prints_reach_the_stream_and_the_callback() {
+    let server = MockServer::start(Behaviour::Normal).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::TimeAndSale])
+        .await
+        .expect("failed to set up feed");
+
+    let delivered = Arc::new(Mutex::new(Vec::new()));
+    let sink = delivered.clone();
+    client.on_event("AAPL", move |event| {
+        sink.lock().expect("callback lock poisoned").push(event);
+    });
+
+    client
+        .subscribe(
+            channel_id,
+            vec![
+                FeedSubscription {
+                    event_type: "TimeAndSale".to_string(),
+                    symbol: "AAPL".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+                FeedSubscription {
+                    event_type: "TimeAndSale".to_string(),
+                    symbol: "MSFT".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+            ],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    let events = collect_events(&mut event_stream, 2).await;
+    assert_eq!(events.len(), 2, "expected two prints, got {events:?}");
+
+    let symbols: Vec<&str> = events
+        .iter()
+        .map(|event| match event {
+            MarketEvent::TimeAndSale(print) => print.event_symbol.as_str(),
+            other => panic!("expected a print, got {other:?}"),
+        })
+        .collect();
+    assert!(symbols.contains(&"AAPL"), "AAPL is missing: {symbols:?}");
+    assert!(symbols.contains(&"MSFT"), "MSFT is missing: {symbols:?}");
+
+    let print = events
+        .iter()
+        .find_map(|event| match event {
+            MarketEvent::TimeAndSale(print) if print.event_symbol == "AAPL" => Some(print),
+            _ => None,
+        })
+        .expect("no TimeAndSale for AAPL reached the stream");
+
+    assert_eq!(print.event_type, "TimeAndSale");
+    assert_eq!(print.event_time, expected::EVENT_TIME);
+    assert_eq!(print.event_flags, expected::EVENT_FLAGS);
+    assert_eq!(print.index, expected::INDEX);
+    assert_eq!(print.time, expected::TIME);
+    assert_eq!(print.time_nano_part, expected::TIME_NANO_PART);
+    assert_eq!(print.sequence, expected::SEQUENCE);
+    assert_eq!(print.exchange_code, expected::EXCHANGE_CODE);
+    assert_eq!(print.price, expected::PRICE);
+    assert_eq!(print.size, expected::SIZE);
+    assert_eq!(print.bid_price, expected::BID_PRICE);
+    assert_eq!(print.ask_price, expected::ASK_PRICE);
+    assert_eq!(
+        print.exchange_sale_conditions,
+        expected::EXCHANGE_SALE_CONDITIONS
+    );
+    assert_eq!(print.trade_through_exempt, expected::TRADE_THROUGH_EXEMPT);
+    assert_eq!(print.aggressor_side, expected::AGGRESSOR_SIDE);
+    assert_eq!(print.spread_leg, expected::SPREAD_LEG);
+    assert_eq!(
+        print.extended_trading_hours,
+        expected::EXTENDED_TRADING_HOURS
+    );
+    assert_eq!(print.valid_tick, expected::VALID_TICK);
+    assert_eq!(print.sale_type, expected::SALE_TYPE);
+    assert_eq!(print.buyer, expected::BUYER);
+    assert_eq!(print.seller, expected::SELLER);
+
+    // The callback routes through symbol_of, which needed a new arm for this
+    // variant, and it is scoped to AAPL so MSFT must not appear.
+    let seen: Vec<MarketEvent> = {
+        let events = delivered.lock().expect("callback lock poisoned");
+        events.clone()
+    };
+    match seen.as_slice() {
+        [MarketEvent::TimeAndSale(print)] => {
+            assert_eq!(print.event_symbol, "AAPL");
+            // The flags matter most on this path: a consumer acting on prints
+            // reads valid_tick before it moves a last price.
+            assert_eq!(print.valid_tick, expected::VALID_TICK);
+            assert_eq!(print.aggressor_side, expected::AGGRESSOR_SIDE);
+        }
+        other => panic!("the callback for AAPL should have received one print, got {other:?}"),
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -472,6 +472,18 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "prevDayClosePriceType" => json!("Final"),
         "prevDayVolume" => json!(58_000_000.0),
         "openInterest" => json!(4_200.0),
+        // TimeAndSale (time, price, size, bidPrice and askPrice are above)
+        "timeNanoPart" => json!(250_000i64),
+        "exchangeCode" => json!("Q"),
+        "exchangeSaleConditions" => json!("@ TI"),
+        "tradeThroughExempt" => json!("X"),
+        "aggressorSide" => json!("Buy"),
+        "spreadLeg" => json!(false),
+        "extendedTradingHours" => json!(true),
+        "validTick" => json!(true),
+        "type" => json!("NEW"),
+        "buyer" => json!("NSDQ"),
+        "seller" => json!("NYSE"),
         // Greeks
         "delta" => json!(0.65),
         "gamma" => json!(0.05),
@@ -530,6 +542,17 @@ pub mod expected {
     pub const PREV_DAY_CLOSE_PRICE: f64 = 147.75;
     pub const PREV_DAY_CLOSE_PRICE_TYPE: &str = "Final";
     pub const PREV_DAY_VOLUME: f64 = 58_000_000.0;
+    pub const TIME_NANO_PART: i64 = 250_000;
+    pub const EXCHANGE_CODE: &str = "Q";
+    pub const EXCHANGE_SALE_CONDITIONS: &str = "@ TI";
+    pub const TRADE_THROUGH_EXEMPT: &str = "X";
+    pub const AGGRESSOR_SIDE: &str = "Buy";
+    pub const SPREAD_LEG: bool = false;
+    pub const EXTENDED_TRADING_HOURS: bool = true;
+    pub const VALID_TICK: bool = true;
+    pub const SALE_TYPE: &str = "NEW";
+    pub const BUYER: &str = "NSDQ";
+    pub const SELLER: &str = "NYSE";
 }
 
 /// Convenience predicates for `wait_for`.


### PR DESCRIPTION
## Summary

`TimeAndSale` completes the six-site checklist: enum variant, struct, field list, decoder arm, dispatch arm, docs. The layout is the full 22 columns issue #26 specifies.

Stacked on #53, which has merged.

## Technical decisions

**Field names come from the dxFeed AsyncAPI schema**, not from memory — a wrong name is a `FEED_SETUP` the server does not recognise, which is not a compile error.

**The whole layout, not a subset.** The metadata is the reason to use this event instead of `Trade`: `exchangeSaleConditions` and `type` say whether a print is tape-eligible or a correction of an earlier one, and `validTick` says whether it should move the last price at all. A consumer that only sees price and size cannot make either decision.

**The decoder gained a strict `as_bool`.** The three flag columns sit next to each other, so reading `0`, `"false"` or `null` as false would turn a layout error into a plausible flag rather than an error — a print wrongly marked `validTick` moves a last price that should not have moved.

**`type` is a Rust keyword**, so the field is `sale_type` with `#[serde(rename = "type")]`. A test asserts the wire name survives serialization.

## Public API impact

Additive: `TimeAndSaleEvent`, `MarketEvent::TimeAndSale`. The new variant breaks downstream exhaustive matches on `MarketEvent`, so this is a 0.x minor bump.

## Testing

- The field list length is pinned against the decoder stride, so the two halves of the COMPACT contract cannot drift apart.
- Two prints in one batch, symbols proving the stride of 22.
- The three booleans keep their own columns — a one-column shift there keeps decoding and only changes which flag is which.
- A numeric value in a flag column and in a sale-conditions column are both rejected, naming the field and the expected type.
- An off-exchange print with no surrounding quote: the protocol sends `NaN` rather than dropping the columns, so it must decode rather than error.
- A truncated row is rejected.
- A print survives an untagged round trip as a `TimeAndSale`, with the wire field names intact.
- End to end against the mock server: two prints reach both the stream and a per-symbol callback with every column intact. Verified by mutation — swapping two field-list entries fails this test.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #26
