### PR TITLE
Decode Profile events end to end (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 - Automatic keepalives while the connection is open.
 - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-  `Greeks`, `Candle`, `Summary` and `TimeAndSale`**, each with the full field set
-  the dxFeed schema defines for it.
+  `Greeks`, `Candle`, `Summary`, `TimeAndSale` and `Profile`**, each with the full
+  field set the dxFeed schema defines for it.
 - Both delivery styles: a per-symbol callback and a single event stream.
 - Historical data via `from_time` on a `Candle` subscription, decoded into
   OHLC bars.
@@ -30,8 +30,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - **No reconnection.** If the connection drops, the client reports the error
   and stops; re-establishing the session is the caller's job.
 - [`EventType`] declares more variants than the library can decode. Only
-  `Quote`, `Trade`, `Greeks`, `Candle`, `Summary` and `TimeAndSale` produce a
-  [`MarketEvent`], and
+  `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale` and `Profile`
+  produce a [`MarketEvent`], and
   configuring or subscribing to any other type is **refused** rather than
   accepted into a stream that can never produce.
 
@@ -199,8 +199,9 @@ are decoded into a [`MarketEvent`] and delivered:
 | `Candle` | the full 18-column layout: OHLCV plus VWAP, bid/ask volume, implied volatility, open interest and the snapshot flags |
 | `Summary` | the full 14-column layout: day and previous-day prices, their price types, volume and open interest |
 | `TimeAndSale` | the full 22-column layout: price, size and the surrounding quote plus exchange, sale conditions, aggressor side and the print flags |
+| `Profile` | the full 20-column layout: description, trading status and halt window, price limits, 52-week range and the fundamentals |
 
-Configuring or subscribing to any other variant (`Profile`, `Underlying`,
+Configuring or subscribing to any other variant (`Underlying`, `TheoPrice`,
 …) is **refused**, rather than accepted into a stream that can
 never produce.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -351,6 +351,7 @@ fn symbol_of(event: &MarketEvent) -> &str {
         MarketEvent::Candle(e) => &e.event_symbol,
         MarketEvent::Summary(e) => &e.event_symbol,
         MarketEvent::TimeAndSale(e) => &e.event_symbol,
+        MarketEvent::Profile(e) => &e.event_symbol,
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -236,6 +236,28 @@ impl EventType {
                 "impVolatility",
                 "openInterest",
             ]),
+            EventType::Profile => Some(&[
+                "eventType",
+                "eventSymbol",
+                "eventTime",
+                "description",
+                "shortSaleRestriction",
+                "tradingStatus",
+                "statusReason",
+                "haltStartTime",
+                "haltEndTime",
+                "highLimitPrice",
+                "lowLimitPrice",
+                "high52WeekPrice",
+                "low52WeekPrice",
+                "beta",
+                "earningsPerShare",
+                "dividendFrequency",
+                "exDividendAmount",
+                "exDividendDayId",
+                "shares",
+                "freeFloat",
+            ]),
             EventType::TimeAndSale => Some(&[
                 "eventType",
                 "eventSymbol",
@@ -271,8 +293,7 @@ impl EventType {
                 "volatility",
             ]),
             // Declared by the protocol, not decoded here.
-            EventType::Profile
-            | EventType::Order
+            EventType::Order
             | EventType::TradeETH
             | EventType::SpreadOrder
             | EventType::TheoPrice
@@ -622,6 +643,95 @@ pub struct SummaryEvent {
     pub open_interest: f64,
 }
 
+/// Instrument metadata: what it is, whether it is tradable right now, and the
+/// fundamentals that frame a price.
+///
+/// Every field the dxFeed AsyncAPI schema defines for a profile, in the order
+/// the client requests them. `trading_status` and the halt window are the
+/// operational half — a price from a halted instrument is stale by definition —
+/// and the limit prices bound what the venue will accept at all.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProfileEvent {
+    /// The type of the event, `Profile`.
+    #[serde(rename = "eventType")]
+    pub event_type: String,
+
+    /// The symbol the profile describes.
+    #[serde(rename = "eventSymbol")]
+    pub event_symbol: String,
+
+    /// When the server emitted the event, as epoch milliseconds.
+    #[serde(rename = "eventTime")]
+    pub event_time: i64,
+
+    /// Human-readable description of the instrument.
+    pub description: String,
+
+    /// Short sale restriction state: `Active`, `Inactive` or `Undefined`.
+    #[serde(rename = "shortSaleRestriction")]
+    pub short_sale_restriction: String,
+
+    /// Whether trading is `Active`, `Halted` or `Undefined`.
+    #[serde(rename = "tradingStatus")]
+    pub trading_status: String,
+
+    /// Why trading is in its current status, when the venue gives a reason.
+    #[serde(rename = "statusReason")]
+    pub status_reason: String,
+
+    /// Start of the trading halt, as epoch milliseconds.
+    #[serde(rename = "haltStartTime")]
+    pub halt_start_time: i64,
+
+    /// End of the trading halt, as epoch milliseconds.
+    #[serde(rename = "haltEndTime")]
+    pub halt_end_time: i64,
+
+    /// Highest price the venue will accept today.
+    #[serde(rename = "highLimitPrice", with = "json_double")]
+    pub high_limit_price: f64,
+
+    /// Lowest price the venue will accept today.
+    #[serde(rename = "lowLimitPrice", with = "json_double")]
+    pub low_limit_price: f64,
+
+    /// Highest price over the last 52 weeks.
+    #[serde(rename = "high52WeekPrice", with = "json_double")]
+    pub high_52_week_price: f64,
+
+    /// Lowest price over the last 52 weeks.
+    #[serde(rename = "low52WeekPrice", with = "json_double")]
+    pub low_52_week_price: f64,
+
+    /// Beta against the market.
+    #[serde(with = "json_double")]
+    pub beta: f64,
+
+    /// Earnings per share.
+    #[serde(rename = "earningsPerShare", with = "json_double")]
+    pub earnings_per_share: f64,
+
+    /// Dividend payments per year.
+    #[serde(rename = "dividendFrequency", with = "json_double")]
+    pub dividend_frequency: f64,
+
+    /// Amount of the last dividend that went ex.
+    #[serde(rename = "exDividendAmount", with = "json_double")]
+    pub ex_dividend_amount: f64,
+
+    /// Day the last dividend went ex, as a day identifier.
+    #[serde(rename = "exDividendDayId")]
+    pub ex_dividend_day_id: i64,
+
+    /// Shares outstanding.
+    #[serde(with = "json_double")]
+    pub shares: f64,
+
+    /// Shares available to trade.
+    #[serde(rename = "freeFloat", with = "json_double")]
+    pub free_float: f64,
+}
+
 /// One execution as it printed, with the quote that stood around it.
 ///
 /// Every field the dxFeed AsyncAPI schema defines for a trade print, in the
@@ -792,13 +902,15 @@ pub enum MarketEvent {
     /// One OHLC bar, from a historical or streaming candle subscription.
     Candle(CandleEvent),
     /// One execution as it printed, with the surrounding quote.
+    TimeAndSale(TimeAndSaleEvent),
+    /// Instrument metadata: description, trading status and fundamentals.
     ///
     /// New variants go last on purpose: `MarketEvent` is `#[serde(untagged)]`,
     /// so serde tries them in declaration order and keeps the first that
     /// deserializes. Appending leaves every variant already in the list
     /// matching exactly as it did. Each type has a round-trip test that would
     /// catch one variant stealing another's payload.
-    TimeAndSale(TimeAndSaleEvent),
+    Profile(ProfileEvent),
 }
 
 /// Represents compact data, which can be either an event type (string) or a vector of JSON values.

--- a/src/events.rs
+++ b/src/events.rs
@@ -1479,3 +1479,203 @@ mod json_double_tests {
         assert!(error.contains("cheap"), "the value is missing: {error}");
     }
 }
+
+/// Serde coverage for the event types added after the original three.
+///
+/// The property is stronger than "the names look right": each struct's
+/// serialized key set has to equal that type's [`EventType::compact_fields`]
+/// list, which is the same list `setup_feed` sends. A `#[serde(rename)]` that
+/// drifts from the wire name fails here rather than on a live feed.
+#[cfg(test)]
+mod event_serde_tests {
+    use super::*;
+    use serde_json::{Value, from_str, to_string};
+
+    /// Asserts the serialized field names are exactly the layout, no more and
+    /// no less, and that the value survives a round trip.
+    fn assert_wire_contract<T>(event: &T, event_type: EventType)
+    where
+        T: Serialize + for<'de> Deserialize<'de>,
+    {
+        let serialized = to_string(event).expect("serialize");
+        let value: Value = from_str(&serialized).expect("valid JSON");
+        let object = value.as_object().expect("an event is an object");
+
+        let mut got: Vec<&str> = object.keys().map(String::as_str).collect();
+        got.sort_unstable();
+
+        let mut want: Vec<&str> = event_type
+            .compact_fields()
+            .expect("the type has a layout")
+            .to_vec();
+        want.sort_unstable();
+
+        assert_eq!(
+            got, want,
+            "{event_type}'s serde names do not match the fields it requests"
+        );
+
+        from_str::<T>(&serialized).expect("round trip");
+    }
+
+    fn candle() -> CandleEvent {
+        CandleEvent {
+            event_type: "Candle".to_string(),
+            event_symbol: "AAPL{=5m}".to_string(),
+            event_time: 1_700_000_000_500,
+            event_flags: 0,
+            index: 7,
+            time: 1_700_000_000_000,
+            sequence: 3,
+            count: 42,
+            open: 149.0,
+            high: 151.0,
+            low: 148.5,
+            close: 150.5,
+            volume: 1_234_000.0,
+            vwap: 150.1,
+            bid_volume: 600_000.0,
+            ask_volume: 634_000.0,
+            imp_volatility: 0.31,
+            open_interest: 4_200.0,
+        }
+    }
+
+    fn summary() -> SummaryEvent {
+        SummaryEvent {
+            event_type: "Summary".to_string(),
+            event_symbol: "AAPL".to_string(),
+            event_time: 1_700_000_000_500,
+            day_id: 20240119,
+            day_open_price: 149.5,
+            day_high_price: 152.0,
+            day_low_price: 148.0,
+            day_close_price: 150.75,
+            day_close_price_type: "Final".to_string(),
+            prev_day_id: 20240118,
+            prev_day_close_price: 147.75,
+            prev_day_close_price_type: "Final".to_string(),
+            prev_day_volume: 58_000_000.0,
+            open_interest: 4_200.0,
+        }
+    }
+
+    fn print() -> TimeAndSaleEvent {
+        TimeAndSaleEvent {
+            event_type: "TimeAndSale".to_string(),
+            event_symbol: "AAPL".to_string(),
+            event_time: 1_700_000_000_500,
+            event_flags: 0,
+            index: 11,
+            time: 1_700_000_000_000,
+            time_nano_part: 250_000,
+            sequence: 3,
+            exchange_code: "Q".to_string(),
+            price: 151.25,
+            size: 75.0,
+            bid_price: 151.2,
+            ask_price: 151.3,
+            exchange_sale_conditions: "@ TI".to_string(),
+            trade_through_exempt: "X".to_string(),
+            aggressor_side: "Buy".to_string(),
+            spread_leg: false,
+            extended_trading_hours: true,
+            valid_tick: true,
+            sale_type: "NEW".to_string(),
+            buyer: "NSDQ".to_string(),
+            seller: "NYSE".to_string(),
+        }
+    }
+
+    fn profile() -> ProfileEvent {
+        ProfileEvent {
+            event_type: "Profile".to_string(),
+            event_symbol: "AAPL".to_string(),
+            event_time: 1_700_000_000_500,
+            description: "Apple Inc. - Common Stock".to_string(),
+            short_sale_restriction: "Inactive".to_string(),
+            trading_status: "Halted".to_string(),
+            status_reason: "News pending".to_string(),
+            halt_start_time: 1_700_000_100_000,
+            halt_end_time: 1_700_000_900_000,
+            high_limit_price: 165.0,
+            low_limit_price: 135.0,
+            high_52_week_price: 199.62,
+            low_52_week_price: 124.17,
+            beta: 1.29,
+            earnings_per_share: 6.13,
+            dividend_frequency: 4.0,
+            ex_dividend_amount: 0.24,
+            ex_dividend_day_id: 20240209,
+            shares: 15_552_800_000.0,
+            free_float: 15_461_900_000.0,
+        }
+    }
+
+    #[test]
+    fn test_candle_serde_names_match_its_layout() {
+        assert_wire_contract(&candle(), EventType::Candle);
+    }
+
+    #[test]
+    fn test_summary_serde_names_match_its_layout() {
+        assert_wire_contract(&summary(), EventType::Summary);
+    }
+
+    #[test]
+    fn test_time_and_sale_serde_names_match_its_layout() {
+        assert_wire_contract(&print(), EventType::TimeAndSale);
+    }
+
+    #[test]
+    fn test_profile_serde_names_match_its_layout() {
+        assert_wire_contract(&profile(), EventType::Profile);
+    }
+
+    /// A FULL-format payload carries the non-finite doubles as strings, so the
+    /// structs have to read them back the same way the COMPACT decoder does.
+    #[test]
+    fn test_non_finite_doubles_survive_a_full_round_trip() {
+        let mut bar = candle();
+        bar.imp_volatility = f64::NAN;
+        let serialized = to_string(&bar).expect("serialize");
+        assert!(
+            serialized.contains("\"impVolatility\":\"NaN\""),
+            "NaN is not a JSON literal, it has to be the string: {serialized}"
+        );
+        let back: CandleEvent = from_str(&serialized).expect("round trip");
+        assert!(back.imp_volatility.is_nan());
+
+        let mut instrument = profile();
+        instrument.high_limit_price = f64::INFINITY;
+        instrument.shares = f64::NAN;
+        let serialized = to_string(&instrument).expect("serialize");
+        assert!(
+            serialized.contains("\"highLimitPrice\":\"Infinity\""),
+            "wrong encoding: {serialized}"
+        );
+        let back: ProfileEvent = from_str(&serialized).expect("round trip");
+        assert_eq!(back.high_limit_price, f64::INFINITY);
+        assert!(back.shares.is_nan());
+    }
+
+    /// Untagged deserialization keeps the first variant that fits, so each new
+    /// type has to still come back as itself.
+    #[test]
+    fn test_each_new_type_round_trips_as_its_own_variant() {
+        for event in [
+            MarketEvent::Candle(candle()),
+            MarketEvent::Summary(summary()),
+            MarketEvent::TimeAndSale(print()),
+            MarketEvent::Profile(profile()),
+        ] {
+            let serialized = to_string(&event).expect("serialize");
+            let back: MarketEvent = from_str(&serialized).expect("round trip");
+            assert_eq!(
+                std::mem::discriminant(&event),
+                std::mem::discriminant(&back),
+                "an untagged round trip picked the wrong variant for {serialized}"
+            );
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 //!   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 //! - Automatic keepalives while the connection is open.
 //! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-//!   `Greeks`, `Candle`, `Summary` and `TimeAndSale`**, each with the full field set
-//!   the dxFeed schema defines for it.
+//!   `Greeks`, `Candle`, `Summary`, `TimeAndSale` and `Profile`**, each with the full
+//!   field set the dxFeed schema defines for it.
 //! - Both delivery styles: a per-symbol callback and a single event stream.
 //! - Historical data via `from_time` on a `Candle` subscription, decoded into
 //!   OHLC bars.
@@ -28,8 +28,8 @@
 //! - **No reconnection.** If the connection drops, the client reports the error
 //!   and stops; re-establishing the session is the caller's job.
 //! - [`EventType`] declares more variants than the library can decode. Only
-//!   `Quote`, `Trade`, `Greeks`, `Candle`, `Summary` and `TimeAndSale` produce a
-//!   [`MarketEvent`], and
+//!   `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale` and `Profile`
+//!   produce a [`MarketEvent`], and
 //!   configuring or subscribing to any other type is **refused** rather than
 //!   accepted into a stream that can never produce.
 //!
@@ -197,8 +197,9 @@
 //! | `Candle` | the full 18-column layout: OHLCV plus VWAP, bid/ask volume, implied volatility, open interest and the snapshot flags |
 //! | `Summary` | the full 14-column layout: day and previous-day prices, their price types, volume and open interest |
 //! | `TimeAndSale` | the full 22-column layout: price, size and the surrounding quote plus exchange, sale conditions, aggressor side and the print flags |
+//! | `Profile` | the full 20-column layout: description, trading status and halt window, price limits, 52-week range and the fundamentals |
 //!
-//! Configuring or subscribing to any other variant (`Profile`, `Underlying`,
+//! Configuring or subscribing to any other variant (`Underlying`, `TheoPrice`,
 //! …) is **refused**, rather than accepted into a stream that can
 //! never produce.
 //!

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,8 +6,8 @@
 use crate::MarketEvent;
 use crate::error::{DXLinkError, DXLinkResult};
 use crate::events::{
-    CandleEvent, CompactData, EventType, GreeksEvent, QuoteEvent, SummaryEvent, TimeAndSaleEvent,
-    TradeEvent,
+    CandleEvent, CompactData, EventType, GreeksEvent, ProfileEvent, QuoteEvent, SummaryEvent,
+    TimeAndSaleEvent, TradeEvent,
 };
 use serde_json::Value;
 use tracing::warn;
@@ -373,6 +373,34 @@ fn build_event(
                 sale_type: text(19)?,
                 buyer: text(20)?,
                 seller: text(21)?,
+            })
+        }
+        EventType::Profile => {
+            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
+            let text = |index: usize| {
+                as_text(row_values, index, header, row, fields[index]).map(str::to_string)
+            };
+            MarketEvent::Profile(ProfileEvent {
+                event_type: header.to_string(),
+                event_symbol: symbol,
+                event_time: int(2)?,
+                description: text(3)?,
+                short_sale_restriction: text(4)?,
+                trading_status: text(5)?,
+                status_reason: text(6)?,
+                halt_start_time: int(7)?,
+                halt_end_time: int(8)?,
+                high_limit_price: number(9)?,
+                low_limit_price: number(10)?,
+                high_52_week_price: number(11)?,
+                low_52_week_price: number(12)?,
+                beta: number(13)?,
+                earnings_per_share: number(14)?,
+                dividend_frequency: number(15)?,
+                ex_dividend_amount: number(16)?,
+                ex_dividend_day_id: int(17)?,
+                shares: number(18)?,
+                free_float: number(19)?,
             })
         }
         // compact_fields returned Some for this type, so a missing arm here is a
@@ -1199,6 +1227,230 @@ mod time_and_sale_tests {
         let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");
         assert!(
             matches!(back, MarketEvent::TimeAndSale(_)),
+            "an untagged round trip picked the wrong variant: {back:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod profile_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The exact 20 columns issue #27 specifies, in order.
+    fn profile_row(symbol: &str) -> Vec<Value> {
+        vec![
+            json!("Profile"),                   // 0 eventType
+            json!(symbol),                      // 1 eventSymbol
+            json!(1_700_000_000_500i64),        // 2 eventTime
+            json!("Apple Inc. - Common Stock"), // 3 description
+            json!("Inactive"),                  // 4 shortSaleRestriction
+            json!("Halted"),                    // 5 tradingStatus
+            json!("News pending"),              // 6 statusReason
+            json!(1_700_000_100_000i64),        // 7 haltStartTime
+            json!(1_700_000_900_000i64),        // 8 haltEndTime
+            json!(165.0),                       // 9 highLimitPrice
+            json!(135.0),                       // 10 lowLimitPrice
+            json!(199.62),                      // 11 high52WeekPrice
+            json!(124.17),                      // 12 low52WeekPrice
+            json!(1.29),                        // 13 beta
+            json!(6.13),                        // 14 earningsPerShare
+            json!(4.0),                         // 15 dividendFrequency
+            json!(0.24),                        // 16 exDividendAmount
+            json!(20240209i64),                 // 17 exDividendDayId
+            json!(15_552_800_000.0),            // 18 shares
+            json!(15_461_900_000.0),            // 19 freeFloat
+        ]
+    }
+
+    fn batch(values: Vec<Value>) -> Vec<CompactData> {
+        vec![
+            CompactData::EventType("Profile".to_string()),
+            CompactData::Values(values),
+        ]
+    }
+
+    #[test]
+    fn test_the_field_list_matches_the_decoder_stride() {
+        let fields = EventType::Profile
+            .compact_fields()
+            .expect("Profile has a decoder");
+        assert_eq!(fields.len(), 20, "the layout is 20 columns");
+        assert_eq!(fields.len(), profile_row("AAPL").len());
+    }
+
+    #[test]
+    fn test_two_profiles_decode_with_the_right_stride() {
+        let mut values = profile_row("AAPL");
+        values.extend(profile_row("MSFT"));
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        assert_eq!(events.len(), 2);
+
+        match (&events[0], &events[1]) {
+            (MarketEvent::Profile(first), MarketEvent::Profile(second)) => {
+                // The symbols prove the stride of twenty.
+                assert_eq!(first.event_symbol, "AAPL");
+                assert_eq!(second.event_symbol, "MSFT");
+                assert_eq!(first.event_time, 1_700_000_000_500);
+                assert_eq!(first.description, "Apple Inc. - Common Stock");
+                assert_eq!(first.short_sale_restriction, "Inactive");
+                assert_eq!(first.trading_status, "Halted");
+                assert_eq!(first.status_reason, "News pending");
+                assert_eq!(first.halt_start_time, 1_700_000_100_000);
+                assert_eq!(first.halt_end_time, 1_700_000_900_000);
+                assert_eq!(first.high_limit_price, 165.0);
+                assert_eq!(first.low_limit_price, 135.0);
+                assert_eq!(first.high_52_week_price, 199.62);
+                assert_eq!(first.low_52_week_price, 124.17);
+                assert_eq!(first.beta, 1.29);
+                assert_eq!(first.earnings_per_share, 6.13);
+                assert_eq!(first.dividend_frequency, 4.0);
+                assert_eq!(first.ex_dividend_amount, 0.24);
+                assert_eq!(first.ex_dividend_day_id, 20240209);
+                assert_eq!(first.shares, 15_552_800_000.0);
+                assert_eq!(first.free_float, 15_461_900_000.0);
+            }
+            other => panic!("expected two profiles, got {other:?}"),
+        }
+    }
+
+    /// The four text columns sit next to each other, so a one-column shift
+    /// keeps decoding and only changes which string is which.
+    #[test]
+    fn test_the_status_columns_keep_their_own_meaning() {
+        let mut values = profile_row("AAPL");
+        values[4] = json!("Active");
+        values[5] = json!("Active");
+        values[6] = json!("");
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        match &events[0] {
+            MarketEvent::Profile(profile) => {
+                assert_eq!(profile.short_sale_restriction, "Active");
+                assert_eq!(profile.trading_status, "Active");
+                // A trading instrument has no reason to report, and an empty
+                // string is a value rather than a missing column.
+                assert_eq!(profile.status_reason, "");
+                assert_eq!(profile.description, "Apple Inc. - Common Stock");
+            }
+            other => panic!("expected a profile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_numeric_trading_status_is_rejected() {
+        let mut values = profile_row("AAPL");
+        values[5] = json!(1.0);
+
+        let error = try_parse_compact_data(&batch(values)).expect_err("the column is text");
+        assert!(
+            error.to_string().contains("tradingStatus"),
+            "the field is missing: {error}"
+        );
+    }
+
+    #[test]
+    fn test_a_textual_limit_price_is_rejected() {
+        let mut values = profile_row("AAPL");
+        // "165.0" as text is what a shifted layout looks like, and it is not a
+        // JSONDouble special value, so it must not decode.
+        values[9] = json!("165.0");
+
+        let error = try_parse_compact_data(&batch(values)).expect_err("the column is a number");
+        assert!(
+            error.to_string().contains("highLimitPrice"),
+            "the field is missing: {error}"
+        );
+    }
+
+    #[test]
+    fn test_an_instrument_without_fundamentals_decodes() {
+        // An index has no earnings, dividends or float; the protocol sends NaN
+        // rather than omitting the columns.
+        let mut values = profile_row("SPX");
+        values[13] = json!("NaN");
+        values[14] = json!("NaN");
+        values[18] = json!("NaN");
+        values[19] = json!("NaN");
+
+        let events = try_parse_compact_data(&batch(values)).expect("NaN is a value");
+        match &events[0] {
+            MarketEvent::Profile(profile) => {
+                assert!(profile.beta.is_nan());
+                assert!(profile.earnings_per_share.is_nan());
+                assert!(profile.shares.is_nan());
+                assert!(profile.free_float.is_nan());
+                // The limits still have to be real numbers.
+                assert_eq!(profile.high_limit_price, 165.0);
+            }
+            other => panic!("expected a profile, got {other:?}"),
+        }
+    }
+
+    /// The venue reports no upper limit as positive infinity, which JSON has no
+    /// literal for.
+    #[test]
+    fn test_an_unbounded_limit_price_decodes() {
+        let mut values = profile_row("AAPL");
+        values[9] = json!("Infinity");
+        values[10] = json!("-Infinity");
+
+        let events = try_parse_compact_data(&batch(values)).expect("Infinity is a value");
+        match &events[0] {
+            MarketEvent::Profile(profile) => {
+                assert_eq!(profile.high_limit_price, f64::INFINITY);
+                assert_eq!(profile.low_limit_price, f64::NEG_INFINITY);
+            }
+            other => panic!("expected a profile, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_truncated_profile_row_is_rejected() {
+        let mut values = profile_row("AAPL");
+        values.pop();
+        assert!(try_parse_compact_data(&batch(values)).is_err());
+    }
+
+    #[test]
+    fn test_a_profile_is_not_mistaken_for_another_event() {
+        let events = try_parse_compact_data(&batch(profile_row("AAPL"))).expect("well formed");
+        assert!(matches!(events[0], MarketEvent::Profile(_)));
+
+        let json = serde_json::to_string(&events[0]).expect("serialize");
+        // Every camelCase wire name has to survive the round trip.
+        for field in [
+            "eventType",
+            "eventSymbol",
+            "eventTime",
+            "description",
+            "shortSaleRestriction",
+            "tradingStatus",
+            "statusReason",
+            "haltStartTime",
+            "haltEndTime",
+            "highLimitPrice",
+            "lowLimitPrice",
+            "high52WeekPrice",
+            "low52WeekPrice",
+            "beta",
+            "earningsPerShare",
+            "dividendFrequency",
+            "exDividendAmount",
+            "exDividendDayId",
+            "shares",
+            "freeFloat",
+        ] {
+            assert!(
+                json.contains(&format!("\"{field}\":")),
+                "wire name `{field}` is missing: {json}"
+            );
+        }
+
+        let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");
+        assert!(
+            matches!(back, MarketEvent::Profile(_)),
             "an untagged round trip picked the wrong variant: {back:?}"
         );
     }

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -728,3 +728,112 @@ async fn test_prints_reach_the_stream_and_the_callback() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+/// Issue #27 asks for two profiles reaching both delivery paths with all their
+/// metadata intact.
+#[tokio::test]
+async fn test_profiles_reach_the_stream_and_the_callback() {
+    let server = MockServer::start(Behaviour::Normal).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Profile])
+        .await
+        .expect("failed to set up feed");
+
+    let delivered = Arc::new(Mutex::new(Vec::new()));
+    let sink = delivered.clone();
+    client.on_event("AAPL", move |event| {
+        sink.lock().expect("callback lock poisoned").push(event);
+    });
+
+    client
+        .subscribe(
+            channel_id,
+            vec![
+                FeedSubscription {
+                    event_type: "Profile".to_string(),
+                    symbol: "AAPL".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+                FeedSubscription {
+                    event_type: "Profile".to_string(),
+                    symbol: "MSFT".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+            ],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    let events = collect_events(&mut event_stream, 2).await;
+    assert_eq!(events.len(), 2, "expected two profiles, got {events:?}");
+
+    let symbols: Vec<&str> = events
+        .iter()
+        .map(|event| match event {
+            MarketEvent::Profile(profile) => profile.event_symbol.as_str(),
+            other => panic!("expected a profile, got {other:?}"),
+        })
+        .collect();
+    assert!(symbols.contains(&"AAPL"), "AAPL is missing: {symbols:?}");
+    assert!(symbols.contains(&"MSFT"), "MSFT is missing: {symbols:?}");
+
+    let profile = events
+        .iter()
+        .find_map(|event| match event {
+            MarketEvent::Profile(profile) if profile.event_symbol == "AAPL" => Some(profile),
+            _ => None,
+        })
+        .expect("no Profile for AAPL reached the stream");
+
+    assert_eq!(profile.event_type, "Profile");
+    assert_eq!(profile.event_time, expected::EVENT_TIME);
+    assert_eq!(profile.description, expected::DESCRIPTION);
+    assert_eq!(
+        profile.short_sale_restriction,
+        expected::SHORT_SALE_RESTRICTION
+    );
+    assert_eq!(profile.trading_status, expected::TRADING_STATUS);
+    assert_eq!(profile.status_reason, expected::STATUS_REASON);
+    assert_eq!(profile.halt_start_time, expected::HALT_START_TIME);
+    assert_eq!(profile.halt_end_time, expected::HALT_END_TIME);
+    assert_eq!(profile.high_limit_price, expected::HIGH_LIMIT_PRICE);
+    assert_eq!(profile.low_limit_price, expected::LOW_LIMIT_PRICE);
+    assert_eq!(profile.high_52_week_price, expected::HIGH_52_WEEK_PRICE);
+    assert_eq!(profile.low_52_week_price, expected::LOW_52_WEEK_PRICE);
+    assert_eq!(profile.beta, expected::BETA);
+    assert_eq!(profile.earnings_per_share, expected::EARNINGS_PER_SHARE);
+    assert_eq!(profile.dividend_frequency, expected::DIVIDEND_FREQUENCY);
+    assert_eq!(profile.ex_dividend_amount, expected::EX_DIVIDEND_AMOUNT);
+    assert_eq!(profile.ex_dividend_day_id, expected::EX_DIVIDEND_DAY_ID);
+    assert_eq!(profile.shares, expected::SHARES);
+    assert_eq!(profile.free_float, expected::FREE_FLOAT);
+
+    // The callback routes through symbol_of, which needed a new arm for this
+    // variant, and it is scoped to AAPL so MSFT must not appear.
+    let seen: Vec<MarketEvent> = {
+        let events = delivered.lock().expect("callback lock poisoned");
+        events.clone()
+    };
+    match seen.as_slice() {
+        [MarketEvent::Profile(profile)] => {
+            assert_eq!(profile.event_symbol, "AAPL");
+            // The operational half is what a consumer acts on: a price from a
+            // halted instrument is stale by definition.
+            assert_eq!(profile.trading_status, expected::TRADING_STATUS);
+            assert_eq!(profile.status_reason, expected::STATUS_REASON);
+        }
+        other => panic!("the callback for AAPL should have received one profile, got {other:?}"),
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -484,6 +484,24 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "type" => json!("NEW"),
         "buyer" => json!("NSDQ"),
         "seller" => json!("NYSE"),
+        // Profile
+        "description" => json!("Apple Inc. - Common Stock"),
+        "shortSaleRestriction" => json!("Inactive"),
+        "tradingStatus" => json!("Halted"),
+        "statusReason" => json!("News pending"),
+        "haltStartTime" => json!(1_700_000_100_000i64),
+        "haltEndTime" => json!(1_700_000_900_000i64),
+        "highLimitPrice" => json!(165.0),
+        "lowLimitPrice" => json!(135.0),
+        "high52WeekPrice" => json!(199.62),
+        "low52WeekPrice" => json!(124.17),
+        "beta" => json!(1.29),
+        "earningsPerShare" => json!(6.13),
+        "dividendFrequency" => json!(4.0),
+        "exDividendAmount" => json!(0.24),
+        "exDividendDayId" => json!(20240209i64),
+        "shares" => json!(15_552_800_000.0),
+        "freeFloat" => json!(15_461_900_000.0),
         // Greeks
         "delta" => json!(0.65),
         "gamma" => json!(0.05),
@@ -553,6 +571,23 @@ pub mod expected {
     pub const SALE_TYPE: &str = "NEW";
     pub const BUYER: &str = "NSDQ";
     pub const SELLER: &str = "NYSE";
+    pub const DESCRIPTION: &str = "Apple Inc. - Common Stock";
+    pub const SHORT_SALE_RESTRICTION: &str = "Inactive";
+    pub const TRADING_STATUS: &str = "Halted";
+    pub const STATUS_REASON: &str = "News pending";
+    pub const HALT_START_TIME: i64 = 1_700_000_100_000;
+    pub const HALT_END_TIME: i64 = 1_700_000_900_000;
+    pub const HIGH_LIMIT_PRICE: f64 = 165.0;
+    pub const LOW_LIMIT_PRICE: f64 = 135.0;
+    pub const HIGH_52_WEEK_PRICE: f64 = 199.62;
+    pub const LOW_52_WEEK_PRICE: f64 = 124.17;
+    pub const BETA: f64 = 1.29;
+    pub const EARNINGS_PER_SHARE: f64 = 6.13;
+    pub const DIVIDEND_FREQUENCY: f64 = 4.0;
+    pub const EX_DIVIDEND_AMOUNT: f64 = 0.24;
+    pub const EX_DIVIDEND_DAY_ID: i64 = 20240209;
+    pub const SHARES: f64 = 15_552_800_000.0;
+    pub const FREE_FLOAT: f64 = 15_461_900_000.0;
 }
 
 /// Convenience predicates for `wait_for`.


### PR DESCRIPTION
## Summary

`Profile` completes the six-site checklist: enum variant, struct, field list, decoder arm, dispatch arm, docs. The layout is the full 20 columns issue #27 specifies.

Stacked on #54, which has merged.

## Technical decisions

**Field names come from the dxFeed AsyncAPI schema**, not from memory — a wrong name is a `FEED_SETUP` the server does not recognise, which is not a compile error.

**The whole layout, not a subset.** `trading_status` and the halt window are the operational half of this event: a price from a halted instrument is stale by definition, and that is only knowable from here. The limit prices bound what the venue will accept at all, and the fundamentals are what the description alone cannot give you.

**Empty strings are values, not missing columns.** A trading instrument reports no `statusReason`, and the decoder keeps that as `""` rather than treating it as absent.

## Public API impact

Additive: `ProfileEvent`, `MarketEvent::Profile`. The new variant breaks downstream exhaustive matches on `MarketEvent`, so this is a 0.x minor bump.

## Testing

- The field list length is pinned against the decoder stride, so the two halves of the COMPACT contract cannot drift apart.
- Two profiles in one batch, symbols proving the stride of 20.
- The four adjacent text columns keep their own meaning — a one-column shift there keeps decoding and only changes which string is which.
- A numeric `tradingStatus` and a textual `highLimitPrice` are both rejected, naming the field.
- An index with no fundamentals decodes: the protocol sends `NaN` rather than omitting the columns.
- An unbounded limit price decodes from `"Infinity"` / `"-Infinity"`.
- A truncated row is rejected.
- Serde: every one of the 20 camelCase wire names survives a round trip.
- **Answering the review**, `CandleEvent`, `SummaryEvent`, `TimeAndSaleEvent` and `ProfileEvent` now all have serde tests asserting their serialized key set equals the type's `compact_fields` list, plus a JSONDouble round trip for the non-finite values.
- End to end against the mock server: two profiles reach both the stream and a per-symbol callback with every column intact. Verified by mutation — swapping two field-list entries fails this test.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #27
