### PR TITLE
Decode Underlying events end to end (#28)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 - Automatic keepalives while the connection is open.
 - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-  `Greeks`, `Candle`, `Summary`, `TimeAndSale` and `Profile`**, each with the full
-  field set the dxFeed schema defines for it.
+  `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile` and `Underlying`**, each
+  with the full field set the dxFeed schema defines for it.
 - Both delivery styles: a per-symbol callback and a single event stream.
 - Historical data via `from_time` on a `Candle` subscription, decoded into
   OHLC bars.
@@ -30,8 +30,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - **No reconnection.** If the connection drops, the client reports the error
   and stops; re-establishing the session is the caller's job.
 - [`EventType`] declares more variants than the library can decode. Only
-  `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale` and `Profile`
-  produce a [`MarketEvent`], and
+  `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile` and
+  `Underlying` produce a [`MarketEvent`], and
   configuring or subscribing to any other type is **refused** rather than
   accepted into a stream that can never produce.
 
@@ -200,8 +200,9 @@ are decoded into a [`MarketEvent`] and delivered:
 | `Summary` | the full 14-column layout: day and previous-day prices, their price types, volume and open interest |
 | `TimeAndSale` | the full 22-column layout: price, size and the surrounding quote plus exchange, sale conditions, aggressor side and the print flags |
 | `Profile` | the full 20-column layout: description, trading status and halt window, price limits, 52-week range and the fundamentals |
+| `Underlying` | the full 13-column layout: implied volatility with its term structure, call and put volume and their ratio |
 
-Configuring or subscribing to any other variant (`Underlying`, `TheoPrice`,
+Configuring or subscribing to any other variant (`TheoPrice`, `Order`,
 …) is **refused**, rather than accepted into a stream that can
 never produce.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -352,6 +352,7 @@ fn symbol_of(event: &MarketEvent) -> &str {
         MarketEvent::Summary(e) => &e.event_symbol,
         MarketEvent::TimeAndSale(e) => &e.event_symbol,
         MarketEvent::Profile(e) => &e.event_symbol,
+        MarketEvent::Underlying(e) => &e.event_symbol,
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -282,6 +282,21 @@ impl EventType {
                 "buyer",
                 "seller",
             ]),
+            EventType::Underlying => Some(&[
+                "eventType",
+                "eventSymbol",
+                "eventTime",
+                "eventFlags",
+                "index",
+                "time",
+                "sequence",
+                "volatility",
+                "frontVolatility",
+                "backVolatility",
+                "callVolume",
+                "putVolume",
+                "putCallRatio",
+            ]),
             EventType::Greeks => Some(&[
                 "eventType",
                 "eventSymbol",
@@ -297,7 +312,6 @@ impl EventType {
             | EventType::TradeETH
             | EventType::SpreadOrder
             | EventType::TheoPrice
-            | EventType::Underlying
             | EventType::Series
             | EventType::Configuration
             | EventType::Message => None,
@@ -831,6 +845,65 @@ pub struct TimeAndSaleEvent {
     pub seller: String,
 }
 
+/// The option surface over an underlying: implied volatility and the call/put
+/// balance.
+///
+/// Every field the dxFeed AsyncAPI schema defines for an underlying, in the
+/// order the client requests them. `front_volatility` and `back_volatility`
+/// bracket the term structure, and `put_call_ratio` is the positioning number
+/// the raw volumes are usually reduced to.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnderlyingEvent {
+    /// The type of the event, `Underlying`.
+    #[serde(rename = "eventType")]
+    pub event_type: String,
+
+    /// The underlying symbol.
+    #[serde(rename = "eventSymbol")]
+    pub event_symbol: String,
+
+    /// When the server emitted the event, as epoch milliseconds.
+    #[serde(rename = "eventTime")]
+    pub event_time: i64,
+
+    /// Transactional and snapshot bits for this record.
+    #[serde(rename = "eventFlags")]
+    pub event_flags: i64,
+
+    /// Unique index of the record, ordering it within the stream.
+    pub index: i64,
+
+    /// When the values were computed, as epoch milliseconds.
+    pub time: i64,
+
+    /// Sequence number, separating records that share a millisecond.
+    pub sequence: i64,
+
+    /// 30-day implied volatility for this underlying, as a fraction.
+    #[serde(with = "json_double")]
+    pub volatility: f64,
+
+    /// Implied volatility of the front-month options.
+    #[serde(rename = "frontVolatility", with = "json_double")]
+    pub front_volatility: f64,
+
+    /// Implied volatility of the second-month options.
+    #[serde(rename = "backVolatility", with = "json_double")]
+    pub back_volatility: f64,
+
+    /// Call option volume for the day.
+    #[serde(rename = "callVolume", with = "json_double")]
+    pub call_volume: f64,
+
+    /// Put option volume for the day.
+    #[serde(rename = "putVolume", with = "json_double")]
+    pub put_volume: f64,
+
+    /// Put volume over call volume.
+    #[serde(rename = "putCallRatio", with = "json_double")]
+    pub put_call_ratio: f64,
+}
+
 /// Represents a market event, which can be a quote, trade, or greeks event.
 ///
 /// This enum uses `serde`'s untagged enum serialization, meaning that the serialized
@@ -904,13 +977,15 @@ pub enum MarketEvent {
     /// One execution as it printed, with the surrounding quote.
     TimeAndSale(TimeAndSaleEvent),
     /// Instrument metadata: description, trading status and fundamentals.
+    Profile(ProfileEvent),
+    /// The option surface over an underlying: implied volatility and volumes.
     ///
     /// New variants go last on purpose: `MarketEvent` is `#[serde(untagged)]`,
     /// so serde tries them in declaration order and keeps the first that
     /// deserializes. Appending leaves every variant already in the list
     /// matching exactly as it did. Each type has a round-trip test that would
     /// catch one variant stealing another's payload.
-    Profile(ProfileEvent),
+    Underlying(UnderlyingEvent),
 }
 
 /// Represents compact data, which can be either an event type (string) or a vector of JSON values.
@@ -1612,6 +1687,29 @@ mod event_serde_tests {
         }
     }
 
+    fn underlying() -> UnderlyingEvent {
+        UnderlyingEvent {
+            event_type: "Underlying".to_string(),
+            event_symbol: "SPX".to_string(),
+            event_time: 1_700_000_000_500,
+            event_flags: 0,
+            index: 9,
+            time: 1_700_000_000_000,
+            sequence: 3,
+            volatility: 0.25,
+            front_volatility: 0.28,
+            back_volatility: 0.22,
+            call_volume: 310_000.0,
+            put_volume: 465_000.0,
+            put_call_ratio: 1.5,
+        }
+    }
+
+    #[test]
+    fn test_underlying_serde_names_match_its_layout() {
+        assert_wire_contract(&underlying(), EventType::Underlying);
+    }
+
     #[test]
     fn test_candle_serde_names_match_its_layout() {
         assert_wire_contract(&candle(), EventType::Candle);
@@ -1668,6 +1766,7 @@ mod event_serde_tests {
             MarketEvent::Summary(summary()),
             MarketEvent::TimeAndSale(print()),
             MarketEvent::Profile(profile()),
+            MarketEvent::Underlying(underlying()),
         ] {
             let serialized = to_string(&event).expect("serialize");
             let back: MarketEvent = from_str(&serialized).expect("round trip");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 //!   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 //! - Automatic keepalives while the connection is open.
 //! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-//!   `Greeks`, `Candle`, `Summary`, `TimeAndSale` and `Profile`**, each with the full
-//!   field set the dxFeed schema defines for it.
+//!   `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile` and `Underlying`**, each
+//!   with the full field set the dxFeed schema defines for it.
 //! - Both delivery styles: a per-symbol callback and a single event stream.
 //! - Historical data via `from_time` on a `Candle` subscription, decoded into
 //!   OHLC bars.
@@ -28,8 +28,8 @@
 //! - **No reconnection.** If the connection drops, the client reports the error
 //!   and stops; re-establishing the session is the caller's job.
 //! - [`EventType`] declares more variants than the library can decode. Only
-//!   `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale` and `Profile`
-//!   produce a [`MarketEvent`], and
+//!   `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile` and
+//!   `Underlying` produce a [`MarketEvent`], and
 //!   configuring or subscribing to any other type is **refused** rather than
 //!   accepted into a stream that can never produce.
 //!
@@ -198,8 +198,9 @@
 //! | `Summary` | the full 14-column layout: day and previous-day prices, their price types, volume and open interest |
 //! | `TimeAndSale` | the full 22-column layout: price, size and the surrounding quote plus exchange, sale conditions, aggressor side and the print flags |
 //! | `Profile` | the full 20-column layout: description, trading status and halt window, price limits, 52-week range and the fundamentals |
+//! | `Underlying` | the full 13-column layout: implied volatility with its term structure, call and put volume and their ratio |
 //!
-//! Configuring or subscribing to any other variant (`Underlying`, `TheoPrice`,
+//! Configuring or subscribing to any other variant (`TheoPrice`, `Order`,
 //! …) is **refused**, rather than accepted into a stream that can
 //! never produce.
 //!

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use crate::MarketEvent;
 use crate::error::{DXLinkError, DXLinkResult};
 use crate::events::{
     CandleEvent, CompactData, EventType, GreeksEvent, ProfileEvent, QuoteEvent, SummaryEvent,
-    TimeAndSaleEvent, TradeEvent,
+    TimeAndSaleEvent, TradeEvent, UnderlyingEvent,
 };
 use serde_json::Value;
 use tracing::warn;
@@ -401,6 +401,24 @@ fn build_event(
                 ex_dividend_day_id: int(17)?,
                 shares: number(18)?,
                 free_float: number(19)?,
+            })
+        }
+        EventType::Underlying => {
+            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
+            MarketEvent::Underlying(UnderlyingEvent {
+                event_type: header.to_string(),
+                event_symbol: symbol,
+                event_time: int(2)?,
+                event_flags: int(3)?,
+                index: int(4)?,
+                time: int(5)?,
+                sequence: int(6)?,
+                volatility: number(7)?,
+                front_volatility: number(8)?,
+                back_volatility: number(9)?,
+                call_volume: number(10)?,
+                put_volume: number(11)?,
+                put_call_ratio: number(12)?,
             })
         }
         // compact_fields returned Some for this type, so a missing arm here is a
@@ -1451,6 +1469,166 @@ mod profile_tests {
         let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");
         assert!(
             matches!(back, MarketEvent::Profile(_)),
+            "an untagged round trip picked the wrong variant: {back:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod underlying_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The exact 13 columns issue #28 specifies, in order.
+    fn underlying_row(symbol: &str) -> Vec<Value> {
+        vec![
+            json!("Underlying"),         // 0 eventType
+            json!(symbol),               // 1 eventSymbol
+            json!(1_700_000_000_500i64), // 2 eventTime
+            json!(0i64),                 // 3 eventFlags
+            json!(9i64),                 // 4 index
+            json!(1_700_000_000_000i64), // 5 time
+            json!(3i64),                 // 6 sequence
+            json!(0.25),                 // 7 volatility
+            json!(0.28),                 // 8 frontVolatility
+            json!(0.22),                 // 9 backVolatility
+            json!(310_000.0),            // 10 callVolume
+            json!(465_000.0),            // 11 putVolume
+            json!(1.5),                  // 12 putCallRatio
+        ]
+    }
+
+    fn batch(values: Vec<Value>) -> Vec<CompactData> {
+        vec![
+            CompactData::EventType("Underlying".to_string()),
+            CompactData::Values(values),
+        ]
+    }
+
+    #[test]
+    fn test_the_field_list_matches_the_decoder_stride() {
+        let fields = EventType::Underlying
+            .compact_fields()
+            .expect("Underlying has a decoder");
+        assert_eq!(fields.len(), 13, "the layout is 13 columns");
+        assert_eq!(fields.len(), underlying_row("SPX").len());
+    }
+
+    #[test]
+    fn test_two_underlyings_decode_with_the_right_stride() {
+        let mut values = underlying_row("SPX");
+        values.extend(underlying_row("NDX"));
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        assert_eq!(events.len(), 2);
+
+        match (&events[0], &events[1]) {
+            (MarketEvent::Underlying(first), MarketEvent::Underlying(second)) => {
+                // The symbols prove the stride of thirteen.
+                assert_eq!(first.event_symbol, "SPX");
+                assert_eq!(second.event_symbol, "NDX");
+                assert_eq!(first.event_time, 1_700_000_000_500);
+                assert_eq!(first.event_flags, 0);
+                assert_eq!(first.index, 9);
+                assert_eq!(first.time, 1_700_000_000_000);
+                assert_eq!(first.sequence, 3);
+                assert_eq!(first.volatility, 0.25);
+                assert_eq!(first.front_volatility, 0.28);
+                assert_eq!(first.back_volatility, 0.22);
+                assert_eq!(first.call_volume, 310_000.0);
+                assert_eq!(first.put_volume, 465_000.0);
+                assert_eq!(first.put_call_ratio, 1.5);
+            }
+            other => panic!("expected two underlyings, got {other:?}"),
+        }
+    }
+
+    /// The three volatilities sit next to each other and are all plausible
+    /// fractions, so a one-column shift there changes the term structure
+    /// without looking wrong.
+    #[test]
+    fn test_the_term_structure_keeps_its_own_columns() {
+        let mut values = underlying_row("SPX");
+        values[7] = json!(0.30);
+        values[8] = json!(0.40);
+        values[9] = json!(0.20);
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        match &events[0] {
+            MarketEvent::Underlying(surface) => {
+                assert_eq!(surface.volatility, 0.30);
+                assert_eq!(surface.front_volatility, 0.40);
+                assert_eq!(surface.back_volatility, 0.20);
+                // Backwardation: the front is above the back, which is the case
+                // a shifted layout would hide.
+                assert!(surface.front_volatility > surface.back_volatility);
+            }
+            other => panic!("expected an underlying, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_textual_volatility_is_rejected() {
+        let mut values = underlying_row("SPX");
+        // Not a JSONDouble special value, so it must not decode.
+        values[8] = json!("high");
+
+        let error = try_parse_compact_data(&batch(values)).expect_err("the column is a number");
+        assert!(
+            error.to_string().contains("frontVolatility"),
+            "the field is missing: {error}"
+        );
+    }
+
+    #[test]
+    fn test_a_fractional_sequence_is_rejected() {
+        let mut values = underlying_row("SPX");
+        values[6] = json!(3.5);
+
+        let error =
+            try_parse_compact_data(&batch(values)).expect_err("the column is a whole number");
+        assert!(
+            error.to_string().contains("sequence"),
+            "the field is missing: {error}"
+        );
+    }
+
+    #[test]
+    fn test_an_underlying_without_options_traded_decodes() {
+        // With no volume on either side the ratio is undefined, and the protocol
+        // sends NaN rather than omitting the column.
+        let mut values = underlying_row("SPX");
+        values[10] = json!(0.0);
+        values[11] = json!(0.0);
+        values[12] = json!("NaN");
+
+        let events = try_parse_compact_data(&batch(values)).expect("NaN is a value");
+        match &events[0] {
+            MarketEvent::Underlying(surface) => {
+                assert_eq!(surface.call_volume, 0.0);
+                assert_eq!(surface.put_volume, 0.0);
+                assert!(surface.put_call_ratio.is_nan());
+            }
+            other => panic!("expected an underlying, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_truncated_underlying_row_is_rejected() {
+        let mut values = underlying_row("SPX");
+        values.pop();
+        assert!(try_parse_compact_data(&batch(values)).is_err());
+    }
+
+    #[test]
+    fn test_an_underlying_is_not_mistaken_for_another_event() {
+        let events = try_parse_compact_data(&batch(underlying_row("SPX"))).expect("well formed");
+        assert!(matches!(events[0], MarketEvent::Underlying(_)));
+
+        let json = serde_json::to_string(&events[0]).expect("serialize");
+        let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");
+        assert!(
+            matches!(back, MarketEvent::Underlying(_)),
             "an untagged round trip picked the wrong variant: {back:?}"
         );
     }

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -837,3 +837,103 @@ async fn test_profiles_reach_the_stream_and_the_callback() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+/// Issue #28 asks for two underlyings reaching both delivery paths with their
+/// volatility term structure and volumes intact.
+#[tokio::test]
+async fn test_underlyings_reach_the_stream_and_the_callback() {
+    let server = MockServer::start(Behaviour::Normal).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Underlying])
+        .await
+        .expect("failed to set up feed");
+
+    let delivered = Arc::new(Mutex::new(Vec::new()));
+    let sink = delivered.clone();
+    client.on_event("SPX", move |event| {
+        sink.lock().expect("callback lock poisoned").push(event);
+    });
+
+    client
+        .subscribe(
+            channel_id,
+            vec![
+                FeedSubscription {
+                    event_type: "Underlying".to_string(),
+                    symbol: "SPX".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+                FeedSubscription {
+                    event_type: "Underlying".to_string(),
+                    symbol: "NDX".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+            ],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    let events = collect_events(&mut event_stream, 2).await;
+    assert_eq!(events.len(), 2, "expected two underlyings, got {events:?}");
+
+    let symbols: Vec<&str> = events
+        .iter()
+        .map(|event| match event {
+            MarketEvent::Underlying(surface) => surface.event_symbol.as_str(),
+            other => panic!("expected an underlying, got {other:?}"),
+        })
+        .collect();
+    assert!(symbols.contains(&"SPX"), "SPX is missing: {symbols:?}");
+    assert!(symbols.contains(&"NDX"), "NDX is missing: {symbols:?}");
+
+    let surface = events
+        .iter()
+        .find_map(|event| match event {
+            MarketEvent::Underlying(surface) if surface.event_symbol == "SPX" => Some(surface),
+            _ => None,
+        })
+        .expect("no Underlying for SPX reached the stream");
+
+    assert_eq!(surface.event_type, "Underlying");
+    assert_eq!(surface.event_time, expected::EVENT_TIME);
+    assert_eq!(surface.event_flags, expected::EVENT_FLAGS);
+    assert_eq!(surface.index, expected::INDEX);
+    assert_eq!(surface.time, expected::TIME);
+    assert_eq!(surface.sequence, expected::SEQUENCE);
+    assert_eq!(surface.volatility, expected::VOLATILITY);
+    assert_eq!(surface.front_volatility, expected::FRONT_VOLATILITY);
+    assert_eq!(surface.back_volatility, expected::BACK_VOLATILITY);
+    assert_eq!(surface.call_volume, expected::CALL_VOLUME);
+    assert_eq!(surface.put_volume, expected::PUT_VOLUME);
+    assert_eq!(surface.put_call_ratio, expected::PUT_CALL_RATIO);
+
+    // The callback routes through symbol_of, which needed a new arm for this
+    // variant, and it is scoped to SPX so NDX must not appear.
+    let seen: Vec<MarketEvent> = {
+        let events = delivered.lock().expect("callback lock poisoned");
+        events.clone()
+    };
+    match seen.as_slice() {
+        [MarketEvent::Underlying(surface)] => {
+            assert_eq!(surface.event_symbol, "SPX");
+            // The three volatilities are all plausible fractions, so asserting
+            // them here is what catches a shift between the two paths.
+            assert_eq!(surface.volatility, expected::VOLATILITY);
+            assert_eq!(surface.front_volatility, expected::FRONT_VOLATILITY);
+            assert_eq!(surface.back_volatility, expected::BACK_VOLATILITY);
+        }
+        other => panic!("the callback for SPX should have received one underlying, got {other:?}"),
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -502,6 +502,12 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "exDividendDayId" => json!(20240209i64),
         "shares" => json!(15_552_800_000.0),
         "freeFloat" => json!(15_461_900_000.0),
+        // Underlying (volatility is above, shared with Greeks)
+        "frontVolatility" => json!(0.28),
+        "backVolatility" => json!(0.22),
+        "callVolume" => json!(310_000.0),
+        "putVolume" => json!(465_000.0),
+        "putCallRatio" => json!(1.5),
         // Greeks
         "delta" => json!(0.65),
         "gamma" => json!(0.05),
@@ -588,6 +594,11 @@ pub mod expected {
     pub const EX_DIVIDEND_DAY_ID: i64 = 20240209;
     pub const SHARES: f64 = 15_552_800_000.0;
     pub const FREE_FLOAT: f64 = 15_461_900_000.0;
+    pub const FRONT_VOLATILITY: f64 = 0.28;
+    pub const BACK_VOLATILITY: f64 = 0.22;
+    pub const CALL_VOLUME: f64 = 310_000.0;
+    pub const PUT_VOLUME: f64 = 465_000.0;
+    pub const PUT_CALL_RATIO: f64 = 1.5;
 }
 
 /// Convenience predicates for `wait_for`.


### PR DESCRIPTION
## Summary

`Underlying` completes the six-site checklist: enum variant, struct, field list, decoder arm, dispatch arm, docs. The layout is the full 13 columns issue #28 specifies.

## Technical decisions

**Field names come from the dxFeed AsyncAPI schema**, not from memory — a wrong name is a `FEED_SETUP` the server does not recognise, which is not a compile error.

**The whole layout, not a subset.** `frontVolatility` and `backVolatility` bracket the term structure: the 30-day number alone cannot tell you whether the front is bid over the back, which is most of what this event is read for. `putCallRatio` comes over the wire rather than being derived, so a consumer sees the venue's own number.

## Public API impact

Additive: `UnderlyingEvent`, `MarketEvent::Underlying`. The new variant breaks downstream exhaustive matches on `MarketEvent`, so this is a 0.x minor bump.

## Testing

- The field list length is pinned against the decoder stride, so the two halves of the COMPACT contract cannot drift apart.
- Two underlyings in one batch, symbols proving the stride of 13.
- The three volatilities keep their own columns. They are all plausible fractions, so a one-column shift there changes the term structure without looking wrong; the test asserts a backwardated surface stays backwardated.
- A textual volatility and a fractional `sequence` are both rejected, naming the field.
- An underlying with no option volume on either side decodes: the ratio is undefined and the protocol sends `NaN` rather than omitting the column.
- A truncated row is rejected.
- Serde: the serialized key set is asserted equal to the type's `compact_fields` list.
- End to end against the mock server: two underlyings reach both the stream and a per-symbol callback with every column intact. Verified by mutation — swapping `frontVolatility` and `backVolatility` in the field list fails this test.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #28
