### PR TITLE
Decode TheoPrice events end to end (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 - Automatic keepalives while the connection is open.
 - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-  `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile` and `Underlying`**, each
-  with the full field set the dxFeed schema defines for it.
+  `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`, `Underlying` and
+  `TheoPrice`**, each with the full field set the dxFeed schema defines for it.
 - Both delivery styles: a per-symbol callback and a single event stream.
 - Historical data via `from_time` on a `Candle` subscription, decoded into
   OHLC bars.
@@ -30,8 +30,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - **No reconnection.** If the connection drops, the client reports the error
   and stops; re-establishing the session is the caller's job.
 - [`EventType`] declares more variants than the library can decode. Only
-  `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile` and
-  `Underlying` produce a [`MarketEvent`], and
+  `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`,
+  `Underlying` and `TheoPrice` produce a [`MarketEvent`], and
   configuring or subscribing to any other type is **refused** rather than
   accepted into a stream that can never produce.
 
@@ -201,8 +201,9 @@ are decoded into a [`MarketEvent`] and delivered:
 | `TimeAndSale` | the full 22-column layout: price, size and the surrounding quote plus exchange, sale conditions, aggressor side and the print flags |
 | `Profile` | the full 20-column layout: description, trading status and halt window, price limits, 52-week range and the fundamentals |
 | `Underlying` | the full 13-column layout: implied volatility with its term structure, call and put volume and their ratio |
+| `TheoPrice` | the full 13-column layout: the theoretical price with the underlying price, delta, gamma, dividend and interest it came from |
 
-Configuring or subscribing to any other variant (`TheoPrice`, `Order`,
+Configuring or subscribing to any other variant (`Order`, `Series`,
 …) is **refused**, rather than accepted into a stream that can
 never produce.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -353,6 +353,7 @@ fn symbol_of(event: &MarketEvent) -> &str {
         MarketEvent::TimeAndSale(e) => &e.event_symbol,
         MarketEvent::Profile(e) => &e.event_symbol,
         MarketEvent::Underlying(e) => &e.event_symbol,
+        MarketEvent::TheoPrice(e) => &e.event_symbol,
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -297,6 +297,21 @@ impl EventType {
                 "putVolume",
                 "putCallRatio",
             ]),
+            EventType::TheoPrice => Some(&[
+                "eventType",
+                "eventSymbol",
+                "eventTime",
+                "eventFlags",
+                "index",
+                "time",
+                "sequence",
+                "price",
+                "underlyingPrice",
+                "delta",
+                "gamma",
+                "dividend",
+                "interest",
+            ]),
             EventType::Greeks => Some(&[
                 "eventType",
                 "eventSymbol",
@@ -311,7 +326,6 @@ impl EventType {
             EventType::Order
             | EventType::TradeETH
             | EventType::SpreadOrder
-            | EventType::TheoPrice
             | EventType::Series
             | EventType::Configuration
             | EventType::Message => None,
@@ -904,6 +918,64 @@ pub struct UnderlyingEvent {
     pub put_call_ratio: f64,
 }
 
+/// The theoretical price of an option and the inputs it was computed from.
+///
+/// Every field the dxFeed AsyncAPI schema defines for a theoretical price, in
+/// the order the client requests them. The inputs travel with the output on
+/// purpose: a theoretical price is only meaningful next to the underlying
+/// price, dividend and interest rate that produced it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TheoPriceEvent {
+    /// The type of the event, `TheoPrice`.
+    #[serde(rename = "eventType")]
+    pub event_type: String,
+
+    /// The option symbol the price is for.
+    #[serde(rename = "eventSymbol")]
+    pub event_symbol: String,
+
+    /// When the server emitted the event, as epoch milliseconds.
+    #[serde(rename = "eventTime")]
+    pub event_time: i64,
+
+    /// Transactional and snapshot bits for this record.
+    #[serde(rename = "eventFlags")]
+    pub event_flags: i64,
+
+    /// Unique index of the record, ordering it within the stream.
+    pub index: i64,
+
+    /// When the price was computed, as epoch milliseconds.
+    pub time: i64,
+
+    /// Sequence number, separating records that share a millisecond.
+    pub sequence: i64,
+
+    /// Theoretical option price.
+    #[serde(with = "json_double")]
+    pub price: f64,
+
+    /// Underlying price the theoretical price was computed from.
+    #[serde(rename = "underlyingPrice", with = "json_double")]
+    pub underlying_price: f64,
+
+    /// Delta of the option at that price.
+    #[serde(with = "json_double")]
+    pub delta: f64,
+
+    /// Gamma of the option at that price.
+    #[serde(with = "json_double")]
+    pub gamma: f64,
+
+    /// Dividend rate used as an input.
+    #[serde(with = "json_double")]
+    pub dividend: f64,
+
+    /// Interest rate used as an input.
+    #[serde(with = "json_double")]
+    pub interest: f64,
+}
+
 /// Represents a market event, which can be a quote, trade, or greeks event.
 ///
 /// This enum uses `serde`'s untagged enum serialization, meaning that the serialized
@@ -979,13 +1051,15 @@ pub enum MarketEvent {
     /// Instrument metadata: description, trading status and fundamentals.
     Profile(ProfileEvent),
     /// The option surface over an underlying: implied volatility and volumes.
+    Underlying(UnderlyingEvent),
+    /// A theoretical option price with the inputs it was computed from.
     ///
     /// New variants go last on purpose: `MarketEvent` is `#[serde(untagged)]`,
     /// so serde tries them in declaration order and keeps the first that
     /// deserializes. Appending leaves every variant already in the list
     /// matching exactly as it did. Each type has a round-trip test that would
     /// catch one variant stealing another's payload.
-    Underlying(UnderlyingEvent),
+    TheoPrice(TheoPriceEvent),
 }
 
 /// Represents compact data, which can be either an event type (string) or a vector of JSON values.
@@ -1705,6 +1779,29 @@ mod event_serde_tests {
         }
     }
 
+    fn theo_price() -> TheoPriceEvent {
+        TheoPriceEvent {
+            event_type: "TheoPrice".to_string(),
+            event_symbol: "AAPL240119C00150000".to_string(),
+            event_time: 1_700_000_000_500,
+            event_flags: 0,
+            index: 5,
+            time: 1_700_000_000_000,
+            sequence: 3,
+            price: 4.35,
+            underlying_price: 152.4,
+            delta: 0.65,
+            gamma: 0.05,
+            dividend: 0.55,
+            interest: 4.75,
+        }
+    }
+
+    #[test]
+    fn test_theo_price_serde_names_match_its_layout() {
+        assert_wire_contract(&theo_price(), EventType::TheoPrice);
+    }
+
     #[test]
     fn test_underlying_serde_names_match_its_layout() {
         assert_wire_contract(&underlying(), EventType::Underlying);
@@ -1767,6 +1864,7 @@ mod event_serde_tests {
             MarketEvent::TimeAndSale(print()),
             MarketEvent::Profile(profile()),
             MarketEvent::Underlying(underlying()),
+            MarketEvent::TheoPrice(theo_price()),
         ] {
             let serialized = to_string(&event).expect("serialize");
             let back: MarketEvent = from_str(&serialized).expect("round trip");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,8 +10,8 @@
 //!   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
 //! - Automatic keepalives while the connection is open.
 //! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-//!   `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile` and `Underlying`**, each
-//!   with the full field set the dxFeed schema defines for it.
+//!   `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`, `Underlying` and
+//!   `TheoPrice`**, each with the full field set the dxFeed schema defines for it.
 //! - Both delivery styles: a per-symbol callback and a single event stream.
 //! - Historical data via `from_time` on a `Candle` subscription, decoded into
 //!   OHLC bars.
@@ -28,8 +28,8 @@
 //! - **No reconnection.** If the connection drops, the client reports the error
 //!   and stops; re-establishing the session is the caller's job.
 //! - [`EventType`] declares more variants than the library can decode. Only
-//!   `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile` and
-//!   `Underlying` produce a [`MarketEvent`], and
+//!   `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`,
+//!   `Underlying` and `TheoPrice` produce a [`MarketEvent`], and
 //!   configuring or subscribing to any other type is **refused** rather than
 //!   accepted into a stream that can never produce.
 //!
@@ -199,8 +199,9 @@
 //! | `TimeAndSale` | the full 22-column layout: price, size and the surrounding quote plus exchange, sale conditions, aggressor side and the print flags |
 //! | `Profile` | the full 20-column layout: description, trading status and halt window, price limits, 52-week range and the fundamentals |
 //! | `Underlying` | the full 13-column layout: implied volatility with its term structure, call and put volume and their ratio |
+//! | `TheoPrice` | the full 13-column layout: the theoretical price with the underlying price, delta, gamma, dividend and interest it came from |
 //!
-//! Configuring or subscribing to any other variant (`TheoPrice`, `Order`,
+//! Configuring or subscribing to any other variant (`Order`, `Series`,
 //! …) is **refused**, rather than accepted into a stream that can
 //! never produce.
 //!

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use crate::MarketEvent;
 use crate::error::{DXLinkError, DXLinkResult};
 use crate::events::{
     CandleEvent, CompactData, EventType, GreeksEvent, ProfileEvent, QuoteEvent, SummaryEvent,
-    TimeAndSaleEvent, TradeEvent, UnderlyingEvent,
+    TheoPriceEvent, TimeAndSaleEvent, TradeEvent, UnderlyingEvent,
 };
 use serde_json::Value;
 use tracing::warn;
@@ -419,6 +419,24 @@ fn build_event(
                 call_volume: number(10)?,
                 put_volume: number(11)?,
                 put_call_ratio: number(12)?,
+            })
+        }
+        EventType::TheoPrice => {
+            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
+            MarketEvent::TheoPrice(TheoPriceEvent {
+                event_type: header.to_string(),
+                event_symbol: symbol,
+                event_time: int(2)?,
+                event_flags: int(3)?,
+                index: int(4)?,
+                time: int(5)?,
+                sequence: int(6)?,
+                price: number(7)?,
+                underlying_price: number(8)?,
+                delta: number(9)?,
+                gamma: number(10)?,
+                dividend: number(11)?,
+                interest: number(12)?,
             })
         }
         // compact_fields returned Some for this type, so a missing arm here is a
@@ -1629,6 +1647,160 @@ mod underlying_tests {
         let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");
         assert!(
             matches!(back, MarketEvent::Underlying(_)),
+            "an untagged round trip picked the wrong variant: {back:?}"
+        );
+    }
+}
+
+#[cfg(test)]
+mod theo_price_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The exact 13 columns issue #29 specifies, in order.
+    fn theo_row(symbol: &str) -> Vec<Value> {
+        vec![
+            json!("TheoPrice"),          // 0 eventType
+            json!(symbol),               // 1 eventSymbol
+            json!(1_700_000_000_500i64), // 2 eventTime
+            json!(0i64),                 // 3 eventFlags
+            json!(5i64),                 // 4 index
+            json!(1_700_000_000_000i64), // 5 time
+            json!(3i64),                 // 6 sequence
+            json!(4.35),                 // 7 price
+            json!(152.4),                // 8 underlyingPrice
+            json!(0.65),                 // 9 delta
+            json!(0.05),                 // 10 gamma
+            json!(0.55),                 // 11 dividend
+            json!(4.75),                 // 12 interest
+        ]
+    }
+
+    fn batch(values: Vec<Value>) -> Vec<CompactData> {
+        vec![
+            CompactData::EventType("TheoPrice".to_string()),
+            CompactData::Values(values),
+        ]
+    }
+
+    #[test]
+    fn test_the_field_list_matches_the_decoder_stride() {
+        let fields = EventType::TheoPrice
+            .compact_fields()
+            .expect("TheoPrice has a decoder");
+        assert_eq!(fields.len(), 13, "the layout is 13 columns");
+        assert_eq!(fields.len(), theo_row("AAPL240119C00150000").len());
+    }
+
+    #[test]
+    fn test_two_theo_prices_decode_with_the_right_stride() {
+        let mut values = theo_row("AAPL240119C00150000");
+        values.extend(theo_row("AAPL240119P00150000"));
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        assert_eq!(events.len(), 2);
+
+        match (&events[0], &events[1]) {
+            (MarketEvent::TheoPrice(first), MarketEvent::TheoPrice(second)) => {
+                // The symbols prove the stride of thirteen.
+                assert_eq!(first.event_symbol, "AAPL240119C00150000");
+                assert_eq!(second.event_symbol, "AAPL240119P00150000");
+                assert_eq!(first.event_time, 1_700_000_000_500);
+                assert_eq!(first.event_flags, 0);
+                assert_eq!(first.index, 5);
+                assert_eq!(first.time, 1_700_000_000_000);
+                assert_eq!(first.sequence, 3);
+                assert_eq!(first.price, 4.35);
+                assert_eq!(first.underlying_price, 152.4);
+                assert_eq!(first.delta, 0.65);
+                assert_eq!(first.gamma, 0.05);
+                assert_eq!(first.dividend, 0.55);
+                assert_eq!(first.interest, 4.75);
+            }
+            other => panic!("expected two theoretical prices, got {other:?}"),
+        }
+    }
+
+    /// The option price and the underlying price are adjacent and both are
+    /// prices, so a one-column shift there is the drift that looks most
+    /// plausible on a screen.
+    #[test]
+    fn test_the_option_price_is_not_the_underlying_price() {
+        let events =
+            try_parse_compact_data(&batch(theo_row("AAPL240119C00150000"))).expect("well formed");
+        match &events[0] {
+            MarketEvent::TheoPrice(theo) => {
+                assert_eq!(theo.price, 4.35, "the option price is the cheap one");
+                assert_eq!(theo.underlying_price, 152.4);
+                assert!(
+                    theo.price < theo.underlying_price,
+                    "a shifted layout would swap these two"
+                );
+            }
+            other => panic!("expected a theoretical price, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_textual_price_is_rejected() {
+        let mut values = theo_row("AAPL240119C00150000");
+        // Not a JSONDouble special value, so it must not decode.
+        values[7] = json!("4.35");
+
+        let error = try_parse_compact_data(&batch(values)).expect_err("the column is a number");
+        assert!(
+            error.to_string().contains("price"),
+            "the field is missing: {error}"
+        );
+    }
+
+    #[test]
+    fn test_a_fractional_index_is_rejected() {
+        let mut values = theo_row("AAPL240119C00150000");
+        values[4] = json!(5.5);
+
+        let error =
+            try_parse_compact_data(&batch(values)).expect_err("the column is a whole number");
+        assert!(
+            error.to_string().contains("index"),
+            "the field is missing: {error}"
+        );
+    }
+
+    #[test]
+    fn test_an_option_with_no_dividend_decodes() {
+        // A non-dividend-paying underlying reports NaN rather than zero, and
+        // the difference matters to whoever re-prices from these inputs.
+        let mut values = theo_row("AAPL240119C00150000");
+        values[11] = json!("NaN");
+
+        let events = try_parse_compact_data(&batch(values)).expect("NaN is a value");
+        match &events[0] {
+            MarketEvent::TheoPrice(theo) => {
+                assert!(theo.dividend.is_nan());
+                assert_eq!(theo.interest, 4.75);
+            }
+            other => panic!("expected a theoretical price, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_truncated_theo_price_row_is_rejected() {
+        let mut values = theo_row("AAPL240119C00150000");
+        values.pop();
+        assert!(try_parse_compact_data(&batch(values)).is_err());
+    }
+
+    #[test]
+    fn test_a_theo_price_is_not_mistaken_for_another_event() {
+        let events =
+            try_parse_compact_data(&batch(theo_row("AAPL240119C00150000"))).expect("well formed");
+        assert!(matches!(events[0], MarketEvent::TheoPrice(_)));
+
+        let json = serde_json::to_string(&events[0]).expect("serialize");
+        let back: MarketEvent = serde_json::from_str(&json).expect("deserialize");
+        assert!(
+            matches!(back, MarketEvent::TheoPrice(_)),
             "an untagged round trip picked the wrong variant: {back:?}"
         );
     }

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -937,3 +937,113 @@ async fn test_underlyings_reach_the_stream_and_the_callback() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+/// Issue #29 asks for two theoretical prices reaching both delivery paths with
+/// every pricing input intact.
+#[tokio::test]
+async fn test_theo_prices_reach_the_stream_and_the_callback() {
+    let server = MockServer::start(Behaviour::Normal).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::TheoPrice])
+        .await
+        .expect("failed to set up feed");
+
+    let call = "AAPL240119C00150000";
+    let put = "AAPL240119P00150000";
+
+    let delivered = Arc::new(Mutex::new(Vec::new()));
+    let sink = delivered.clone();
+    client.on_event(call, move |event| {
+        sink.lock().expect("callback lock poisoned").push(event);
+    });
+
+    client
+        .subscribe(
+            channel_id,
+            vec![
+                FeedSubscription {
+                    event_type: "TheoPrice".to_string(),
+                    symbol: call.to_string(),
+                    from_time: None,
+                    source: None,
+                },
+                FeedSubscription {
+                    event_type: "TheoPrice".to_string(),
+                    symbol: put.to_string(),
+                    from_time: None,
+                    source: None,
+                },
+            ],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    let events = collect_events(&mut event_stream, 2).await;
+    assert_eq!(
+        events.len(),
+        2,
+        "expected two theoretical prices, got {events:?}"
+    );
+
+    let symbols: Vec<&str> = events
+        .iter()
+        .map(|event| match event {
+            MarketEvent::TheoPrice(theo) => theo.event_symbol.as_str(),
+            other => panic!("expected a theoretical price, got {other:?}"),
+        })
+        .collect();
+    assert!(symbols.contains(&call), "the call is missing: {symbols:?}");
+    assert!(symbols.contains(&put), "the put is missing: {symbols:?}");
+
+    let theo = events
+        .iter()
+        .find_map(|event| match event {
+            MarketEvent::TheoPrice(theo) if theo.event_symbol == call => Some(theo),
+            _ => None,
+        })
+        .expect("no TheoPrice for the call reached the stream");
+
+    assert_eq!(theo.event_type, "TheoPrice");
+    assert_eq!(theo.event_time, expected::EVENT_TIME);
+    assert_eq!(theo.event_flags, expected::EVENT_FLAGS);
+    assert_eq!(theo.index, expected::INDEX);
+    assert_eq!(theo.time, expected::TIME);
+    assert_eq!(theo.sequence, expected::SEQUENCE);
+    assert_eq!(theo.price, expected::PRICE);
+    assert_eq!(theo.underlying_price, expected::UNDERLYING_PRICE);
+    assert_eq!(theo.delta, expected::DELTA);
+    assert_eq!(theo.gamma, expected::GAMMA);
+    assert_eq!(theo.dividend, expected::DIVIDEND);
+    assert_eq!(theo.interest, expected::INTEREST);
+
+    // The callback routes through symbol_of, which needed a new arm for this
+    // variant, and it is scoped to the call so the put must not appear.
+    let seen: Vec<MarketEvent> = {
+        let events = delivered.lock().expect("callback lock poisoned");
+        events.clone()
+    };
+    match seen.as_slice() {
+        [MarketEvent::TheoPrice(theo)] => {
+            assert_eq!(theo.event_symbol, call);
+            // The two prices are adjacent columns and both are prices, so this
+            // is the pair a shifted layout would swap.
+            assert_eq!(theo.price, expected::PRICE);
+            assert_eq!(theo.underlying_price, expected::UNDERLYING_PRICE);
+        }
+        other => {
+            panic!(
+                "the callback for the call should have received one theoretical price, got {other:?}"
+            )
+        }
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -472,7 +472,8 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "prevDayClosePriceType" => json!("Final"),
         "prevDayVolume" => json!(58_000_000.0),
         "openInterest" => json!(4_200.0),
-        // TimeAndSale (time, price, size, bidPrice and askPrice are above)
+        // TimeAndSale (time comes from Candle, price and size from Trade,
+        // bidPrice and askPrice from Quote)
         "timeNanoPart" => json!(250_000i64),
         "exchangeCode" => json!("Q"),
         "exchangeSaleConditions" => json!("@ TI"),
@@ -502,13 +503,13 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "exDividendDayId" => json!(20240209i64),
         "shares" => json!(15_552_800_000.0),
         "freeFloat" => json!(15_461_900_000.0),
-        // Underlying (volatility is above, shared with Greeks)
+        // Underlying (volatility is shared with Greeks)
         "frontVolatility" => json!(0.28),
         "backVolatility" => json!(0.22),
         "callVolume" => json!(310_000.0),
         "putVolume" => json!(465_000.0),
         "putCallRatio" => json!(1.5),
-        // TheoPrice (price, delta and gamma are above)
+        // TheoPrice (price is shared with Trade, delta and gamma with Greeks)
         "underlyingPrice" => json!(152.4),
         "dividend" => json!(0.55),
         "interest" => json!(4.75),

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -508,6 +508,10 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "callVolume" => json!(310_000.0),
         "putVolume" => json!(465_000.0),
         "putCallRatio" => json!(1.5),
+        // TheoPrice (price, delta and gamma are above)
+        "underlyingPrice" => json!(152.4),
+        "dividend" => json!(0.55),
+        "interest" => json!(4.75),
         // Greeks
         "delta" => json!(0.65),
         "gamma" => json!(0.05),
@@ -599,6 +603,9 @@ pub mod expected {
     pub const CALL_VOLUME: f64 = 310_000.0;
     pub const PUT_VOLUME: f64 = 465_000.0;
     pub const PUT_CALL_RATIO: f64 = 1.5;
+    pub const UNDERLYING_PRICE: f64 = 152.4;
+    pub const DIVIDEND: f64 = 0.55;
+    pub const INTEREST: f64 = 4.75;
 }
 
 /// Convenience predicates for `wait_for`.


### PR DESCRIPTION
## Summary

`TheoPrice` completes the six-site checklist: enum variant, struct, field list, decoder arm, dispatch arm, docs. The layout is the full 13 columns issue #29 specifies.

Stacked on #56.

## Technical decisions

**Field names come from the dxFeed AsyncAPI schema**, not from memory — a wrong name is a `FEED_SETUP` the server does not recognise, which is not a compile error.

**The whole layout, not a subset.** The inputs travel with the output on purpose: a theoretical price is only meaningful next to the underlying price, dividend and interest rate that produced it, and a consumer that wants to re-price needs all four.

**`dividend` stays `NaN` rather than becoming zero.** A non-dividend-paying underlying reports no rate, and that is not the same statement as a rate of zero to whoever re-prices from these inputs.

## Public API impact

Additive: `TheoPriceEvent`, `MarketEvent::TheoPrice`. The new variant breaks downstream exhaustive matches on `MarketEvent`, so this is a 0.x minor bump.

## Testing

- The field list length is pinned against the decoder stride, so the two halves of the COMPACT contract cannot drift apart.
- Two theoretical prices in one batch, a call and a put, symbols proving the stride of 13.
- `price` and `underlyingPrice` are adjacent and both are prices, which is the drift that looks most plausible on a screen; a test asserts the option price stays the cheap one.
- A textual price and a fractional `index` are both rejected, naming the field.
- An option on a non-dividend-paying underlying decodes with `NaN`.
- A truncated row is rejected.
- Serde: the serialized key set is asserted equal to the type's `compact_fields` list.
- End to end against the mock server: two theoretical prices reach both the stream and a per-symbol callback with every column intact. Verified by mutation — swapping `price` and `underlyingPrice` in the field list fails this test.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #29
