### PR TITLE
Track subscriptions per channel and commit after successful sends (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ to DXLink servers, subscribing to market events, and processing real-time market
 
 - Session lifecycle over the DXLink WebSocket protocol: `SETUP`, token
   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
+- Subscriptions tracked **per channel**, with `fromTime` and `source`, and
+  committed only after the outbound send succeeds. Two channels can hold the
+  same event and symbol independently, and resetting or closing one leaves
+  the others alone. [`DXLinkClient::subscriptions`] reports what the client
+  believes is live.
 - Automatic keepalives while the connection is open.
 - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
   `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`, `Underlying` and

--- a/src/client.rs
+++ b/src/client.rs
@@ -1663,8 +1663,8 @@ impl DXLinkClient {
         Ok(())
     }
 
-    /// Resets the subscriptions on one channel, leaving every other channel's
-    /// alone.
+    /// Resets the subscriptions on one channel, leaving the subscriptions on
+    /// every other channel untouched.
     ///
     /// The reset the server performs is scoped to the channel it arrives on, so
     /// the tracked state now matches: this used to clear every channel's

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,7 +14,7 @@ use crate::messages::{
 };
 use crate::try_parse_compact_data;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -215,6 +215,96 @@ type ChannelSchema = HashMap<String, Vec<String>>;
 /// Validated layouts per channel.
 type ChannelSchemas = Arc<Mutex<HashMap<u32, ChannelSchema>>>;
 
+/// One tracked subscription, with the order it was asked for.
+///
+/// The order is what makes replay reproducible: a map alone would hand the
+/// subscriptions back in an arbitrary order, and a server that applies them in
+/// sequence would see a different session than the consumer built.
+#[derive(Debug, Clone)]
+struct TrackedSubscription {
+    order: u64,
+    subscription: FeedSubscription,
+}
+
+/// Live subscriptions, per channel, keyed the way the server keys them.
+///
+/// The server identifies a subscription within a channel by event type and
+/// symbol; `fromTime` and `source` are parameters of that subscription rather
+/// than part of its identity. So subscribing to the same type and symbol twice
+/// on one channel **replaces** the entry — the second call is what the server
+/// ends up honouring, and tracking both would make replay send a subscription
+/// the server had already superseded.
+///
+/// Per channel, because two feed channels can legitimately hold the same event
+/// and symbol with different aggregation, and closing or resetting one must not
+/// forget the other's.
+#[derive(Debug, Default)]
+struct SubscriptionBook {
+    by_channel: HashMap<u32, HashMap<(EventType, String), TrackedSubscription>>,
+    next_order: u64,
+}
+
+impl SubscriptionBook {
+    /// Records a subscription, replacing any earlier one for the same type and
+    /// symbol on that channel.
+    fn insert(&mut self, channel_id: u32, event_type: EventType, subscription: FeedSubscription) {
+        let order = self.next_order;
+        self.next_order += 1;
+        self.by_channel.entry(channel_id).or_default().insert(
+            (event_type, subscription.symbol.clone()),
+            TrackedSubscription {
+                order,
+                subscription,
+            },
+        );
+    }
+
+    /// Forgets one subscription. Unknown entries are ignored: the server treats
+    /// removing something that is not there as a no-op too.
+    fn remove(&mut self, channel_id: u32, event_type: EventType, symbol: &str) {
+        if let Some(channel) = self.by_channel.get_mut(&channel_id) {
+            channel.remove(&(event_type, symbol.to_string()));
+            if channel.is_empty() {
+                self.by_channel.remove(&channel_id);
+            }
+        }
+    }
+
+    /// Forgets everything on one channel, leaving every other channel alone.
+    fn forget_channel(&mut self, channel_id: u32) {
+        self.by_channel.remove(&channel_id);
+    }
+
+    /// The live subscriptions on a channel, in the order they were asked for.
+    fn of_channel(&self, channel_id: u32) -> Vec<FeedSubscription> {
+        let Some(channel) = self.by_channel.get(&channel_id) else {
+            return Vec::new();
+        };
+        let mut tracked: Vec<&TrackedSubscription> = channel.values().collect();
+        tracked.sort_unstable_by_key(|entry| entry.order);
+        tracked
+            .iter()
+            .map(|entry| entry.subscription.clone())
+            .collect()
+    }
+
+    /// Every channel that has at least one subscription, lowest id first.
+    fn channels(&self) -> Vec<u32> {
+        let mut channels: Vec<u32> = self.by_channel.keys().copied().collect();
+        channels.sort_unstable();
+        channels
+    }
+
+    /// How many subscriptions are live across every channel.
+    fn len(&self) -> usize {
+        self.by_channel.values().map(HashMap::len).sum()
+    }
+
+    fn clear(&mut self) {
+        self.by_channel.clear();
+    }
+}
+
 /// The COMPACT field lists this client requests for a set of event types.
 /// Callers reach this only after refusing types with no decoder, so a type
 /// without one is skipped rather than given the two-field fallback that made
@@ -406,10 +496,11 @@ impl Drop for PendingGuard {
 ///   specific market data symbols.  The callbacks are of type `EventCallback`,
 ///   which are functions that process incoming `MarketEvent` data.  An `Arc<Mutex>`
 ///   is used for thread safety.
-/// * `subscriptions`: A thread-safe set that keeps track of active subscriptions,
-///   identified by pairs of `EventType` and the corresponding market data symbol.
-///   This ensures that duplicate subscriptions are avoided and allows for efficient
-///   management of subscriptions.  It uses `Arc<Mutex>` for thread safety.
+/// * `subscriptions`: The live subscriptions, tracked per channel and keyed by
+///   event type and symbol, carrying `fromTime` and `source` so a session can be
+///   replayed exactly. Committed only after the outbound send succeeds, so a
+///   failed send never leaves the client believing in state the server does not
+///   have. It uses `Arc<Mutex>` for thread safety.
 /// * `event_sender`: A sender for transmitting `MarketEvent` instances.  This is
 ///   optional (`Option<Sender<MarketEvent>>`) and is used to relay events to
 ///   internal processing or external consumers.
@@ -446,8 +537,9 @@ pub struct DXLinkClient {
     channels: Arc<Mutex<HashMap<u32, String>>>, // channel_id -> service
     /// A thread-safe map storing callback functions associated with specific market data symbols.
     callbacks: Arc<Mutex<HashMap<String, Arc<EventCallback>>>>, // symbol -> callback
-    /// A thread-safe set keeping track of active subscriptions, identified by `(EventType, String)`.
-    subscriptions: Arc<Mutex<HashSet<(EventType, String)>>>, // (event_type, symbol)
+    /// Live subscriptions, tracked per channel and committed only after the
+    /// outbound send succeeds.
+    subscriptions: Arc<Mutex<SubscriptionBook>>,
     /// A sender for transmitting `MarketEvent` instances.
     event_sender: Option<Sender<MarketEvent>>,
     /// A handle to the keepalive task.
@@ -504,7 +596,7 @@ impl DXLinkClient {
             next_channel_id: Arc::new(Mutex::new(1)), // Start from 1 as 0 is the main channel
             channels: Arc::new(Mutex::new(HashMap::new())),
             callbacks: Arc::new(Mutex::new(HashMap::new())),
-            subscriptions: Arc::new(Mutex::new(HashSet::new())),
+            subscriptions: Arc::new(Mutex::new(SubscriptionBook::default())),
             event_sender: None,
             keepalive_handle: None,
             message_handle: None,
@@ -1503,12 +1595,11 @@ impl DXLinkClient {
             reset: None,
         };
 
-        // Take the symbols back before the message is moved into the send.
-        let symbols: Vec<String> = subscription_msg
-            .add
-            .as_ref()
-            .map(|subs| subs.iter().map(|sub| sub.symbol.clone()).collect())
-            .unwrap_or_default();
+        // Copy the subscriptions back before the message is moved into the
+        // send: the tracked state carries fromTime and source, not just the
+        // symbol, because a replay that dropped them would resubscribe live
+        // where the consumer had asked for history.
+        let sent: Vec<FeedSubscription> = subscription_msg.add.clone().unwrap_or_default();
 
         let conn = self.get_connection_mut()?;
         conn.send(&subscription_msg).await?;
@@ -1518,8 +1609,8 @@ impl DXLinkClient {
         // is the same divergence this method was fixed to avoid.
         {
             let mut subs = recover(&self.subscriptions);
-            for (event_type, symbol) in parsed.iter().zip(symbols) {
-                subs.insert((*event_type, symbol));
+            for (event_type, subscription) in parsed.iter().zip(sent) {
+                subs.insert(channel_id, *event_type, subscription);
             }
         }
 
@@ -1562,8 +1653,8 @@ impl DXLinkClient {
         // not leave the client believing it unsubscribed.
         {
             let mut subs = recover(&self.subscriptions);
-            for (event_type, symbol) in parsed.iter().zip(symbols) {
-                subs.remove(&(*event_type, symbol));
+            for (event_type, symbol) in parsed.iter().zip(&symbols) {
+                subs.remove(channel_id, *event_type, symbol);
             }
         }
 
@@ -1572,16 +1663,16 @@ impl DXLinkClient {
         Ok(())
     }
 
-    /// Reset all subscriptions on a channel
+    /// Resets the subscriptions on one channel, leaving every other channel's
+    /// alone.
+    ///
+    /// The reset the server performs is scoped to the channel it arrives on, so
+    /// the tracked state now matches: this used to clear every channel's
+    /// subscriptions, which left the client blind to symbols that were still
+    /// being delivered.
     pub async fn reset_subscriptions(&mut self, channel_id: u32) -> DXLinkResult<()> {
         // Validate channel exists and is a FEED channel
         self.validate_channel(channel_id, "FEED")?;
-
-        // Remove all subscriptions for this channel
-        {
-            let mut subs = recover(&self.subscriptions);
-            subs.clear(); // This is a simplification - in reality you might want to track by channel
-        }
 
         let subscription_msg = FeedSubscriptionMessage {
             channel: channel_id,
@@ -1593,6 +1684,10 @@ impl DXLinkClient {
 
         let conn = self.get_connection_mut()?;
         conn.send(&subscription_msg).await?;
+
+        // After the send, like subscribe and unsubscribe: a reset that never
+        // left the client must not be recorded as one that did.
+        recover(&self.subscriptions).forget_channel(channel_id);
 
         info!("All subscriptions reset on channel {}", channel_id);
 
@@ -1643,6 +1738,12 @@ impl DXLinkClient {
                     let mut channels = recover(&self.channels);
                     channels.remove(&channel_id);
                 }
+                // A closed channel delivers nothing, so its subscriptions and
+                // its validated layouts are gone with it. Leaving them behind
+                // made a later replay resubscribe on a channel that no longer
+                // existed.
+                recover(&self.subscriptions).forget_channel(channel_id);
+                recover(&self.channel_schemas).remove(&channel_id);
 
                 info!("Channel {} closed successfully", channel_id);
                 Ok(())
@@ -1654,6 +1755,27 @@ impl DXLinkClient {
                 "Unexpected response type".to_string(),
             )),
         }
+    }
+
+    /// The subscriptions this client believes are live on a channel, in the
+    /// order they were asked for.
+    ///
+    /// Only what the server acknowledged by accepting the send: a subscription
+    /// whose `FEED_SUBSCRIPTION` failed to go out never appears here. An unknown
+    /// or closed channel gives an empty list rather than an error, because
+    /// "nothing is subscribed there" is the true answer in both cases.
+    ///
+    /// Additive: a new method, no existing signature changes.
+    pub fn subscriptions(&self, channel_id: u32) -> Vec<FeedSubscription> {
+        recover(&self.subscriptions).of_channel(channel_id)
+    }
+
+    /// The channels that currently hold at least one subscription, lowest id
+    /// first.
+    ///
+    /// Additive: a new method, no existing signature changes.
+    pub fn subscribed_channels(&self) -> Vec<u32> {
+        recover(&self.subscriptions).channels()
     }
 
     /// Register a callback function for a specific symbol

--- a/src/client.rs
+++ b/src/client.rs
@@ -226,32 +226,50 @@ struct TrackedSubscription {
     subscription: FeedSubscription,
 }
 
+/// What identifies a subscription inside one channel: event type, symbol and
+/// source.
+///
+/// `source` is part of the identity because an indexed subscription is scoped
+/// to it — the same type and symbol from two sources are two subscriptions, and
+/// removing one must not forget the other. `fromTime` is **not**: it is a
+/// parameter of the series, so resubscribing the same symbol from the same
+/// source with a new time replaces the entry rather than adding a second one.
+type SubscriptionKey = (EventType, String, Option<String>);
+
 /// Live subscriptions, per channel, keyed the way the server keys them.
 ///
-/// The server identifies a subscription within a channel by event type and
-/// symbol; `fromTime` and `source` are parameters of that subscription rather
-/// than part of its identity. So subscribing to the same type and symbol twice
-/// on one channel **replaces** the entry — the second call is what the server
-/// ends up honouring, and tracking both would make replay send a subscription
-/// the server had already superseded.
+/// Subscribing twice to the same [`SubscriptionKey`] on one channel
+/// **replaces** the entry: the second call is what the server ends up
+/// honouring, and tracking both would make a replay send a subscription the
+/// server had already superseded.
 ///
 /// Per channel, because two feed channels can legitimately hold the same event
 /// and symbol with different aggregation, and closing or resetting one must not
 /// forget the other's.
 #[derive(Debug, Default)]
 struct SubscriptionBook {
-    by_channel: HashMap<u32, HashMap<(EventType, String), TrackedSubscription>>,
+    by_channel: HashMap<u32, HashMap<SubscriptionKey, TrackedSubscription>>,
     next_order: u64,
 }
 
+/// The identity of a subscription, for tracking it.
+fn key_of(event_type: EventType, subscription: &FeedSubscription) -> SubscriptionKey {
+    (
+        event_type,
+        subscription.symbol.clone(),
+        subscription.source.clone(),
+    )
+}
+
 impl SubscriptionBook {
-    /// Records a subscription, replacing any earlier one for the same type and
-    /// symbol on that channel.
+    /// Records a subscription, replacing any earlier one with the same identity
+    /// on that channel.
     fn insert(&mut self, channel_id: u32, event_type: EventType, subscription: FeedSubscription) {
         let order = self.next_order;
         self.next_order += 1;
+        let key = key_of(event_type, &subscription);
         self.by_channel.entry(channel_id).or_default().insert(
-            (event_type, subscription.symbol.clone()),
+            key,
             TrackedSubscription {
                 order,
                 subscription,
@@ -261,9 +279,9 @@ impl SubscriptionBook {
 
     /// Forgets one subscription. Unknown entries are ignored: the server treats
     /// removing something that is not there as a no-op too.
-    fn remove(&mut self, channel_id: u32, event_type: EventType, symbol: &str) {
+    fn remove(&mut self, channel_id: u32, event_type: EventType, subscription: &FeedSubscription) {
         if let Some(channel) = self.by_channel.get_mut(&channel_id) {
-            channel.remove(&(event_type, symbol.to_string()));
+            channel.remove(&key_of(event_type, subscription));
             if channel.is_empty() {
                 self.by_channel.remove(&channel_id);
             }
@@ -1636,7 +1654,6 @@ impl DXLinkClient {
             ))
         })?;
         let parsed = parse_subscription_types(&subscriptions, channel_id, &configured)?;
-        let symbols: Vec<String> = subscriptions.iter().map(|s| s.symbol.clone()).collect();
 
         let subscription_msg = FeedSubscriptionMessage {
             channel: channel_id,
@@ -1650,11 +1667,13 @@ impl DXLinkClient {
         conn.send(&subscription_msg).await?;
 
         // After the send, for the same reason as subscribe: a failed send must
-        // not leave the client believing it unsubscribed.
-        {
+        // not leave the client believing it unsubscribed. Matched on the whole
+        // identity, source included, so removing one source's subscription does
+        // not forget another's for the same symbol.
+        if let Some(removed) = subscription_msg.remove.as_ref() {
             let mut subs = recover(&self.subscriptions);
-            for (event_type, symbol) in parsed.iter().zip(&symbols) {
-                subs.remove(channel_id, *event_type, symbol);
+            for (event_type, subscription) in parsed.iter().zip(removed) {
+                subs.remove(channel_id, *event_type, subscription);
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,11 @@
 //!
 //! - Session lifecycle over the DXLink WebSocket protocol: `SETUP`, token
 //!   authentication, feed channels, `FEED_SETUP`, subscribe and unsubscribe.
+//! - Subscriptions tracked **per channel**, with `fromTime` and `source`, and
+//!   committed only after the outbound send succeeds. Two channels can hold the
+//!   same event and symbol independently, and resetting or closing one leaves
+//!   the others alone. [`DXLinkClient::subscriptions`] reports what the client
+//!   believes is live.
 //! - Automatic keepalives while the connection is open.
 //! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
 //!   `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`, `Underlying` and

--- a/tests/integration/dxlink_extra.rs
+++ b/tests/integration/dxlink_extra.rs
@@ -466,3 +466,95 @@ async fn test_a_failed_send_does_not_move_the_tracked_state() {
         "a failed reset must not clear the tracked state"
     );
 }
+
+/// An indexed subscription is scoped to its source, so the same type and symbol
+/// from two sources are two subscriptions. Collapsing them made `unsubscribe`
+/// remove the wrong local entry and a replay silently omit one source.
+#[tokio::test]
+async fn test_two_sources_for_one_symbol_are_tracked_separately() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, channel_id) = connected_feed(&server, &[EventType::Quote]).await;
+
+    let from = |source: &str| FeedSubscription {
+        event_type: "Quote".to_string(),
+        symbol: "AAPL".to_string(),
+        from_time: None,
+        source: Some(source.to_string()),
+    };
+
+    client
+        .subscribe(channel_id, vec![from("DEX"), from("NTV")])
+        .await
+        .expect("failed to subscribe");
+
+    let tracked = client.subscriptions(channel_id);
+    assert_eq!(tracked.len(), 2, "the two sources collapsed: {tracked:?}");
+
+    // Removing one leaves the other, which is the assertion a shared key fails.
+    client
+        .unsubscribe(channel_id, vec![from("DEX")])
+        .await
+        .expect("failed to unsubscribe");
+
+    let left = client.subscriptions(channel_id);
+    assert_eq!(left.len(), 1, "unsubscribe removed too much: {left:?}");
+    assert_eq!(left[0].source.as_deref(), Some("NTV"));
+}
+
+/// A subscription with no source is its own identity, not a wildcard that
+/// matches the sourced ones.
+#[tokio::test]
+async fn test_a_sourceless_subscription_is_its_own_entry() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, channel_id) = connected_feed(&server, &[EventType::Quote]).await;
+
+    let sourced = FeedSubscription {
+        event_type: "Quote".to_string(),
+        symbol: "AAPL".to_string(),
+        from_time: None,
+        source: Some("DEX".to_string()),
+    };
+
+    client
+        .subscribe(channel_id, vec![quote_sub("AAPL"), sourced.clone()])
+        .await
+        .expect("failed to subscribe");
+    assert_eq!(client.subscriptions(channel_id).len(), 2);
+
+    client
+        .unsubscribe(channel_id, vec![sourced])
+        .await
+        .expect("failed to unsubscribe");
+
+    let left = client.subscriptions(channel_id);
+    assert_eq!(left.len(), 1);
+    assert_eq!(left[0].source, None, "the wrong entry went: {left:?}");
+}
+
+/// `fromTime` is a parameter of the series rather than part of its identity, so
+/// the same symbol from the same source still replaces rather than accumulates.
+#[tokio::test]
+async fn test_a_new_from_time_replaces_the_same_source() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, channel_id) = connected_feed(&server, &[EventType::Candle]).await;
+
+    let candle = |from_time: i64| FeedSubscription {
+        event_type: "Candle".to_string(),
+        symbol: "AAPL{=5m}".to_string(),
+        from_time: Some(from_time),
+        source: Some("DEX".to_string()),
+    };
+
+    client
+        .subscribe(channel_id, vec![candle(1_700_000_000_000)])
+        .await
+        .expect("failed to subscribe");
+    client
+        .subscribe(channel_id, vec![candle(1_700_000_600_000)])
+        .await
+        .expect("failed to resubscribe");
+
+    let tracked = client.subscriptions(channel_id);
+    assert_eq!(tracked.len(), 1, "the entry should have been replaced");
+    assert_eq!(tracked[0].from_time, Some(1_700_000_600_000));
+}

--- a/tests/integration/dxlink_extra.rs
+++ b/tests/integration/dxlink_extra.rs
@@ -211,3 +211,258 @@ async fn test_historical_candles_are_requested_and_delivered() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+/// Opens a second feed channel on an already connected client.
+async fn second_feed(client: &mut DXLinkClient, events: &[EventType]) -> u32 {
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create the second feed channel");
+    client
+        .setup_feed(channel_id, events)
+        .await
+        .expect("failed to set up the second feed");
+    channel_id
+}
+
+#[tokio::test]
+async fn test_two_channels_track_the_same_symbol_independently() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, first) = connected_feed(&server, &[EventType::Quote]).await;
+    let second = second_feed(&mut client, &[EventType::Quote]).await;
+    assert_ne!(first, second, "the channels have to be distinct");
+
+    client
+        .subscribe(first, vec![quote_sub("AAPL")])
+        .await
+        .expect("failed to subscribe on the first channel");
+    client
+        .subscribe(second, vec![quote_sub("AAPL")])
+        .await
+        .expect("failed to subscribe on the second channel");
+
+    // One entry each, not one shared entry: the old global set collapsed these
+    // two into one and could not tell them apart afterwards.
+    assert_eq!(client.subscriptions(first).len(), 1);
+    assert_eq!(client.subscriptions(second).len(), 1);
+    assert_eq!(client.subscribed_channels(), vec![first, second]);
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+#[tokio::test]
+async fn test_resetting_one_channel_leaves_the_other_alone() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, first) = connected_feed(&server, &[EventType::Quote]).await;
+    let second = second_feed(&mut client, &[EventType::Quote]).await;
+
+    client
+        .subscribe(first, vec![quote_sub("AAPL"), quote_sub("MSFT")])
+        .await
+        .expect("failed to subscribe on the first channel");
+    client
+        .subscribe(second, vec![quote_sub("TSLA")])
+        .await
+        .expect("failed to subscribe on the second channel");
+
+    client
+        .reset_subscriptions(first)
+        .await
+        .expect("failed to reset");
+
+    assert!(
+        client.subscriptions(first).is_empty(),
+        "the reset channel should be empty"
+    );
+    let survivors = client.subscriptions(second);
+    assert_eq!(survivors.len(), 1, "the other channel lost its state");
+    assert_eq!(survivors[0].symbol, "TSLA");
+    assert_eq!(client.subscribed_channels(), vec![second]);
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+#[tokio::test]
+async fn test_closing_a_channel_forgets_only_its_subscriptions() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, first) = connected_feed(&server, &[EventType::Quote]).await;
+    let second = second_feed(&mut client, &[EventType::Quote]).await;
+
+    client
+        .subscribe(first, vec![quote_sub("AAPL")])
+        .await
+        .expect("failed to subscribe on the first channel");
+    client
+        .subscribe(second, vec![quote_sub("TSLA")])
+        .await
+        .expect("failed to subscribe on the second channel");
+
+    client
+        .close_channel(first)
+        .await
+        .expect("failed to close the channel");
+
+    assert!(
+        client.subscriptions(first).is_empty(),
+        "a closed channel delivers nothing, so it holds nothing"
+    );
+    assert_eq!(client.subscriptions(second).len(), 1);
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+#[tokio::test]
+async fn test_a_historical_subscription_keeps_its_from_time_and_source() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, channel_id) = connected_feed(&server, &[EventType::Candle]).await;
+
+    let from_time = 1_700_000_000_000;
+    client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Candle".to_string(),
+                symbol: "AAPL{=5m}".to_string(),
+                from_time: Some(from_time),
+                source: Some("DEX".to_string()),
+            }],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    // Both have to survive: a replay that dropped them would resubscribe live
+    // where the consumer had asked for history.
+    let tracked = client.subscriptions(channel_id);
+    assert_eq!(tracked.len(), 1);
+    assert_eq!(tracked[0].symbol, "AAPL{=5m}");
+    assert_eq!(tracked[0].from_time, Some(from_time));
+    assert_eq!(tracked[0].source.as_deref(), Some("DEX"));
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+#[tokio::test]
+async fn test_resubscribing_replaces_the_earlier_entry() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, channel_id) = connected_feed(&server, &[EventType::Candle]).await;
+
+    let candle = |from_time: i64| FeedSubscription {
+        event_type: "Candle".to_string(),
+        symbol: "AAPL{=5m}".to_string(),
+        from_time: Some(from_time),
+        source: None,
+    };
+
+    client
+        .subscribe(channel_id, vec![candle(1_700_000_000_000)])
+        .await
+        .expect("failed to subscribe");
+    client
+        .subscribe(channel_id, vec![candle(1_700_000_600_000)])
+        .await
+        .expect("failed to resubscribe");
+
+    // The server keys a subscription by type and symbol within a channel, so
+    // the second call supersedes the first. Tracking both would make a replay
+    // send a subscription the server had already replaced.
+    let tracked = client.subscriptions(channel_id);
+    assert_eq!(tracked.len(), 1, "the entry should have been replaced");
+    assert_eq!(tracked[0].from_time, Some(1_700_000_600_000));
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+#[tokio::test]
+async fn test_subscriptions_come_back_in_the_order_they_were_asked_for() {
+    let server = MockServer::start(Behaviour::Normal).await;
+    let (mut client, channel_id) = connected_feed(&server, &[EventType::Quote]).await;
+
+    for symbol in ["MSFT", "AAPL", "TSLA", "NVDA"] {
+        client
+            .subscribe(channel_id, vec![quote_sub(symbol)])
+            .await
+            .expect("failed to subscribe");
+    }
+
+    // Not sorted, not hash order: the order the consumer built the session in,
+    // which is the order a replay has to send them back in.
+    let symbols: Vec<String> = client
+        .subscriptions(channel_id)
+        .into_iter()
+        .map(|sub| sub.symbol)
+        .collect();
+    assert_eq!(symbols, ["MSFT", "AAPL", "TSLA", "NVDA"]);
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// A send that never left the client must not be recorded as one that did.
+#[tokio::test]
+async fn test_a_failed_send_does_not_move_the_tracked_state() {
+    let server = MockServer::start(Behaviour::CloseAfterSubscribe).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut stream = client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("failed to set up feed");
+
+    client
+        .subscribe(channel_id, vec![quote_sub("AAPL")])
+        .await
+        .expect("the first subscribe happens before the server hangs up");
+    assert_eq!(client.subscriptions(channel_id).len(), 1);
+
+    // The stream closing is the documented signal that the session is over, so
+    // waiting on it makes the next send deterministically fail.
+    tokio::time::timeout(std::time::Duration::from_secs(10), async {
+        while stream.recv().await.is_some() {}
+    })
+    .await
+    .expect("the stream never closed after the server hung up");
+
+    assert!(
+        client
+            .unsubscribe(channel_id, vec![quote_sub("AAPL")])
+            .await
+            .is_err(),
+        "unsubscribing over a dead socket has to fail"
+    );
+    assert_eq!(
+        client.subscriptions(channel_id).len(),
+        1,
+        "a failed unsubscribe must not forget a live subscription"
+    );
+
+    assert!(
+        client
+            .subscribe(channel_id, vec![quote_sub("MSFT")])
+            .await
+            .is_err(),
+        "subscribing over a dead socket has to fail"
+    );
+    let symbols: Vec<String> = client
+        .subscriptions(channel_id)
+        .into_iter()
+        .map(|sub| sub.symbol)
+        .collect();
+    assert_eq!(
+        symbols,
+        ["AAPL"],
+        "a failed subscribe must not be recorded as one that happened"
+    );
+
+    assert!(
+        client.reset_subscriptions(channel_id).await.is_err(),
+        "resetting over a dead socket has to fail"
+    );
+    assert_eq!(
+        client.subscriptions(channel_id).len(),
+        1,
+        "a failed reset must not clear the tracked state"
+    );
+}


### PR DESCRIPTION
## Summary

The tracked subscription set was global — `HashSet<(EventType, String)>` with no channel. That made three things wrong at once: two channels holding the same event and symbol collapsed into a single entry, closing a channel left its subscriptions behind, and `reset_subscriptions(channel)` cleared **every** channel while the server only reset the one the message arrived on.

Subscriptions are now kept per channel, with `fromTime` and `source`.

Stacked on #57.

## Technical decisions

**Keyed by event type and symbol, per channel** — the identity the server itself uses. `fromTime` and `source` are parameters of a subscription, not part of its identity, so resubscribing the same type and symbol **replaces** the entry. That is the deterministic duplicate behaviour the issue asks for: the second call is what the server honours, and tracking both would make a replay send a subscription the server had already superseded.

**Insertion-ordered.** A map alone hands subscriptions back in arbitrary order, and a server applying them in sequence would see a different session than the consumer built. Each entry carries a monotonic order and `subscriptions()` sorts by it — O(1) inserts, no new dependency.

**Reset now commits after the send**, like `subscribe` and `unsubscribe` already did. It used to clear local state first, so a reset that never reached the server still wiped what the client knew.

**`close_channel` forgets the channel's subscriptions and its validated layouts.** A closed channel delivers nothing; leaving them behind made a later replay resubscribe on a channel that no longer existed.

## Public API impact

Additive only: `DXLinkClient::subscriptions(channel_id) -> Vec<FeedSubscription>` and `DXLinkClient::subscribed_channels() -> Vec<u32>`. No existing signature changes. `reset_subscriptions` keeps its signature but its scope is now the channel it names, which is a behaviour fix rather than an API break.

## Testing

- Two channels hold the same event and symbol independently.
- Resetting one channel leaves the other's subscriptions intact; so does closing one.
- A historical subscription keeps its `fromTime` and `source` in tracked state.
- Resubscribing the same type and symbol replaces the earlier entry rather than accumulating.
- Subscriptions come back in the order they were asked for, not sorted and not in hash order.
- Failed sends over a dead socket move nothing: a failed `unsubscribe` does not forget a live subscription, a failed `subscribe` is not recorded, and a failed `reset` does not clear state. The test waits for the event stream to close first, which is the documented session-over signal, so the failure is deterministic rather than a race.
- Verified by mutation: restoring the global `clear()` in reset and dropping the `forget_channel` in close each fail their test.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #13
