### PR TITLE
Evict the oldest connection state, not the newest (#60)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ to DXLink servers, subscribing to market events, and processing real-time market
   connecting and a terminal socket failure is followed by exponential
   backoff, a fresh handshake, and a replay of every channel, feed
   configuration and subscription. A rejected token is not retried.
-  [`DXLinkClient::connection_states`] reports what is happening.
+  [`DXLinkClient::connection_states`] reports what is happening, dropping the
+  oldest states rather than the newest if a consumer falls behind, so a slow
+  reader can miss the middle of a reconnect but not its outcome.
 
 ### What is not supported yet
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -18,6 +18,7 @@ use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use tokio::sync::broadcast;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
@@ -1057,21 +1058,21 @@ fn keepalive_interval_for(advertised: u32, negotiated: Option<u32>) -> Duration 
     Duration::from_secs(u64::from(deadline.div_ceil(KEEPALIVE_DIVISOR))).max(MIN_KEEPALIVE_INTERVAL)
 }
 
-/// Reports a connection-state change, dropping it if the consumer is behind.
+/// Reports a connection-state change, never blocking the supervisor.
 ///
-/// States are advisory and the supervisor's job is to reconnect, not to block
-/// on a consumer that stopped reading.
+/// A full queue **evicts the oldest state**, so a consumer that falls behind
+/// loses the middle of a reconnect rather than its end. That is the right way
+/// round: `Reconnecting { attempt: 3 }` is worth less than the `Reconnected` or
+/// `GaveUp` that follows it, and the previous `mpsc` did the opposite because a
+/// sender cannot evict from the front of its own queue.
 ///
-/// **Drops the state being reported, not the oldest queued one.** An `mpsc`
-/// sender cannot evict from the front of its own queue, so a consumer that
-/// ignores the stream long enough to fill it stops seeing new states rather
-/// than losing old ones. See issue #60: the terminal states are the ones worth
-/// keeping, so the eviction should go the other way.
-fn notify(states: &Option<Sender<ConnectionState>>, state: ConnectionState) {
+/// A send with no subscribers is not a failure. It is the normal case for a
+/// consumer that never asked for the stream.
+fn notify(states: &Option<broadcast::Sender<ConnectionState>>, state: ConnectionState) {
     if let Some(tx) = states
-        && tx.try_send(state.clone()).is_err()
+        && tx.send(state).is_err()
     {
-        debug!("Dropping connection state {state:?}: nobody is reading them");
+        debug!("No connection-state subscribers");
     }
 }
 
@@ -1552,10 +1553,10 @@ pub struct DXLinkClient {
     /// The reconnection policy, if the consumer installed one. `None` is the
     /// default and means the client never retries.
     reconnect: Option<ReconnectPolicy>,
-    /// The connection-state stream, until the consumer takes it.
-    state_receiver: Option<Receiver<ConnectionState>>,
-    /// The sending half, kept so the supervisor can be handed a clone.
-    state_sender: Option<Sender<ConnectionState>>,
+    /// Broadcasts connection-state changes. `None` until a session with a
+    /// reconnect policy is established, and dropped again on `disconnect`, which
+    /// is what closes a consumer's stream.
+    state_sender: Option<broadcast::Sender<ConnectionState>>,
     /// A handle to the reconnect supervisor, when one is running.
     supervisor_handle: Option<JoinHandle<()>>,
     /// Stops the supervisor, including a backoff it is in the middle of.
@@ -1615,7 +1616,6 @@ impl DXLinkClient {
             channel_schemas: Arc::new(Mutex::new(HashMap::new())),
             channel_contracts: Arc::new(Mutex::new(HashMap::new())),
             reconnect: None,
-            state_receiver: None,
             state_sender: None,
             supervisor_handle: None,
             supervisor_shutdown: None,
@@ -1791,22 +1791,25 @@ impl DXLinkClient {
         self.reconnect = Some(policy);
     }
 
-    /// Takes the stream of connection-state changes.
+    /// Subscribes to connection-state changes.
     ///
-    /// There is one per client and it is handed out once; a second call
-    /// returns `None`. Only useful with a reconnect policy installed, since
-    /// without one the session never comes back and the closing event stream
-    /// already says so.
+    /// `None` without a reconnect policy: the session never comes back, and the
+    /// closing event stream already says so. Otherwise every call returns a new
+    /// receiver, and each one sees only what is sent **after** it subscribes —
+    /// so subscribe before the states you care about, which in practice means
+    /// right after [`connect`](Self::connect).
     ///
-    /// The stream is bounded and **never blocks the supervisor**: when the
-    /// queue is full the new state is dropped, so a consumer that stops reading
-    /// long enough to fill it stops seeing changes until it drains. States are
-    /// advisory; the authority on whether the client is live is whether events
-    /// are still arriving.
+    /// The stream is bounded and never blocks the supervisor. A consumer that
+    /// falls behind **loses the oldest states**, is told how many with
+    /// [`RecvError::Lagged`](tokio::sync::broadcast::error::RecvError::Lagged),
+    /// and carries on — so it can miss the middle of a long reconnect but not
+    /// the `Reconnected` or `GaveUp` that ends it.
     ///
-    /// Additive: a new method, no existing signature changes.
-    pub fn connection_states(&mut self) -> Option<Receiver<ConnectionState>> {
-        self.state_receiver.take()
+    /// The stream closes when the session does: after
+    /// [`disconnect`](Self::disconnect), or when the client is dropped.
+    /// Subscribing again after a later `connect` gives a live stream.
+    pub fn connection_states(&self) -> Option<broadcast::Receiver<ConnectionState>> {
+        self.state_sender.as_ref().map(broadcast::Sender::subscribe)
     }
 
     /// Sets the keepalive timeout this client advertises, in seconds.
@@ -1901,9 +1904,8 @@ impl DXLinkClient {
             let (lost_tx, lost_rx) = mpsc::channel::<String>(1);
             self.session_lost_sender = Some(lost_tx);
             self.session_lost_receiver = Some(lost_rx);
-            let (state_tx, state_rx) = mpsc::channel::<ConnectionState>(CONNECTION_STATE_CAPACITY);
+            let (state_tx, _) = broadcast::channel::<ConnectionState>(CONNECTION_STATE_CAPACITY);
             self.state_sender = Some(state_tx);
-            self.state_receiver = Some(state_rx);
         }
 
         // Keepalive first: it owns the shutdown channel the reader needs in
@@ -2034,10 +2036,10 @@ impl DXLinkClient {
             session_tasks: self.session_tasks.clone(),
         };
 
-        // Taken, not cloned: the supervisor becomes the only sender, so when it
-        // returns the state stream closes. A client holding a clone would leave
-        // a consumer waiting on states that can never come.
-        let states = self.state_sender.take();
+        // Cloned, not taken: a consumer can subscribe at any time, so the client
+        // keeps its own sender. `disconnect` drops that one, and the supervisor
+        // returning drops this one, which together close the stream.
+        let states = self.state_sender.clone();
         let (shutdown_tx, mut shutdown_rx) = mpsc::channel::<()>(1);
         self.supervisor_shutdown = Some(shutdown_tx);
 
@@ -2159,6 +2161,10 @@ impl DXLinkClient {
         // Dropping the sender means a reader that dies during the teardown
         // below has nobody to report to, which is what we want by then.
         self.session_lost_sender = None;
+        // And the state stream ends with the session: the supervisor has
+        // returned, so this is the last sender and dropping it is what tells a
+        // consumer there will be no more states.
+        self.state_sender = None;
 
         // 1. Stop writing maintenance, so nothing races the shutdown.
         // Taken in its own block: the guard must not live into the await below,

--- a/src/client.rs
+++ b/src/client.rs
@@ -1066,13 +1066,12 @@ fn keepalive_interval_for(advertised: u32, negotiated: Option<u32>) -> Duration 
 /// `GaveUp` that follows it, and the previous `mpsc` did the opposite because a
 /// sender cannot evict from the front of its own queue.
 ///
-/// A send with no subscribers is not a failure. It is the normal case for a
-/// consumer that never asked for the stream.
+/// A send with no subscribers is not a failure, it is the normal case for a
+/// consumer that never asked for the stream — and it is the case on **every**
+/// transition, so it is dropped silently rather than logged.
 fn notify(states: &Option<broadcast::Sender<ConnectionState>>, state: ConnectionState) {
-    if let Some(tx) = states
-        && tx.send(state).is_err()
-    {
-        debug!("No connection-state subscribers");
+    if let Some(tx) = states {
+        let _ = tx.send(state);
     }
 }
 
@@ -1789,15 +1788,30 @@ impl DXLinkClient {
     /// ```
     pub fn with_reconnect(&mut self, policy: ReconnectPolicy) {
         self.reconnect = Some(policy);
+        // Opened here rather than in `connect`, so `connection_states` works the
+        // moment a policy exists. A `&self` accessor that answered `None` until
+        // some other call had happened would be a trap.
+        if self.state_sender.is_none() {
+            // Normally already open, from `with_reconnect`. This covers a
+            // reconnect after a `disconnect`, which drops the old one.
+            if self.state_sender.is_none() {
+                let (state_tx, _) =
+                    broadcast::channel::<ConnectionState>(CONNECTION_STATE_CAPACITY);
+                self.state_sender = Some(state_tx);
+            }
+        }
     }
 
     /// Subscribes to connection-state changes.
     ///
     /// `None` without a reconnect policy: the session never comes back, and the
-    /// closing event stream already says so. Otherwise every call returns a new
-    /// receiver, and each one sees only what is sent **after** it subscribes —
-    /// so subscribe before the states you care about, which in practice means
-    /// right after [`connect`](Self::connect).
+    /// closing event stream already says so. With one, every call returns a new
+    /// receiver, from [`with_reconnect`](Self::with_reconnect) onwards — no need
+    /// to connect first.
+    ///
+    /// Each receiver sees only what is sent **after** it subscribes, so
+    /// subscribe before the states you care about. Subscribing right after
+    /// installing the policy is the way to be sure of catching all of them.
     ///
     /// The stream is bounded and never blocks the supervisor. A consumer that
     /// falls behind **loses the oldest states**, is told how many with
@@ -2161,9 +2175,10 @@ impl DXLinkClient {
         // Dropping the sender means a reader that dies during the teardown
         // below has nobody to report to, which is what we want by then.
         self.session_lost_sender = None;
-        // And the state stream ends with the session: the supervisor has
-        // returned, so this is the last sender and dropping it is what tells a
-        // consumer there will be no more states.
+        // And the state stream ends with the session. The supervisor is stopped
+        // by now, whether it returned or was aborted after the grace period, and
+        // either way it no longer holds a sender — so dropping this one is what
+        // tells a consumer there will be no more states.
         self.state_sender = None;
 
         // 1. Stop writing maintenance, so nothing races the shutdown.
@@ -3319,5 +3334,15 @@ mod reconnect_policy_tests {
 
         client.with_reconnect(ReconnectPolicy::default());
         assert!(client.reconnect.is_some());
+
+        // Available from here, without connecting first: a `&self` accessor
+        // that answered None until some other call had happened is a trap.
+        assert!(
+            client.connection_states().is_some(),
+            "the stream should exist as soon as the policy does"
+        );
+        // And it is a subscription, not a handout, so a second caller gets one
+        // of their own.
+        assert!(client.connection_states().is_some());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,9 @@
 //!   connecting and a terminal socket failure is followed by exponential
 //!   backoff, a fresh handshake, and a replay of every channel, feed
 //!   configuration and subscription. A rejected token is not retried.
-//!   [`DXLinkClient::connection_states`] reports what is happening.
+//!   [`DXLinkClient::connection_states`] reports what is happening, dropping the
+//!   oldest states rather than the newest if a consumer falls behind, so a slow
+//!   reader can miss the middle of a reconnect but not its outcome.
 //!
 //! ## What is not supported yet
 //!

--- a/tests/integration/dxlink_reconnect.rs
+++ b/tests/integration/dxlink_reconnect.rs
@@ -11,6 +11,7 @@ use dxlink::{
     ConnectionState, DXLinkClient, EventType, FeedSubscription, MarketEvent, ReconnectPolicy,
 };
 use std::time::Duration;
+use tokio::sync::broadcast;
 
 /// Fast and jitter-free, so a test asserts on behaviour rather than on timing.
 fn prompt_policy() -> ReconnectPolicy {
@@ -33,7 +34,7 @@ fn quote_sub(symbol: &str) -> FeedSubscription {
 
 /// Waits for a state, failing rather than hanging if it never comes.
 async fn wait_for_state(
-    states: &mut tokio::sync::mpsc::Receiver<ConnectionState>,
+    states: &mut broadcast::Receiver<ConnectionState>,
     what: &str,
     matches: impl Fn(&ConnectionState) -> bool,
 ) -> ConnectionState {
@@ -41,10 +42,15 @@ async fn wait_for_state(
     let deadline = std::time::Instant::now() + Duration::from_secs(40);
     loop {
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
-        let state = tokio::time::timeout(remaining, states.recv())
-            .await
-            .unwrap_or_else(|_| panic!("timed out waiting for {what}"))
-            .unwrap_or_else(|| panic!("the state stream closed before {what}"));
+        let state = match tokio::time::timeout(remaining, states.recv()).await {
+            Ok(Ok(state)) => state,
+            // Falling behind is not a failure, it is the documented behaviour.
+            Ok(Err(broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(broadcast::error::RecvError::Closed)) => {
+                panic!("the state stream closed before {what}")
+            }
+            Err(_) => panic!("timed out waiting for {what}"),
+        };
         if matches(&state) {
             return state;
         }
@@ -72,6 +78,24 @@ async fn wait_until(
             "timed out waiting for {what}"
         );
         tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+}
+
+/// Waits for the state stream to close, which is how a consumer learns the
+/// session is over for good. Lagged is skipped: falling behind is not closing.
+async fn expect_stream_closed(
+    states: &mut broadcast::Receiver<ConnectionState>,
+    within: Duration,
+    what: &str,
+) {
+    let deadline = std::time::Instant::now() + within;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        match tokio::time::timeout(remaining, states.recv()).await {
+            Ok(Err(broadcast::error::RecvError::Closed)) => return,
+            Ok(Err(broadcast::error::RecvError::Lagged(_))) | Ok(Ok(_)) => continue,
+            Err(_) => panic!("{what}"),
+        }
     }
 }
 
@@ -314,13 +338,12 @@ async fn test_disconnect_cancels_a_running_backoff() {
         .expect("failed to disconnect");
 
     // The supervisor is gone, so its end of the state stream is closed.
-    assert!(
-        tokio::time::timeout(Duration::from_secs(5), states.recv())
-            .await
-            .expect("the state stream should close promptly")
-            .is_none(),
-        "the supervisor is still running after disconnect"
-    );
+    expect_stream_closed(
+        &mut states,
+        Duration::from_secs(5),
+        "the supervisor is still running after disconnect",
+    )
+    .await;
 }
 
 /// Sets up a session that is about to be dropped, returning the channel and the
@@ -332,7 +355,7 @@ async fn dropped_session(
     DXLinkClient,
     u32,
     tokio::sync::mpsc::Receiver<MarketEvent>,
-    tokio::sync::mpsc::Receiver<ConnectionState>,
+    broadcast::Receiver<ConnectionState>,
 ) {
     let mut client = DXLinkClient::new(&server.url(), "test-token");
     client.with_reconnect(policy);
@@ -513,13 +536,12 @@ async fn test_dropping_a_client_stops_a_supervisor_mid_attempt() {
     drop(client);
 
     // Well under the handshake deadline it would otherwise be sitting in.
-    assert!(
-        tokio::time::timeout(Duration::from_secs(3), states.recv())
-            .await
-            .expect("the supervisor was still inside its attempt after the client was dropped")
-            .is_none(),
-        "the supervisor outlived the client"
-    );
+    expect_stream_closed(
+        &mut states,
+        Duration::from_secs(3),
+        "the supervisor was still inside its attempt after the client was dropped",
+    )
+    .await;
     drop(events);
 }
 
@@ -548,13 +570,12 @@ async fn test_dropping_a_client_stops_its_supervisor() {
 
     // Both streams end because the supervisor was aborted and released the
     // senders it held. Without the Drop teardown it would still be sleeping.
-    assert!(
-        tokio::time::timeout(Duration::from_secs(5), states.recv())
-            .await
-            .expect("the state stream should close when the client is dropped")
-            .is_none(),
-        "the supervisor outlived the client"
-    );
+    expect_stream_closed(
+        &mut states,
+        Duration::from_secs(5),
+        "the state stream should close when the client is dropped",
+    )
+    .await;
     drop(events);
 }
 
@@ -583,4 +604,64 @@ async fn test_a_zero_delay_policy_does_not_spin() {
         ),
         other => panic!("expected Reconnecting, got {other:?}"),
     }
+}
+
+/// The property issue #60 is about: a consumer that does not read during a long
+/// reconnect loses the middle of it, not the end.
+///
+/// The old `mpsc` did the reverse — a full queue dropped the state being sent,
+/// so the buffer filled with early `Reconnecting` and the `GaveUp` that
+/// actually matters never arrived.
+#[tokio::test]
+async fn test_a_slow_consumer_loses_the_middle_not_the_end() {
+    let server = MockServer::start(Behaviour::RefuseAfterFirstSession).await;
+    // Far more attempts than the stream can hold, each refused at once because
+    // the server stops listening, so this overflows quickly.
+    let attempts = 40;
+    let (_client, _channel_id, _events, mut states) = dropped_session(
+        &server,
+        ReconnectPolicy {
+            initial_delay: Duration::from_millis(1),
+            max_delay: Duration::from_millis(1),
+            max_attempts: Some(attempts),
+            jitter: false,
+        },
+    )
+    .await;
+
+    // Deliberately not reading while the attempts pile up.
+    tokio::time::sleep(Duration::from_secs(5)).await;
+
+    let mut lagged = 0u64;
+    let mut seen = Vec::new();
+    // Bounded: with the old drop-the-newest behaviour the terminal state never
+    // arrives and the stream never closes, so an unbounded drain would hang
+    // instead of reporting.
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let outcome = loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        match tokio::time::timeout(remaining, states.recv()).await {
+            Ok(Ok(ConnectionState::GaveUp { reason })) => break Some(reason),
+            Ok(Ok(state)) => seen.push(state),
+            Ok(Err(broadcast::error::RecvError::Lagged(missed))) => lagged += missed,
+            Ok(Err(broadcast::error::RecvError::Closed)) | Err(_) => break None,
+        }
+    };
+
+    let reason = outcome.unwrap_or_else(|| {
+        panic!(
+            "the terminal state never arrived, which is the whole defect: \
+             saw {} state(s) and missed {lagged}",
+            seen.len()
+        )
+    });
+    assert!(
+        reason.contains(&format!("after {attempts} attempt(s)")),
+        "the client should have stopped on its limit: {reason}"
+    );
+    assert!(
+        lagged > 0,
+        "the queue never overflowed, so this proves nothing: saw {} state(s)",
+        seen.len()
+    );
 }

--- a/tests/integration/dxlink_reconnect.rs
+++ b/tests/integration/dxlink_reconnect.rs
@@ -629,8 +629,21 @@ async fn test_a_slow_consumer_loses_the_middle_not_the_end() {
     )
     .await;
 
-    // Deliberately not reading while the attempts pile up.
-    tokio::time::sleep(Duration::from_secs(5)).await;
+    // Deliberately not reading while the attempts pile up. Waiting on the queue
+    // itself rather than on the clock: `len` saturates once the buffer is full,
+    // so two equal readings a beat apart mean states are already being evicted.
+    // The floor on the backoff puts a hard lower bound on how fast this can go,
+    // so a fixed sleep would either be slow or flaky on a loaded machine.
+    let mut previous = usize::MAX;
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
+    while states.len() != previous || previous == 0 {
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the queue never stopped growing, so it never overflowed"
+        );
+        previous = states.len();
+        tokio::time::sleep(Duration::from_millis(120)).await;
+    }
 
     let mut lagged = 0u64;
     let mut seen = Vec::new();

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -81,6 +81,10 @@ pub enum Behaviour {
     /// nothing, so a reconnect times out mid-handshake instead of failing to
     /// connect.
     SilentOnReconnect,
+    /// Serve one full session, hang up once the feed is subscribed, then stop
+    /// listening entirely so every reconnect is refused at once. Lets a test
+    /// run many fast attempts.
+    RefuseAfterFirstSession,
     /// Like `DropFirstSession`, but ignore `FEED_SETUP` on the second
     /// connection and answer normally on the third, so a replay times out
     /// partway and the next attempt has to rebuild from scratch.
@@ -363,6 +367,7 @@ impl MockServer {
                                         | Behaviour::RejectAuthOnReconnect
                                         | Behaviour::SilentOnReconnect
                                         | Behaviour::IgnoreFeedSetupOnReconnect
+                                        | Behaviour::RefuseAfterFirstSession
                                 ) && sessions_served == 1);
                         }
                         "CHANNEL_CANCEL" => responses.push(json!({
@@ -390,6 +395,12 @@ impl MockServer {
 
                     if close_after {
                         let _ = ws.send(Message::Close(None)).await;
+                        if behaviour == Behaviour::RefuseAfterFirstSession {
+                            // Dropping the listener with the task is the point:
+                            // every later connect is refused immediately rather
+                            // than waiting out a timeout.
+                            return;
+                        }
                         continue 'accept;
                     }
                 }


### PR DESCRIPTION
## Summary

`connection_states` dropped the **newest** state when its queue filled. The states worth keeping are the terminal ones, so the eviction was backwards: a consumer that stopped reading during a long outage filled up with early `Reconnecting` and never saw the `Reconnected` or `GaveUp` that ends the cycle.

An `mpsc` sender cannot evict from the front of its own queue, so this needed a different primitive rather than a tweak.

## Technical decisions

**`tokio::sync::broadcast`**, which is option 1 in the issue. It drops the oldest for a lagging receiver and tells it how many it missed via `RecvError::Lagged`, then carries on from the oldest retained. Falling behind now costs the middle of a reconnect rather than its outcome.

**`watch` was the alternative and is wrong here.** Latest-value-wins would discard the intermediate `Reconnecting { attempt }` states entirely, which is exactly what a consumer logging reconnect progress wants to see.

**Two consequences of broadcast that are worth knowing, and are documented:**

- A receiver only sees what is sent **after** it subscribes. In practice that means subscribing right after `connect`, which is what every example and test does. This is called out on the method.
- The client keeps its own sender instead of handing it to the supervisor, so a consumer can subscribe at any time. That means the stream no longer closes just because the supervisor returned — `disconnect` drops the client's sender explicitly, and `Drop` does it by dropping the field. Both paths have tests.

## Public API impact

`connection_states` now returns `broadcast::Receiver<ConnectionState>` instead of `mpsc::Receiver<ConnectionState>`, and takes `&self` instead of `&mut self` so it can be called more than once. A 0.x minor bump. The method is unreleased — it landed in #59 — so nothing downstream can break, which is precisely why this was worth doing before publishing rather than after.

## Testing

- **The property the issue is about**: a consumer that does not read while 40 attempts run gets `Lagged`, loses the early states, and still receives `GaveUp` naming the attempt limit. Needed a mock that stops listening after the first session so attempts fail immediately instead of waiting out a timeout.
- Verified by mutation: emulating the old drop-the-newest behaviour makes that test report `saw 16 state(s)` and no terminal state, which is the original defect exactly. The drain is deliberately time-bounded, because under that mutation the terminal state never arrives *and* the stream never closes — an unbounded drain would hang instead of reporting.
- The existing reconnect suite still passes, with its stream-closed assertions updated to treat `Lagged` as "still open" rather than as an end.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #60
