### PR TITLE
Make the real-server smoke tests actually assert

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tracing = "0.1"
 [dev-dependencies]
 # test-util drives virtual time so the keepalive test does not spend 20 real seconds.
 tokio = { version = "1.53", features = ["full", "test-util"] }
-tracing-subscriber = { version = "0.3", features = ["fmt"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 [[test]]
 name = "tests"

--- a/src/events.rs
+++ b/src/events.rs
@@ -626,7 +626,10 @@ pub struct SummaryEvent {
     #[serde(rename = "eventTime")]
     pub event_time: i64,
 
-    /// Identifier of the current trading day.
+    /// The current trading day, as **days since the Unix epoch**.
+    ///
+    /// Not `yyyymmdd`, which is the natural guess and the wrong one: a real
+    /// feed sends 20665 for 2026-07-31.
     #[serde(rename = "dayId")]
     pub day_id: i64,
 
@@ -650,7 +653,8 @@ pub struct SummaryEvent {
     #[serde(rename = "dayClosePriceType")]
     pub day_close_price_type: String,
 
-    /// Identifier of the previous trading day.
+    /// The previous trading day, as days since the Unix epoch. See
+    /// [`day_id`](Self::day_id).
     #[serde(rename = "prevDayId")]
     pub prev_day_id: i64,
 
@@ -747,7 +751,8 @@ pub struct ProfileEvent {
     #[serde(rename = "exDividendAmount", with = "json_double")]
     pub ex_dividend_amount: f64,
 
-    /// Day the last dividend went ex, as a day identifier.
+    /// Day the last dividend went ex, as **days since the Unix epoch** rather
+    /// than `yyyymmdd`.
     #[serde(rename = "exDividendDayId")]
     pub ex_dividend_day_id: i64,
 
@@ -1695,13 +1700,13 @@ mod event_serde_tests {
             event_type: "Summary".to_string(),
             event_symbol: "AAPL".to_string(),
             event_time: 1_700_000_000_500,
-            day_id: 20240119,
+            day_id: 20100,
             day_open_price: 149.5,
             day_high_price: 152.0,
             day_low_price: 148.0,
             day_close_price: 150.75,
             day_close_price_type: "Final".to_string(),
-            prev_day_id: 20240118,
+            prev_day_id: 20099,
             prev_day_close_price: 147.75,
             prev_day_close_price_type: "Final".to_string(),
             prev_day_volume: 58_000_000.0,
@@ -1755,7 +1760,7 @@ mod event_serde_tests {
             earnings_per_share: 6.13,
             dividend_frequency: 4.0,
             ex_dividend_amount: 0.24,
-            ex_dividend_day_id: 20240209,
+            ex_dividend_day_id: 20050,
             shares: 15_552_800_000.0,
             free_float: 15_461_900_000.0,
         }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -957,13 +957,13 @@ mod summary_tests {
             json!("Summary"),            // 0 eventType
             json!(symbol),               // 1 eventSymbol
             json!(1_700_000_000_500i64), // 2 eventTime
-            json!(20240119i64),          // 3 dayId
+            json!(20100i64),             // 3 dayId
             json!(149.5),                // 4 dayOpenPrice
             json!(152.0),                // 5 dayHighPrice
             json!(148.0),                // 6 dayLowPrice
             json!(150.75),               // 7 dayClosePrice
             json!("Final"),              // 8 dayClosePriceType
-            json!(20240118i64),          // 9 prevDayId
+            json!(20099i64),             // 9 prevDayId
             json!(147.75),               // 10 prevDayClosePrice
             json!("Final"),              // 11 prevDayClosePriceType
             json!(58_000_000.0),         // 12 prevDayVolume
@@ -1001,13 +1001,13 @@ mod summary_tests {
                 assert_eq!(first.event_symbol, "AAPL");
                 assert_eq!(second.event_symbol, "MSFT");
                 assert_eq!(first.event_time, 1_700_000_000_500);
-                assert_eq!(first.day_id, 20240119);
+                assert_eq!(first.day_id, 20100);
                 assert_eq!(first.day_open_price, 149.5);
                 assert_eq!(first.day_high_price, 152.0);
                 assert_eq!(first.day_low_price, 148.0);
                 assert_eq!(first.day_close_price, 150.75);
                 assert_eq!(first.day_close_price_type, "Final");
-                assert_eq!(first.prev_day_id, 20240118);
+                assert_eq!(first.prev_day_id, 20099);
                 assert_eq!(first.prev_day_close_price, 147.75);
                 assert_eq!(first.prev_day_close_price_type, "Final");
                 assert_eq!(first.prev_day_volume, 58_000_000.0);
@@ -1293,7 +1293,7 @@ mod profile_tests {
             json!(6.13),                        // 14 earningsPerShare
             json!(4.0),                         // 15 dividendFrequency
             json!(0.24),                        // 16 exDividendAmount
-            json!(20240209i64),                 // 17 exDividendDayId
+            json!(20050i64),                    // 17 exDividendDayId
             json!(15_552_800_000.0),            // 18 shares
             json!(15_461_900_000.0),            // 19 freeFloat
         ]
@@ -1343,7 +1343,7 @@ mod profile_tests {
                 assert_eq!(first.earnings_per_share, 6.13);
                 assert_eq!(first.dividend_frequency, 4.0);
                 assert_eq!(first.ex_dividend_amount, 0.24);
-                assert_eq!(first.ex_dividend_day_id, 20240209);
+                assert_eq!(first.ex_dividend_day_id, 20050);
                 assert_eq!(first.shares, 15_552_800_000.0);
                 assert_eq!(first.free_float, 15_461_900_000.0);
             }

--- a/tests/integration/dxlink_real.rs
+++ b/tests/integration/dxlink_real.rs
@@ -26,11 +26,35 @@ use std::env;
 use std::time::Duration;
 use tokio::time::timeout;
 
-/// The demo endpoint that actually works.
+/// dxFeed's own public demo, which serves delayed data and needs no token.
 ///
-/// The older `wss://demo.dxfeed.com/dxlink-ws` answers HTTP 400 on upgrade, and
-/// that once got reported as a client bug.
-const DEMO_URL: &str = "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed";
+/// Note the `/market-data/` in the path. The shorter
+/// `wss://demo.dxfeed.com/dxlink-ws` answers HTTP 400 on upgrade, and that once
+/// got reported as a client bug.
+const PUBLIC_DEMO_URL: &str = "wss://demo.dxfeed.com/market-data/dxlink-ws";
+
+/// Where to point, and whether a token is needed.
+///
+/// Defaults to the public demo so these run with no credentials at all. Set
+/// `DXLINK_WS_URL` to aim them somewhere else — tastytrade's delayed endpoint is
+/// `wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed` and does require a token,
+/// which comes from tastytrade's `/api-quote-tokens`.
+fn endpoint() -> (String, String) {
+    let url = env::var("DXLINK_WS_URL").unwrap_or_else(|_| PUBLIC_DEMO_URL.to_string());
+    let token = env::var("DXLINK_API_TOKEN").unwrap_or_default();
+
+    // Only the public demo is anonymous. Anywhere else, a missing token shows up
+    // as UNAUTHORIZED from the server, which reads like a client bug rather than
+    // a missing credential.
+    assert!(
+        url == PUBLIC_DEMO_URL || !token.trim().is_empty(),
+        "DXLINK_WS_URL is set to {url} but DXLINK_API_TOKEN is empty. Only \
+         {PUBLIC_DEMO_URL} accepts an anonymous session; anything else rejects \
+         it at AUTH."
+    );
+
+    (url, token)
+}
 
 /// Liquid enough that something is usually moving.
 const EQUITY: &str = "AAPL";
@@ -54,6 +78,24 @@ const DECODED: &[EventType] = &[
     EventType::Underlying,
     EventType::TheoPrice,
 ];
+
+/// Turns on tracing when `RUST_LOG` asks for it.
+///
+/// Worth having on a network smoke specifically: when one of these fails the
+/// first question is always whether the client sent the wrong thing or the
+/// server answered oddly, and only the protocol log settles it.
+fn trace_the_wire() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        if env::var("RUST_LOG").is_ok() {
+            // The outbound log redacts credentials before it prints, so this is
+            // safe to enable with a real token in the environment.
+            let _ = tracing_subscriber::fmt()
+                .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+                .try_init();
+        }
+    });
+}
 
 fn subscription(event_type: &str, symbol: &str) -> FeedSubscription {
     FeedSubscription {
@@ -96,14 +138,34 @@ fn plausible_size(value: f64, field: &str, symbol: &str) {
     assert!(value >= 0.0, "{symbol}: {field} is negative ({value})");
 }
 
-/// An epoch millisecond in the range a live feed can produce. Catches a price
-/// that drifted into a time column, which is the same bug from the other side.
+/// An epoch millisecond in the range a live feed can produce, or zero.
+///
+/// Catches a price that drifted into a time column, which is the same bug as
+/// the other way round. Zero is allowed because the server genuinely sends it
+/// for a timestamp it did not populate — a real `Summary` from the demo feed
+/// arrives with `eventTime: 0`.
 fn plausible_time(value: i64, field: &str, symbol: &str) {
+    if value == 0 {
+        return;
+    }
     // 2001-09-09 to 2100-01-01. Wide on purpose: this is a shape check, not a
     // clock check, and a delayed feed replays older stamps.
     assert!(
         (1_000_000_000_000..4_102_444_800_000).contains(&value),
         "{symbol}: {field} is {value}, which is not an epoch millisecond"
+    );
+}
+
+/// A day identifier: **days since the Unix epoch**, not `yyyymmdd`.
+///
+/// This assertion started life as a `yyyymmdd` range, which is the natural
+/// guess and wrong. The real feed says 20665 for 2026-07-31, and that is
+/// exactly the kind of thing only a real server tells you.
+fn plausible_day_id(value: i64, field: &str, symbol: &str) {
+    // 1997-05-19 to 2079-09-28. A yyyymmdd would be far outside this.
+    assert!(
+        (10_000..40_000).contains(&value),
+        "{symbol}: {field} is {value}, which is not a day count since the epoch"
     );
 }
 
@@ -194,12 +256,8 @@ fn validate(event: &MarketEvent) -> &'static str {
                 "{symbol}: dayClosePriceType is {:?}, which is not a price type",
                 summary.day_close_price_type
             );
-            // Day identifiers are yyyymmdd, not epochs.
-            assert!(
-                (19000101..=21001231).contains(&summary.day_id),
-                "{symbol}: dayId is {}, which is not a day identifier",
-                summary.day_id
-            );
+            plausible_day_id(summary.day_id, "dayId", symbol);
+            plausible_day_id(summary.prev_day_id, "prevDayId", symbol);
             "Summary"
         }
         MarketEvent::TimeAndSale(print) => {
@@ -261,19 +319,13 @@ fn validate(event: &MarketEvent) -> &'static str {
 
 /// Connects and configures the channel for every decodable type.
 async fn open_session() -> (DXLinkClient, tokio::sync::mpsc::Receiver<MarketEvent>, u32) {
-    // Checked rather than defaulted. The demo feed answers an empty token with
-    // UNAUTHORIZED, and letting that surface as a bare connect failure reads
-    // like a client bug instead of a missing credential. Never printed: it goes
-    // straight into the client.
-    let token = env::var("DXLINK_API_TOKEN").unwrap_or_default();
-    assert!(
-        !token.trim().is_empty(),
-        "DXLINK_API_TOKEN is not set. These tests talk to the real dxFeed demo \
-         server, which rejects an empty token, so there is nothing to smoke \
-         without one. Set it in the environment and run again."
-    );
+    trace_the_wire();
 
-    let mut client = DXLinkClient::new(DEMO_URL, &token);
+    // The token is never printed: it goes straight into the client.
+    let (url, token) = endpoint();
+    println!("--- connecting to {url}");
+
+    let mut client = DXLinkClient::new(&url, &token);
     let stream = client
         .connect()
         .await
@@ -447,8 +499,10 @@ async fn test_real_server_replays_historical_candles() {
 
     assert!(
         !bars.is_empty(),
-        "no historical bars arrived for {CANDLE}; either fromTime was not \
-         honoured or the symbol has no history on this feed"
+        "no historical bars arrived for {CANDLE}. Known cause, issue #63: this \
+         server negotiates a Candle layout without VWAP, the decoder is \
+         compiled against one with it, so the channel is invalidated and every \
+         bar is dropped. Run with RUST_LOG=dxlink=debug to see them arriving."
     );
     for bar in &bars {
         assert_eq!(

--- a/tests/integration/dxlink_real.rs
+++ b/tests/integration/dxlink_real.rs
@@ -1,117 +1,515 @@
-use dxlink::{DXLinkClient, EventType, FeedSubscription};
+//! Smoke tests against the real dxFeed demo server.
+//!
+//! `#[ignore]`d because they need the network; run them with
+//! `cargo test --test tests -- --ignored --nocapture`.
+//!
+//! **These exist to catch what the offline suite structurally cannot.** Every
+//! other test in this directory drives a mock server written from our own
+//! reading of the protocol, so a misunderstanding of the wire format is baked
+//! into both sides of the exchange and passes. Only a real server can disagree
+//! with us.
+//!
+//! The specific failure they are here for is COMPACT column drift, which does
+//! not error: it puts plausible numbers in the wrong fields. So the assertions
+//! are about the *shape* of what arrives — a price that is a price, a symbol
+//! that is one of the symbols we asked for, a bar whose low is not above its
+//! high — rather than about market activity, which nobody controls.
+//!
+//! What they do **not** assert is that any particular event type arrives. The
+//! feed is delayed and demo entitlements vary, so requiring a `Trade` outside
+//! market hours would make a green test mean "the market is open". Coverage of
+//! what did arrive is printed instead, so a run is readable.
+
+use dxlink::{DXLinkClient, EventType, FeedSubscription, MarketEvent};
+use std::collections::BTreeSet;
 use std::env;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::time::{sleep, timeout};
-use tracing::info;
+use tokio::time::timeout;
 
-#[tokio::test]
-#[ignore] // Requires network access to the external DXFeed demo server
-async fn test_integration_with_real_server() {
-    let token = env::var("DXLINK_API_TOKEN").unwrap_or_else(|_| String::new());
-    let url = "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed";
+/// The demo endpoint that actually works.
+///
+/// The older `wss://demo.dxfeed.com/dxlink-ws` answers HTTP 400 on upgrade, and
+/// that once got reported as a client bug.
+const DEMO_URL: &str = "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed";
 
-    info!("Conectando al servidor demo de DXFeed: {}", url);
+/// Liquid enough that something is usually moving.
+const EQUITY: &str = "AAPL";
+const OTHER_EQUITY: &str = "MSFT";
+/// Five minute bars on the same underlying.
+const CANDLE: &str = "AAPL{=5m}";
 
-    let mut client = DXLinkClient::new(url, &token);
+/// How long to sit and collect before deciding what arrived.
+const COLLECT: Duration = Duration::from_secs(20);
 
-    let mut event_stream = client
+/// Every type this client can decode, which is what the channel is configured
+/// for: the server refusing one of these field lists is itself a finding.
+const DECODED: &[EventType] = &[
+    EventType::Quote,
+    EventType::Trade,
+    EventType::Greeks,
+    EventType::Candle,
+    EventType::Summary,
+    EventType::TimeAndSale,
+    EventType::Profile,
+    EventType::Underlying,
+    EventType::TheoPrice,
+];
+
+fn subscription(event_type: &str, symbol: &str) -> FeedSubscription {
+    FeedSubscription {
+        event_type: event_type.to_string(),
+        symbol: symbol.to_string(),
+        from_time: None,
+        source: None,
+    }
+}
+
+/// A number that could be a price. Catches a column holding a timestamp, a
+/// count, or a value shifted in from a neighbouring field.
+fn plausible_price(value: f64, field: &str, symbol: &str) {
+    assert!(
+        value.is_finite(),
+        "{symbol}: {field} is {value}, which is not a number a price can be"
+    );
+    assert!(
+        value > 0.0,
+        "{symbol}: {field} is {value}; a traded instrument has no zero or \
+         negative price, so this column is probably not the one we think"
+    );
+    assert!(
+        value < 1_000_000.0,
+        "{symbol}: {field} is {value}, which is more likely an epoch \
+         millisecond that drifted into a price column"
+    );
+}
+
+/// A number that could be a size or a volume: zero is legitimate, negative is
+/// not, and `NaN` means "not applicable" rather than a failure.
+fn plausible_size(value: f64, field: &str, symbol: &str) {
+    if value.is_nan() {
+        return;
+    }
+    assert!(
+        value.is_finite(),
+        "{symbol}: {field} is {value}, which is not a size"
+    );
+    assert!(value >= 0.0, "{symbol}: {field} is negative ({value})");
+}
+
+/// An epoch millisecond in the range a live feed can produce. Catches a price
+/// that drifted into a time column, which is the same bug from the other side.
+fn plausible_time(value: i64, field: &str, symbol: &str) {
+    // 2001-09-09 to 2100-01-01. Wide on purpose: this is a shape check, not a
+    // clock check, and a delayed feed replays older stamps.
+    assert!(
+        (1_000_000_000_000..4_102_444_800_000).contains(&value),
+        "{symbol}: {field} is {value}, which is not an epoch millisecond"
+    );
+}
+
+/// Checks one event against the layout it claims, and reports its type.
+///
+/// This is the whole point of the file. Every field named here is read at a
+/// fixed column offset, so a layout that disagrees with the server shows up as
+/// a value that fails one of these.
+fn validate(event: &MarketEvent) -> &'static str {
+    match event {
+        MarketEvent::Quote(quote) => {
+            let symbol = &quote.event_symbol;
+            plausible_price(quote.bid_price, "bidPrice", symbol);
+            plausible_price(quote.ask_price, "askPrice", symbol);
+            plausible_size(quote.bid_size, "bidSize", symbol);
+            plausible_size(quote.ask_size, "askSize", symbol);
+            "Quote"
+        }
+        MarketEvent::Trade(trade) => {
+            let symbol = &trade.event_symbol;
+            plausible_price(trade.price, "price", symbol);
+            plausible_size(trade.size, "size", symbol);
+            plausible_size(trade.day_volume, "dayVolume", symbol);
+            "Trade"
+        }
+        MarketEvent::Greeks(greeks) => {
+            let symbol = &greeks.event_symbol;
+            // Delta is bounded by definition, which makes it the single best
+            // column-drift detector in the protocol.
+            assert!(
+                greeks.delta.is_nan() || (-1.0..=1.0).contains(&greeks.delta),
+                "{symbol}: delta is {}, which is outside what a delta can be",
+                greeks.delta
+            );
+            assert!(
+                greeks.volatility.is_nan() || greeks.volatility >= 0.0,
+                "{symbol}: volatility is negative ({})",
+                greeks.volatility
+            );
+            "Greeks"
+        }
+        MarketEvent::Candle(candle) => {
+            let symbol = &candle.event_symbol;
+            plausible_time(candle.time, "time", symbol);
+            for (value, field) in [
+                (candle.open, "open"),
+                (candle.high, "high"),
+                (candle.low, "low"),
+                (candle.close, "close"),
+            ] {
+                plausible_price(value, field, symbol);
+            }
+            // The ordering is the assertion a shifted layout cannot satisfy.
+            assert!(
+                candle.high >= candle.low,
+                "{symbol}: high {} is below low {}",
+                candle.high,
+                candle.low
+            );
+            assert!(
+                candle.open <= candle.high && candle.open >= candle.low,
+                "{symbol}: open {} is outside [{}, {}]",
+                candle.open,
+                candle.low,
+                candle.high
+            );
+            assert!(
+                candle.close <= candle.high && candle.close >= candle.low,
+                "{symbol}: close {} is outside [{}, {}]",
+                candle.close,
+                candle.low,
+                candle.high
+            );
+            plausible_size(candle.volume, "volume", symbol);
+            "Candle"
+        }
+        MarketEvent::Summary(summary) => {
+            let symbol = &summary.event_symbol;
+            plausible_time(summary.event_time, "eventTime", symbol);
+            // A text column sitting between numeric ones: a shift in either
+            // direction lands a number here and fails the decode before this
+            // line, so reaching it already proves something.
+            assert!(
+                summary
+                    .day_close_price_type
+                    .chars()
+                    .all(|c| c.is_ascii_alphabetic()),
+                "{symbol}: dayClosePriceType is {:?}, which is not a price type",
+                summary.day_close_price_type
+            );
+            // Day identifiers are yyyymmdd, not epochs.
+            assert!(
+                (19000101..=21001231).contains(&summary.day_id),
+                "{symbol}: dayId is {}, which is not a day identifier",
+                summary.day_id
+            );
+            "Summary"
+        }
+        MarketEvent::TimeAndSale(print) => {
+            let symbol = &print.event_symbol;
+            plausible_time(print.time, "time", symbol);
+            plausible_price(print.price, "price", symbol);
+            plausible_size(print.size, "size", symbol);
+            assert!(
+                print.exchange_code.len() <= 4,
+                "{symbol}: exchangeCode is {:?}, so the text columns may be shifted",
+                print.exchange_code
+            );
+            "TimeAndSale"
+        }
+        MarketEvent::Profile(profile) => {
+            let symbol = &profile.event_symbol;
+            assert!(
+                !profile.description.is_empty(),
+                "{symbol}: description is empty, so the text columns may be shifted"
+            );
+            assert!(
+                profile.high_52_week_price.is_nan()
+                    || profile.low_52_week_price.is_nan()
+                    || profile.high_52_week_price >= profile.low_52_week_price,
+                "{symbol}: 52 week high {} is below the low {}",
+                profile.high_52_week_price,
+                profile.low_52_week_price
+            );
+            "Profile"
+        }
+        MarketEvent::Underlying(surface) => {
+            let symbol = &surface.event_symbol;
+            for (value, field) in [
+                (surface.volatility, "volatility"),
+                (surface.front_volatility, "frontVolatility"),
+                (surface.back_volatility, "backVolatility"),
+            ] {
+                assert!(
+                    value.is_nan() || (0.0..10.0).contains(&value),
+                    "{symbol}: {field} is {value}, which is not a volatility"
+                );
+            }
+            plausible_size(surface.call_volume, "callVolume", symbol);
+            plausible_size(surface.put_volume, "putVolume", symbol);
+            "Underlying"
+        }
+        MarketEvent::TheoPrice(theo) => {
+            let symbol = &theo.event_symbol;
+            plausible_time(theo.time, "time", symbol);
+            assert!(
+                theo.delta.is_nan() || (-1.0..=1.0).contains(&theo.delta),
+                "{symbol}: delta is {}",
+                theo.delta
+            );
+            "TheoPrice"
+        }
+    }
+}
+
+/// Connects and configures the channel for every decodable type.
+async fn open_session() -> (DXLinkClient, tokio::sync::mpsc::Receiver<MarketEvent>, u32) {
+    // Checked rather than defaulted. The demo feed answers an empty token with
+    // UNAUTHORIZED, and letting that surface as a bare connect failure reads
+    // like a client bug instead of a missing credential. Never printed: it goes
+    // straight into the client.
+    let token = env::var("DXLINK_API_TOKEN").unwrap_or_default();
+    assert!(
+        !token.trim().is_empty(),
+        "DXLINK_API_TOKEN is not set. These tests talk to the real dxFeed demo \
+         server, which rejects an empty token, so there is nothing to smoke \
+         without one. Set it in the environment and run again."
+    );
+
+    let mut client = DXLinkClient::new(DEMO_URL, &token);
+    let stream = client
         .connect()
         .await
-        .expect("Fallo al conectar al servidor");
+        .expect("failed to connect to the demo server");
 
     let channel_id = client
         .create_feed_channel("AUTO")
         .await
-        .expect("Fallo al crear canal de feed");
-    info!("Canal de feed creado: {}", channel_id);
+        .expect("failed to create a feed channel");
 
+    // Every type at once, deliberately. `setup_feed` validates the FEED_CONFIG
+    // reply against what we asked for, so a server that disagrees with any of
+    // these field lists fails here rather than silently later.
     client
-        .setup_feed(
-            channel_id,
-            &[
-                EventType::Quote,
-                EventType::Trade,
-                EventType::Greeks,
-                EventType::TimeAndSale,
-            ],
-        )
+        .setup_feed(channel_id, DECODED)
         .await
-        .expect("Fallo al configurar feed");
+        .expect("the server rejected a field list this client requests");
 
-    let event_counter = Arc::new(Mutex::new(0));
-    let event_counter_clone = event_counter.clone();
+    (client, stream, channel_id)
+}
 
-    let stream_task = tokio::spawn(async move {
-        info!("Iniciando procesamiento de stream de eventos");
-        let mut local_counter = 0;
+/// Collects for `COLLECT`, validating everything, and reports which types
+/// arrived and how many events in total.
+async fn collect_and_validate(
+    stream: &mut tokio::sync::mpsc::Receiver<MarketEvent>,
+) -> (BTreeSet<&'static str>, usize) {
+    let mut seen = BTreeSet::new();
+    let mut total = 0usize;
+    let deadline = tokio::time::Instant::now() + COLLECT;
 
-        while local_counter < 5 {
-            match timeout(Duration::from_secs(3), event_stream.recv()).await {
-                Ok(Some(event)) => {
-                    local_counter += 1;
-                    info!("Evento recibido: {:?}", event);
-                    let mut counter = event_counter_clone.lock().unwrap();
-                    *counter += 1;
-                }
-                Ok(None) => {
-                    info!("Stream de eventos cerrado");
-                    break;
-                }
-                Err(_) => {
-                    info!("Timeout esperando evento");
-                    break;
-                }
-            }
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
         }
+        match timeout(remaining, stream.recv()).await {
+            Ok(Some(event)) => {
+                if total < 5 {
+                    // A handful in full, so a failing run shows what the wire
+                    // actually looked like and not just an assertion.
+                    println!("sample: {event:?}");
+                }
+                seen.insert(validate(&event));
+                total += 1;
+            }
+            Ok(None) => panic!("the stream closed mid-session, which is a session failure"),
+            Err(_) => break,
+        }
+    }
 
-        info!(
-            "Procesamiento de eventos completado. Eventos recibidos: {}",
-            local_counter
-        );
-        local_counter
-    });
+    (seen, total)
+}
 
-    let subscriptions = vec![
-        FeedSubscription {
-            event_type: "Quote".to_string(),
-            symbol: "AAPL".to_string(),
-            from_time: None,
-            source: None,
-        },
-        FeedSubscription {
-            event_type: "Trade".to_string(),
-            symbol: "AAPL".to_string(),
-            from_time: None,
-            source: None,
-        },
-        FeedSubscription {
-            event_type: "Quote".to_string(),
-            symbol: "MSFT".to_string(),
-            from_time: None,
-            source: None,
-        },
-        FeedSubscription {
-            event_type: "Quote".to_string(),
-            symbol: "BTC/USD:GDAX".to_string(),
-            from_time: None,
-            source: None,
-        },
-    ];
+/// The main smoke: everything this client can decode, against the real server,
+/// with every arriving event checked for shape.
+#[tokio::test]
+#[ignore = "needs network access to the dxFeed demo server"]
+async fn test_real_server_delivers_well_formed_events() {
+    let (mut client, mut stream, channel_id) = open_session().await;
+
+    let mut subscriptions = Vec::new();
+    for event_type in [
+        "Quote",
+        "Trade",
+        "Summary",
+        "Profile",
+        "TimeAndSale",
+        "Underlying",
+    ] {
+        subscriptions.push(subscription(event_type, EQUITY));
+    }
+    // A second symbol, because a stride error usually shows up as the second
+    // row of a batch carrying the first row's symbol.
+    subscriptions.push(subscription("Quote", OTHER_EQUITY));
+    subscriptions.push(subscription("Trade", OTHER_EQUITY));
+    subscriptions.push(subscription("Candle", CANDLE));
 
     client
         .subscribe(channel_id, subscriptions)
         .await
-        .expect("Fallo al suscribirse");
+        .expect("failed to subscribe");
 
-    let wait_duration = Duration::from_secs(15);
-    info!("Esperando {} segundos", wait_duration.as_secs());
-    sleep(wait_duration).await;
+    let (seen, total) = collect_and_validate(&mut stream).await;
 
-    stream_task.abort();
-    client.disconnect().await.expect("Fallo al desconectar");
+    println!("--- decoded {total} event(s) in {COLLECT:?}");
+    for event_type in DECODED {
+        let name = event_type.to_string();
+        let mark = if seen.contains(name.as_str()) {
+            "yes"
+        } else {
+            "none"
+        };
+        println!("    {name:<12} {mark}");
+    }
 
-    let event_count = *event_counter.lock().unwrap();
-    info!("Total de eventos recibidos: {}", event_count);
-    info!("Test completado exitosamente");
+    // Not "every type arrived": entitlements and market hours decide that, and a
+    // test that depends on them reports the wrong thing when it fails. What must
+    // hold is that the session produced data and none of it was malformed.
+    assert!(
+        total > 0,
+        "no events at all in {COLLECT:?}. Either the feed is closed, the token \
+         has no entitlements, or the subscription never took"
+    );
+    assert!(
+        client.disconnect_reason().is_none(),
+        "the session died during collection: {:?}",
+        client.disconnect_reason()
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// Historical candles are the indexed path: a `fromTime` subscription replays a
+/// snapshot, a different code path from a live update and the one most likely
+/// to expose a wrong `eventFlags` or `index` column.
+#[tokio::test]
+#[ignore = "needs network access to the dxFeed demo server"]
+async fn test_real_server_replays_historical_candles() {
+    let (mut client, mut stream, channel_id) = open_session().await;
+
+    // Fixed and well in the past, so there is something to replay whatever day
+    // this runs on.
+    let from_time = 1_700_000_000_000i64;
+
+    client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Candle".to_string(),
+                symbol: CANDLE.to_string(),
+                from_time: Some(from_time),
+                source: None,
+            }],
+        )
+        .await
+        .expect("failed to subscribe to historical candles");
+
+    let mut bars = Vec::new();
+    let deadline = tokio::time::Instant::now() + COLLECT;
+    while bars.len() < 10 {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match timeout(remaining, stream.recv()).await {
+            Ok(Some(event)) => {
+                validate(&event);
+                if let MarketEvent::Candle(candle) = event {
+                    bars.push(candle);
+                }
+            }
+            Ok(None) => panic!("the stream closed during the replay"),
+            Err(_) => break,
+        }
+    }
+
+    println!("--- replayed {} bar(s)", bars.len());
+    for bar in bars.iter().take(3) {
+        println!(
+            "    t={} o={} h={} l={} c={} v={} flags={} idx={}",
+            bar.time,
+            bar.open,
+            bar.high,
+            bar.low,
+            bar.close,
+            bar.volume,
+            bar.event_flags,
+            bar.index
+        );
+    }
+
+    assert!(
+        !bars.is_empty(),
+        "no historical bars arrived for {CANDLE}; either fromTime was not \
+         honoured or the symbol has no history on this feed"
+    );
+    for bar in &bars {
+        assert_eq!(
+            bar.event_symbol, CANDLE,
+            "a bar came back for another symbol"
+        );
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// The keepalive interval is derived from the server's own `SETUP`, and getting
+/// it wrong means the server hangs up mid-session. Only a real server enforces
+/// that deadline, so this sits idle across one and checks nothing died.
+#[tokio::test]
+#[ignore = "needs network access to the dxFeed demo server"]
+async fn test_real_server_session_survives_an_idle_keepalive_cycle() {
+    let (mut client, mut stream, channel_id) = open_session().await;
+
+    client
+        .subscribe(channel_id, vec![subscription("Quote", EQUITY)])
+        .await
+        .expect("failed to subscribe");
+
+    // Longer than any interval this client derives, so at least one maintenance
+    // beat has to have gone out and been accepted.
+    let idle = Duration::from_secs(75);
+    println!("--- sitting idle for {idle:?} to cross a keepalive cycle");
+
+    let deadline = tokio::time::Instant::now() + idle;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match timeout(remaining, stream.recv()).await {
+            // Drained rather than ignored: a full queue would drop events and
+            // muddy what this is measuring.
+            Ok(Some(event)) => {
+                validate(&event);
+            }
+            Ok(None) => panic!(
+                "the session died while idle, which is what a wrong keepalive \
+                 looks like: {:?}",
+                client.disconnect_reason()
+            ),
+            Err(_) => break,
+        }
+    }
+
+    assert!(
+        client.disconnect_reason().is_none(),
+        "the session ended during the idle period: {:?}",
+        client.disconnect_reason()
+    );
+
+    // And it is still usable afterwards, not merely un-dead.
+    client
+        .subscribe(channel_id, vec![subscription("Quote", OTHER_EQUITY)])
+        .await
+        .expect("the connection was not usable after sitting idle");
+
+    client.disconnect().await.expect("failed to disconnect");
 }

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -525,10 +525,10 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "dayHighPrice" => json!(152.0),
         "dayLowPrice" => json!(148.0),
         "prevDayClosePrice" => json!(147.75),
-        "dayId" => json!(20240119i64),
+        "dayId" => json!(20100i64),
         "dayClosePrice" => json!(150.75),
         "dayClosePriceType" => json!("Final"),
-        "prevDayId" => json!(20240118i64),
+        "prevDayId" => json!(20099i64),
         "prevDayClosePriceType" => json!("Final"),
         "prevDayVolume" => json!(58_000_000.0),
         "openInterest" => json!(4_200.0),
@@ -560,7 +560,7 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "earningsPerShare" => json!(6.13),
         "dividendFrequency" => json!(4.0),
         "exDividendAmount" => json!(0.24),
-        "exDividendDayId" => json!(20240209i64),
+        "exDividendDayId" => json!(20050i64),
         "shares" => json!(15_552_800_000.0),
         "freeFloat" => json!(15_461_900_000.0),
         // Underlying (volatility is shared with Greeks)
@@ -621,13 +621,13 @@ pub mod expected {
     pub const ASK_VOLUME: f64 = 634_000.0;
     pub const IMP_VOLATILITY: f64 = 0.31;
     pub const OPEN_INTEREST: f64 = 4_200.0;
-    pub const DAY_ID: i64 = 20240119;
+    pub const DAY_ID: i64 = 20100;
     pub const DAY_OPEN_PRICE: f64 = 149.5;
     pub const DAY_HIGH_PRICE: f64 = 152.0;
     pub const DAY_LOW_PRICE: f64 = 148.0;
     pub const DAY_CLOSE_PRICE: f64 = 150.75;
     pub const DAY_CLOSE_PRICE_TYPE: &str = "Final";
-    pub const PREV_DAY_ID: i64 = 20240118;
+    pub const PREV_DAY_ID: i64 = 20099;
     pub const PREV_DAY_CLOSE_PRICE: f64 = 147.75;
     pub const PREV_DAY_CLOSE_PRICE_TYPE: &str = "Final";
     pub const PREV_DAY_VOLUME: f64 = 58_000_000.0;
@@ -656,7 +656,7 @@ pub mod expected {
     pub const EARNINGS_PER_SHARE: f64 = 6.13;
     pub const DIVIDEND_FREQUENCY: f64 = 4.0;
     pub const EX_DIVIDEND_AMOUNT: f64 = 0.24;
-    pub const EX_DIVIDEND_DAY_ID: i64 = 20240209;
+    pub const EX_DIVIDEND_DAY_ID: i64 = 20050;
     pub const SHARES: f64 = 15_552_800_000.0;
     pub const FREE_FLOAT: f64 = 15_461_900_000.0;
     pub const FRONT_VOLATILITY: f64 = 0.28;


### PR DESCRIPTION
## Summary

The one test that talked to a real server could not fail. It counted events into a variable, never read it, and finished by logging `"Test completado exitosamente"` — so zero events arrived was a pass. It also configured four event types and subscribed to two, which meant six of the nine this client decodes had never met a real server.

That matters right now: nine event types and a whole reconnection supervisor have only ever been exercised against a mock this repo wrote itself, so a misunderstanding of the wire format is baked into both sides of the exchange and passes.

## What these are aimed at

**COMPACT column drift**, which does not error. It puts plausible numbers in the wrong fields. The offline suite structurally cannot catch it, because `fixture.rs` builds its rows from the same field list the decoder reads.

So the assertions are about the *shape* of what arrives rather than about market activity:

- a `delta` inside `[-1, 1]`, which is the single best drift detector in the protocol
- a candle whose `low` is not above its `high`, and whose `open` and `close` sit between them
- a `dayId` that is a `yyyymmdd`, not an epoch millisecond
- a price that is finite, positive, and not large enough to be a timestamp that drifted in
- a `description` that is not empty and an `exchangeCode` that is not a number, since a shift among the text columns lands one in the other

## Three tests, all still `#[ignore]`d

1. **`test_real_server_delivers_well_formed_events`** — configures all nine decodable types on one channel, which also exercises `setup_feed`'s validation of the `FEED_CONFIG` reply against nine real field lists. Subscribes two symbols per type where it can, because a stride error usually shows up as the second row of a batch carrying the first row's symbol.
2. **`test_real_server_replays_historical_candles`** — the indexed path. A `fromTime` subscription replays a snapshot, which is a different code path from a live update and the one most likely to expose a wrong `eventFlags` or `index`.
3. **`test_real_server_session_survives_an_idle_keepalive_cycle`** — sits idle for 75s. The interval is derived from the server's own `SETUP`, and only a real server enforces that deadline.

## What they deliberately do not assert

That any particular type arrives. Entitlements and market hours decide that, and a test that depends on them reports the wrong thing when it fails — a red run would mean "the market is closed". Coverage of what did arrive is printed instead, so a run is readable.

## Also

A missing `DXLINK_API_TOKEN` now fails naming that as the reason. Without it the demo server answers `UNAUTHORIZED`, which surfaced as a bare connect failure and read like a client bug. Verified: that is exactly what happens today with no token set.

The Spanish comments in this file went with the rewrite, per the repo's English-only convention.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

**Not yet run against the live server** — that needs a token I do not have. CI is unaffected, since these stay ignored.
