### PR TITLE
Decode against the layout the server negotiated (#63)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tracing = "0.1"
 [dev-dependencies]
 # test-util drives virtual time so the keepalive test does not spend 20 real seconds.
 tokio = { version = "1.53", features = ["full", "test-util"] }
-tracing-subscriber = { version = "0.3", features = ["fmt"] }
+tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 
 [[test]]
 name = "tests"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - Strict decoding: [`try_parse_compact_data`] reports a short row, a wrong
   column type or an unknown event type instead of returning fewer events and
   letting a consumer read that as a quiet market.
+- **The layout the server negotiates is the one that gets decoded.** A feed
+  may serve fewer fields than were asked for — the dxFeed demo drops `VWAP`
+  from `Candle` — so columns are read by name rather than by position. A
+  field the server does not send arrives as `NaN`, `0` or an empty string
+  rather than as its neighbour's value, and a reordered list is followed
+  rather than refused.
 - A lost connection is observable: the event stream closes, and
   [`DXLinkClient::disconnect_reason`] says why.
 - **Opt-in reconnection.** Off by default. Install a

--- a/examples/miscellaneous/src/bin/basic.rs
+++ b/examples/miscellaneous/src/bin/basic.rs
@@ -14,7 +14,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Get configuration from environment variables
     let url = env::var("DXLINK_WS_URL")
-        .unwrap_or_else(|_| "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed".to_string());
+        .unwrap_or_else(|_| "wss://demo.dxfeed.com/market-data/dxlink-ws".to_string());
     let token = env::var("DXLINK_API_TOKEN").unwrap_or_else(|_| String::new());
 
     info!("Using DXLink URL: {}", url);

--- a/src/client.rs
+++ b/src/client.rs
@@ -12,7 +12,7 @@ use crate::messages::{
     FeedConfigMessage, FeedDataMessage, FeedSetupMessage, FeedSubscription,
     FeedSubscriptionMessage, KeepaliveMessage, ServerSetupMessage, SetupMessage,
 };
-use crate::try_parse_compact_data;
+use crate::utils::try_parse_negotiated;
 
 use std::collections::HashMap;
 use std::fmt;
@@ -430,53 +430,54 @@ fn spawn_reader(setup: ReaderSetup) -> JoinHandle<()> {
                         // Si nadie esperaba este mensaje específicamente, procesarlo normalmente
                         match msg_type {
                             "FEED_CONFIG" => {
-                                // Nobody was waiting: this is the server
-                                // changing the layout mid-session, which the
-                                // spec allows. The decoder cannot follow it,
-                                // so the channel stops being decodable
-                                // rather than producing shifted values.
+                                // Nobody was waiting, so this is the server
+                                // reporting the layout it settled on. The demo
+                                // feed does this routinely: it answers
+                                // FEED_SETUP with nothing, then sends the real
+                                // list once a subscription exists.
+                                //
+                                // Adopted, not refused. The decoder reads by
+                                // field name, so serving fewer fields than we
+                                // asked for is decodable — the missing ones
+                                // read as "not provided". Invalidating instead
+                                // meant the channel delivered nothing at all.
                                 if let Some(ch) = channel {
-                                    // Only a real disagreement invalidates.
-                                    // A server may resend an identical
-                                    // FEED_CONFIG, and treating that as a
-                                    // change would stop decoding a channel
-                                    // nothing had happened to.
-                                    let disagrees =
-                                        match serde_json::from_str::<FeedConfigMessage>(&msg) {
-                                            Ok(config) => {
-                                                let schemas = recover(&channel_schemas);
-                                                schemas.get(&ch).is_some_and(|stored| {
-                                                    config_disagrees(&config, stored)
-                                                })
+                                    match serde_json::from_str::<FeedConfigMessage>(&msg) {
+                                        Ok(config) => adopt_config(&channel_schemas, ch, &config),
+                                        Err(e) => {
+                                            // Unreadable is not agreement: stop
+                                            // decoding rather than keep using a
+                                            // layout the server may have moved
+                                            // away from.
+                                            if recover(&channel_schemas).remove(&ch).is_some() {
+                                                error!(
+                                                    "Channel {ch} sent an unreadable \
+                                                     FEED_CONFIG ({e}); its data will be \
+                                                     dropped rather than decoded against a \
+                                                     layout that may be stale"
+                                                );
                                             }
-                                            // Unreadable is not agreement.
-                                            Err(_) => true,
-                                        };
-
-                                    if disagrees && recover(&channel_schemas).remove(&ch).is_some()
-                                    {
-                                        error!(
-                                            "Channel {} was reconfigured by the server; \
-                                                 its data will be dropped rather than decoded \
-                                                 against the old layout",
-                                            ch
-                                        );
+                                        }
                                     }
                                 }
                             }
                             "FEED_DATA" => {
                                 // Only decode against a layout the server
-                                // agreed to.
-                                let decodable = channel
-                                    .map(|ch| recover(&channel_schemas).contains_key(&ch))
-                                    .unwrap_or(false);
+                                // agreed to, and against *that* layout rather
+                                // than the one this client asked for: the two
+                                // are not always the same.
+                                let layout = channel
+                                    .and_then(|ch| recover(&channel_schemas).get(&ch).cloned());
 
-                                if !decodable {
+                                let Some(layout) = layout else {
                                     debug!(
                                         "Dropping FEED_DATA for channel {:?}: no validated layout",
                                         channel
                                     );
-                                } else if let Ok(data_msg) =
+                                    continue;
+                                };
+
+                                if let Ok(data_msg) =
                                     serde_json::from_str::<FeedDataMessage<Vec<CompactData>>>(&msg)
                                 {
                                     // Hand off and keep reading. Delivery is
@@ -484,19 +485,20 @@ fn spawn_reader(setup: ReaderSetup) -> JoinHandle<()> {
                                     // one slow callback or a full consumer
                                     // stream stop the socket reads that every
                                     // channel operation depends on.
-                                    let decoded = match try_parse_compact_data(&data_msg.data) {
-                                        Ok(events) => events,
-                                        Err(e) => {
-                                            // Report it rather than
-                                            // delivering a partial batch
-                                            // that looks complete.
-                                            error!(
-                                                "Malformed COMPACT data on channel {:?}: {e}",
-                                                channel
-                                            );
-                                            continue;
-                                        }
-                                    };
+                                    let decoded =
+                                        match try_parse_negotiated(&data_msg.data, &layout) {
+                                            Ok(events) => events,
+                                            Err(e) => {
+                                                // Report it rather than
+                                                // delivering a partial batch
+                                                // that looks complete.
+                                                error!(
+                                                    "Malformed COMPACT data on channel {:?}: {e}",
+                                                    channel
+                                                );
+                                                continue;
+                                            }
+                                        };
 
                                     for event in decoded {
                                         match delivery_tx.try_send(event) {
@@ -961,8 +963,8 @@ async fn replay_session(ctx: &ReconnectContext) -> DXLinkResult<()> {
         .await?
         {
             ResponseType::FeedConfig(config) => {
-                validate_feed_config(&config, channel_id, &event_types)?;
-                recover(&ctx.channel_schemas).insert(channel_id, requested_fields(&event_types));
+                let schema = negotiated_schema(&config, channel_id, &event_types)?;
+                recover(&ctx.channel_schemas).insert(channel_id, schema);
             }
             other => {
                 return Err(DXLinkError::Protocol(format!(
@@ -1308,31 +1310,21 @@ fn requested_fields(event_types: &[EventType]) -> ChannelSchema {
         .collect()
 }
 
-/// Whether a `FEED_CONFIG` contradicts a layout already validated for a channel.
-fn config_disagrees(config: &FeedConfigMessage, stored: &ChannelSchema) -> bool {
-    if !config.data_format.eq_ignore_ascii_case("COMPACT") {
-        return true;
-    }
-    let Some(negotiated) = config.event_fields.as_ref() else {
-        return false;
-    };
-    negotiated
-        .iter()
-        .any(|(event_type, fields)| stored.get(event_type).is_some_and(|known| known != fields))
-}
-
-/// Checks that the server agreed to the contract this client asked for.
+/// The layout a channel will actually be decoded against.
 ///
-/// The specification says `FEED_CONFIG` reports the *actual* configuration, and
-/// that the server may send it again when it changes. Treating it as a bare
-/// acknowledgement meant a different data format, a reordered field list, or a
-/// dropped field all went unnoticed until the decoder produced numbers in the
-/// wrong fields.
-fn validate_feed_config(
+/// `FEED_CONFIG` reports the **actual** configuration, which is not always the
+/// one requested: a server may serve a subset of the fields asked for, and the
+/// dxFeed demo does exactly that, dropping `VWAP` from `Candle`. So the reply is
+/// adopted rather than merely checked. What it cannot do is change the data
+/// format, or leave out the two columns that identify a row.
+///
+/// A type the server did not mention keeps the requested list, which is the
+/// spec's own reading: silence is agreement.
+fn negotiated_schema(
     config: &FeedConfigMessage,
     channel_id: u32,
     event_types: &[EventType],
-) -> DXLinkResult<()> {
+) -> DXLinkResult<ChannelSchema> {
     if !config.data_format.eq_ignore_ascii_case("COMPACT") {
         return Err(DXLinkError::Protocol(format!(
             "channel {channel_id}: this client decodes COMPACT rows, but the server \
@@ -1341,26 +1333,88 @@ fn validate_feed_config(
         )));
     }
 
-    // A server that echoes no field list has not disagreed with the request.
+    let mut schema = requested_fields(event_types);
     let Some(negotiated) = config.event_fields.as_ref() else {
-        return Ok(());
+        return Ok(schema);
     };
 
-    for (event_type, expected) in requested_fields(event_types) {
-        let Some(actual) = negotiated.get(&event_type) else {
-            // Not echoed back is not a disagreement either.
+    for (event_type, fields) in negotiated {
+        // Only what was asked for. A server volunteering a type we never
+        // requested has nothing to deliver on this channel anyway.
+        if !schema.contains_key(event_type) {
+            continue;
+        }
+        check_identifiable(event_type, channel_id, fields)?;
+        schema.insert(event_type.clone(), fields.clone());
+    }
+
+    Ok(schema)
+}
+
+/// Takes on the layout a `FEED_CONFIG` reports, for a channel already
+/// configured.
+///
+/// Only the types the channel knows about, and only layouts whose rows can
+/// still be identified. A channel with no stored schema is one that was never
+/// set up, so there is nothing to update.
+fn adopt_config(schemas: &ChannelSchemas, channel_id: u32, config: &FeedConfigMessage) {
+    if !config.data_format.eq_ignore_ascii_case("COMPACT") {
+        if recover(schemas).remove(&channel_id).is_some() {
+            error!(
+                "Channel {channel_id} was moved to {} data, which this client cannot \
+                 decode; its data will be dropped",
+                config.data_format
+            );
+        }
+        return;
+    }
+
+    let Some(negotiated) = config.event_fields.as_ref() else {
+        return;
+    };
+
+    let mut schemas = recover(schemas);
+    let Some(stored) = schemas.get_mut(&channel_id) else {
+        return;
+    };
+
+    for (event_type, fields) in negotiated {
+        let Some(known) = stored.get(event_type) else {
             continue;
         };
+        if known == fields {
+            continue;
+        }
+        if let Err(e) = check_identifiable(event_type, channel_id, fields) {
+            debug!("Ignoring an unusable {event_type} layout on channel {channel_id}: {e}");
+            continue;
+        }
+        info!(
+            "Channel {channel_id} negotiated a different {event_type} layout; decoding \
+             against it. Fields this client asked for and will not get: {:?}",
+            known
+                .iter()
+                .filter(|field| !fields.contains(field))
+                .collect::<Vec<_>>()
+        );
+        stored.insert(event_type.clone(), fields.clone());
+    }
+}
 
-        if *actual != expected {
+/// Rejects a layout that cannot identify its own rows.
+///
+/// Everything else may be missing and read as "not provided", but without these
+/// two there is no way to tell what a row is or what it is about, and decoding
+/// it would be guessing.
+fn check_identifiable(event_type: &str, channel_id: u32, fields: &[String]) -> DXLinkResult<()> {
+    for required in ["eventType", "eventSymbol"] {
+        if !fields.iter().any(|field| field == required) {
             return Err(DXLinkError::Protocol(format!(
-                "channel {channel_id}: the server changed the {event_type} field layout; \
-                 requested {expected:?} but it negotiated {actual:?}. Decoding against the \
-                 requested order would attach values to the wrong fields"
+                "channel {channel_id}: the server negotiated a {event_type} layout with no \
+                 `{required}` column ({fields:?}), so its rows cannot be identified"
             )));
         }
     }
-
     Ok(())
 }
 
@@ -2404,13 +2458,14 @@ impl DXLinkClient {
                     )));
                 }
 
-                // The reply is the negotiated contract, not an acknowledgement.
-                // Accepting it unread meant a server that chose a different
-                // format or reordered a field list left the decoder attaching
-                // values to the wrong fields, silently.
-                validate_feed_config(&config, channel_id, event_types)?;
+                // The reply is the negotiated contract, not an
+                // acknowledgement, and it is what the decoder will read against
+                // — the server may serve fewer fields than were asked for.
+                // Accepting it unread meant a different data format went
+                // unnoticed until values landed in the wrong fields.
+                let schema = negotiated_schema(&config, channel_id, event_types)?;
 
-                recover(&self.channel_schemas).insert(channel_id, requested_fields(event_types));
+                recover(&self.channel_schemas).insert(channel_id, schema);
 
                 info!("Feed channel {} setup completed successfully", channel_id);
                 Ok(())

--- a/src/client.rs
+++ b/src/client.rs
@@ -1373,6 +1373,29 @@ fn adopt_config(schemas: &ChannelSchemas, channel_id: u32, config: &FeedConfigMe
         return;
     };
 
+    // Checked before anything is written. An unusable layout has to fail
+    // closed: ignoring it would leave the old one installed while the server
+    // sends rows in the new one, and if the two happen to have the same column
+    // count that decodes into wrong values rather than into an error.
+    for (event_type, fields) in negotiated {
+        let is_known = recover(schemas)
+            .get(&channel_id)
+            .is_some_and(|stored| stored.contains_key(event_type));
+        if !is_known {
+            continue;
+        }
+        if let Err(e) = check_identifiable(event_type, channel_id, fields)
+            && recover(schemas).remove(&channel_id).is_some()
+        {
+            error!(
+                "Channel {channel_id} was moved to a {event_type} layout this client \
+                 cannot read ({e}); its data will be dropped rather than decoded against \
+                 a layout the server has moved away from"
+            );
+            return;
+        }
+    }
+
     let mut schemas = recover(schemas);
     let Some(stored) = schemas.get_mut(&channel_id) else {
         return;
@@ -1383,10 +1406,6 @@ fn adopt_config(schemas: &ChannelSchemas, channel_id: u32, config: &FeedConfigMe
             continue;
         };
         if known == fields {
-            continue;
-        }
-        if let Err(e) = check_identifiable(event_type, channel_id, fields) {
-            debug!("Ignoring an unusable {event_type} layout on channel {channel_id}: {e}");
             continue;
         }
         info!(

--- a/src/events.rs
+++ b/src/events.rs
@@ -626,7 +626,10 @@ pub struct SummaryEvent {
     #[serde(rename = "eventTime")]
     pub event_time: i64,
 
-    /// Identifier of the current trading day.
+    /// The current trading day, as **days since the Unix epoch**.
+    ///
+    /// Not `yyyymmdd`, which is the natural guess and the wrong one: a real
+    /// feed sends 20665 for 2026-07-31.
     #[serde(rename = "dayId")]
     pub day_id: i64,
 
@@ -650,7 +653,8 @@ pub struct SummaryEvent {
     #[serde(rename = "dayClosePriceType")]
     pub day_close_price_type: String,
 
-    /// Identifier of the previous trading day.
+    /// The previous trading day, as days since the Unix epoch. See
+    /// [`day_id`](Self::day_id).
     #[serde(rename = "prevDayId")]
     pub prev_day_id: i64,
 
@@ -747,7 +751,8 @@ pub struct ProfileEvent {
     #[serde(rename = "exDividendAmount", with = "json_double")]
     pub ex_dividend_amount: f64,
 
-    /// Day the last dividend went ex, as a day identifier.
+    /// Day the last dividend went ex, as **days since the Unix epoch** rather
+    /// than `yyyymmdd`.
     #[serde(rename = "exDividendDayId")]
     pub ex_dividend_day_id: i64,
 
@@ -1695,13 +1700,13 @@ mod event_serde_tests {
             event_type: "Summary".to_string(),
             event_symbol: "AAPL".to_string(),
             event_time: 1_700_000_000_500,
-            day_id: 20240119,
+            day_id: 20100,
             day_open_price: 149.5,
             day_high_price: 152.0,
             day_low_price: 148.0,
             day_close_price: 150.75,
             day_close_price_type: "Final".to_string(),
-            prev_day_id: 20240118,
+            prev_day_id: 20099,
             prev_day_close_price: 147.75,
             prev_day_close_price_type: "Final".to_string(),
             prev_day_volume: 58_000_000.0,
@@ -1755,7 +1760,7 @@ mod event_serde_tests {
             earnings_per_share: 6.13,
             dividend_frequency: 4.0,
             ex_dividend_amount: 0.24,
-            ex_dividend_day_id: 20240209,
+            ex_dividend_day_id: 20050,
             shares: 15_552_800_000.0,
             free_float: 15_461_900_000.0,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,12 @@
 //! - Strict decoding: [`try_parse_compact_data`] reports a short row, a wrong
 //!   column type or an unknown event type instead of returning fewer events and
 //!   letting a consumer read that as a quiet market.
+//! - **The layout the server negotiates is the one that gets decoded.** A feed
+//!   may serve fewer fields than were asked for — the dxFeed demo drops `VWAP`
+//!   from `Candle` — so columns are read by name rather than by position. A
+//!   field the server does not send arrives as `NaN`, `0` or an empty string
+//!   rather than as its neighbour's value, and a reordered list is followed
+//!   rather than refused.
 //! - A lost connection is observable: the event stream closes, and
 //!   [`DXLinkClient::disconnect_reason`] says why.
 //! - **Opt-in reconnection.** Off by default. Install a

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -957,13 +957,13 @@ mod summary_tests {
             json!("Summary"),            // 0 eventType
             json!(symbol),               // 1 eventSymbol
             json!(1_700_000_000_500i64), // 2 eventTime
-            json!(20240119i64),          // 3 dayId
+            json!(20100i64),             // 3 dayId
             json!(149.5),                // 4 dayOpenPrice
             json!(152.0),                // 5 dayHighPrice
             json!(148.0),                // 6 dayLowPrice
             json!(150.75),               // 7 dayClosePrice
             json!("Final"),              // 8 dayClosePriceType
-            json!(20240118i64),          // 9 prevDayId
+            json!(20099i64),             // 9 prevDayId
             json!(147.75),               // 10 prevDayClosePrice
             json!("Final"),              // 11 prevDayClosePriceType
             json!(58_000_000.0),         // 12 prevDayVolume
@@ -1001,13 +1001,13 @@ mod summary_tests {
                 assert_eq!(first.event_symbol, "AAPL");
                 assert_eq!(second.event_symbol, "MSFT");
                 assert_eq!(first.event_time, 1_700_000_000_500);
-                assert_eq!(first.day_id, 20240119);
+                assert_eq!(first.day_id, 20100);
                 assert_eq!(first.day_open_price, 149.5);
                 assert_eq!(first.day_high_price, 152.0);
                 assert_eq!(first.day_low_price, 148.0);
                 assert_eq!(first.day_close_price, 150.75);
                 assert_eq!(first.day_close_price_type, "Final");
-                assert_eq!(first.prev_day_id, 20240118);
+                assert_eq!(first.prev_day_id, 20099);
                 assert_eq!(first.prev_day_close_price, 147.75);
                 assert_eq!(first.prev_day_close_price_type, "Final");
                 assert_eq!(first.prev_day_volume, 58_000_000.0);
@@ -1293,7 +1293,7 @@ mod profile_tests {
             json!(6.13),                        // 14 earningsPerShare
             json!(4.0),                         // 15 dividendFrequency
             json!(0.24),                        // 16 exDividendAmount
-            json!(20240209i64),                 // 17 exDividendDayId
+            json!(20050i64),                    // 17 exDividendDayId
             json!(15_552_800_000.0),            // 18 shares
             json!(15_461_900_000.0),            // 19 freeFloat
         ]
@@ -1343,7 +1343,7 @@ mod profile_tests {
                 assert_eq!(first.earnings_per_share, 6.13);
                 assert_eq!(first.dividend_frequency, 4.0);
                 assert_eq!(first.ex_dividend_amount, 0.24);
-                assert_eq!(first.ex_dividend_day_id, 20240209);
+                assert_eq!(first.ex_dividend_day_id, 20050);
                 assert_eq!(first.shares, 15_552_800_000.0);
                 assert_eq!(first.free_float, 15_461_900_000.0);
             }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -10,6 +10,7 @@ use crate::events::{
     TheoPriceEvent, TimeAndSaleEvent, TradeEvent, UnderlyingEvent,
 };
 use serde_json::Value;
+use std::collections::HashMap;
 use tracing::warn;
 
 /// Decodes COMPACT rows, dropping the whole batch if any of it is malformed.
@@ -47,7 +48,7 @@ use tracing::warn;
 /// }
 /// ```
 pub fn parse_compact_data(data: &[CompactData]) -> Vec<MarketEvent> {
-    let (events, error) = decode(data);
+    let (events, error) = decode(data, None);
     if let Some(error) = error {
         warn!("Dropping malformed COMPACT data: {error}");
     }
@@ -90,7 +91,7 @@ pub fn parse_compact_data(data: &[CompactData]) -> Vec<MarketEvent> {
 /// assert_eq!(events.len(), 1);
 /// ```
 pub fn try_parse_compact_data(data: &[CompactData]) -> DXLinkResult<Vec<MarketEvent>> {
-    match decode(data) {
+    match decode(data, None) {
         (events, None) => Ok(events),
         (_, Some(error)) => Err(error),
     }
@@ -104,81 +105,139 @@ fn as_json_double(value: &Value) -> Option<f64> {
     crate::events::json_double::from_value(value)
 }
 
-/// A column that must be text.
-fn as_text<'a>(
-    values: &'a [Value],
-    index: usize,
-    event_type: &str,
-    row: usize,
-    field: &str,
-) -> DXLinkResult<&'a str> {
-    values[index].as_str().ok_or_else(|| {
-        DXLinkError::Protocol(format!(
-            "{event_type} row {row}: field `{field}` should be a string, got {}",
-            values[index]
-        ))
-    })
-}
-
-/// A column that must be a whole number, such as an epoch millisecond time.
-fn as_int(
-    values: &[Value],
-    index: usize,
-    event_type: &str,
-    row: usize,
-    field: &str,
-) -> DXLinkResult<i64> {
-    values[index].as_i64().ok_or_else(|| {
-        DXLinkError::Protocol(format!(
-            "{event_type} row {row}: field `{field}` should be a whole number, got {}",
-            values[index]
-        ))
-    })
-}
-
-/// A column that must be a double.
-fn as_double(
-    values: &[Value],
-    index: usize,
-    event_type: &str,
-    row: usize,
-    field: &str,
-) -> DXLinkResult<f64> {
-    as_json_double(&values[index]).ok_or_else(|| {
-        DXLinkError::Protocol(format!(
-            "{event_type} row {row}: field `{field}` should be a number, got {}",
-            values[index]
-        ))
-    })
-}
-
-/// A column that must be a boolean.
+/// Decodes against the layout a channel actually negotiated.
 ///
-/// Strict on purpose: the protocol sends JSON `true`/`false` here, and treating
-/// `0`, `"false"` or `null` as false would turn a layout error into a plausible
-/// flag. A print wrongly marked `validTick` moves a last price that should not
-/// have moved.
-fn as_bool(
-    values: &[Value],
-    index: usize,
-    event_type: &str,
+/// The client uses this rather than [`try_parse_compact_data`], because the
+/// list the server agreed to is not always the list that was requested.
+pub(crate) fn try_parse_negotiated(
+    data: &[CompactData],
+    layout: &HashMap<String, Vec<String>>,
+) -> DXLinkResult<Vec<MarketEvent>> {
+    match decode(data, Some(layout)) {
+        (events, None) => Ok(events),
+        (_, Some(error)) => Err(error),
+    }
+}
+
+/// One COMPACT row, addressed by field name rather than by position.
+///
+/// **This is the fix for the layout the server actually negotiates.** The
+/// client asks for a field list, but a server may serve a *subset* of it: the
+/// dxFeed demo drops `VWAP` from `Candle`, for instance. Reading by position
+/// against the requested list then either shifts every value after the gap or,
+/// if the arithmetic happens not to divide, drops the batch entirely.
+///
+/// Reading by name makes both harmless. A field the server left out reads as
+/// "not provided" instead of as its neighbour, and a field it added or moved is
+/// simply looked up where it really is.
+struct Row<'a> {
+    values: &'a [Value],
+    /// Field name to column, built once per batch from the negotiated layout.
+    columns: &'a HashMap<&'a str, usize>,
+    event_type: &'a str,
     row: usize,
-    field: &str,
-) -> DXLinkResult<bool> {
-    values[index].as_bool().ok_or_else(|| {
-        DXLinkError::Protocol(format!(
-            "{event_type} row {row}: field `{field}` should be a boolean, got {}",
-            values[index]
-        ))
-    })
+}
+
+impl<'a> Row<'a> {
+    fn value(&self, field: &str) -> Option<&'a Value> {
+        self.columns.get(field).map(|index| &self.values[*index])
+    }
+
+    /// A column that must be text when present.
+    ///
+    /// Absent means the server does not serve it, which is an empty string
+    /// rather than an error: the alternative is refusing an event over a field
+    /// the consumer may not even read.
+    fn text(&self, field: &str) -> DXLinkResult<String> {
+        let Some(value) = self.value(field) else {
+            return Ok(String::new());
+        };
+        value.as_str().map(str::to_string).ok_or_else(|| {
+            DXLinkError::Protocol(format!(
+                "{} row {}: field `{field}` should be a string, got {value}",
+                self.event_type, self.row
+            ))
+        })
+    }
+
+    /// A column that has to be there for the event to mean anything.
+    fn required_text(&self, field: &str) -> DXLinkResult<String> {
+        let Some(value) = self.value(field) else {
+            return Err(DXLinkError::Protocol(format!(
+                "{} row {}: the negotiated layout has no `{field}` column, so the \
+                 row cannot be identified",
+                self.event_type, self.row
+            )));
+        };
+        value.as_str().map(str::to_string).ok_or_else(|| {
+            DXLinkError::Protocol(format!(
+                "{} row {}: field `{field}` should be a string, got {value}",
+                self.event_type, self.row
+            ))
+        })
+    }
+
+    /// A column that must be a whole number, such as an epoch millisecond.
+    ///
+    /// Absent reads as zero, which is what the server itself sends for a
+    /// timestamp it did not populate.
+    fn int(&self, field: &str) -> DXLinkResult<i64> {
+        let Some(value) = self.value(field) else {
+            return Ok(0);
+        };
+        value.as_i64().ok_or_else(|| {
+            DXLinkError::Protocol(format!(
+                "{} row {}: field `{field}` should be a whole number, got {value}",
+                self.event_type, self.row
+            ))
+        })
+    }
+
+    /// A column that must be a double.
+    ///
+    /// Absent reads as `NaN`, the same value the protocol uses for a number
+    /// that does not apply, so a consumer already has to handle it.
+    fn double(&self, field: &str) -> DXLinkResult<f64> {
+        let Some(value) = self.value(field) else {
+            return Ok(f64::NAN);
+        };
+        as_json_double(value).ok_or_else(|| {
+            DXLinkError::Protocol(format!(
+                "{} row {}: field `{field}` should be a number, got {value}",
+                self.event_type, self.row
+            ))
+        })
+    }
+
+    /// A column that must be a boolean.
+    ///
+    /// Strict when present: the protocol sends JSON `true`/`false` here, and
+    /// treating `0` or `"false"` as false would turn a layout error into a
+    /// plausible flag. Absent reads as `false`, which for `validTick` and the
+    /// rest is the conservative answer.
+    fn flag(&self, field: &str) -> DXLinkResult<bool> {
+        let Some(value) = self.value(field) else {
+            return Ok(false);
+        };
+        value.as_bool().ok_or_else(|| {
+            DXLinkError::Protocol(format!(
+                "{} row {}: field `{field}` should be a boolean, got {value}",
+                self.event_type, self.row
+            ))
+        })
+    }
 }
 
 /// Decodes what it can and reports the first problem it hit.
 ///
-/// The layout comes from [`EventType::compact_fields`], the same list
-/// `setup_feed` asked the server for, so the stride cannot drift away from the
-/// request the way three separate literals could.
-fn decode(data: &[CompactData]) -> (Vec<MarketEvent>, Option<DXLinkError>) {
+/// `layout` is the field list per event type that the channel **negotiated**,
+/// which is not always the one it requested. `None` falls back to
+/// [`EventType::compact_fields`], which is what the standalone
+/// [`parse_compact_data`] entry points use when no channel is in play.
+fn decode(
+    data: &[CompactData],
+    layout: Option<&HashMap<String, Vec<String>>>,
+) -> (Vec<MarketEvent>, Option<DXLinkError>) {
     let mut events = Vec::new();
     let mut index = 0;
 
@@ -213,7 +272,25 @@ fn decode(data: &[CompactData]) -> (Vec<MarketEvent>, Option<DXLinkError>) {
             );
         };
 
-        let Some(fields) = event_type.compact_fields() else {
+        // The negotiated list wins; the requested one is the fallback.
+        let negotiated = layout.and_then(|layout| layout.get(header.as_str()));
+        let fields: Vec<&str> = match negotiated {
+            Some(fields) => fields.iter().map(String::as_str).collect(),
+            None => match event_type.compact_fields() {
+                Some(fields) => fields.to_vec(),
+                None => {
+                    return (
+                        events,
+                        Some(DXLinkError::Protocol(format!(
+                            "event type `{header}` has no decoder in this client, so its \
+                             rows cannot be read"
+                        ))),
+                    );
+                }
+            },
+        };
+
+        if event_type.compact_fields().is_none() {
             return (
                 events,
                 Some(DXLinkError::Protocol(format!(
@@ -221,9 +298,17 @@ fn decode(data: &[CompactData]) -> (Vec<MarketEvent>, Option<DXLinkError>) {
                      cannot be read"
                 ))),
             );
-        };
+        }
 
         let stride = fields.len();
+        if stride == 0 {
+            return (
+                events,
+                Some(DXLinkError::Protocol(format!(
+                    "{header}: the negotiated layout has no columns at all"
+                ))),
+            );
+        }
         if values.len() % stride != 0 {
             return (
                 events,
@@ -235,24 +320,40 @@ fn decode(data: &[CompactData]) -> (Vec<MarketEvent>, Option<DXLinkError>) {
             );
         }
 
+        // Built once per batch, not per row.
+        let mut columns: HashMap<&str, usize> = HashMap::with_capacity(stride);
+        for (column, field) in fields.iter().enumerate() {
+            // First wins. A duplicated name is the server's problem, and
+            // picking one deterministically beats failing the batch.
+            columns.entry(field).or_insert(column);
+        }
+
         for (row, chunk) in values.chunks_exact(stride).enumerate() {
+            let row = Row {
+                values: chunk,
+                columns: &columns,
+                event_type: header,
+                row,
+            };
+
             // The batch header and the row's own eventType must agree, or the
             // row belongs to a layout other than the one being applied.
-            let inner = match as_text(chunk, 0, header, row, fields[0]) {
+            let inner = match row.required_text("eventType") {
                 Ok(inner) => inner,
                 Err(e) => return (events, Some(e)),
             };
-            if inner != header {
+            if inner != *header {
                 return (
                     events,
                     Some(DXLinkError::Protocol(format!(
-                        "{header} row {row}: the row says it is a `{inner}`, so it is not \
-                         laid out the way this batch claims"
+                        "{header} row {}: the row says it is a `{inner}`, so it is not \
+                         laid out the way this batch claims",
+                        row.row
                     ))),
                 );
             }
 
-            match build_event(event_type, chunk, header, row, fields) {
+            match build_event(event_type, &row) {
                 Ok(event) => events.push(event),
                 Err(e) => return (events, Some(e)),
             }
@@ -262,183 +363,149 @@ fn decode(data: &[CompactData]) -> (Vec<MarketEvent>, Option<DXLinkError>) {
     (events, None)
 }
 
-/// Builds one event from a row whose length already matches the layout.
-fn build_event(
-    event_type: EventType,
-    row_values: &[Value],
-    header: &str,
-    row: usize,
-    fields: &[&str],
-) -> DXLinkResult<MarketEvent> {
-    let symbol = as_text(row_values, 1, header, row, fields[1])?.to_string();
-    let number = |index: usize| as_double(row_values, index, header, row, fields[index]);
+/// Builds one event from a row, reading every column by name.
+fn build_event(event_type: EventType, row: &Row<'_>) -> DXLinkResult<MarketEvent> {
+    let event_type_name = row.required_text("eventType")?;
+    let symbol = row.required_text("eventSymbol")?;
 
     Ok(match event_type {
         EventType::Quote => MarketEvent::Quote(QuoteEvent {
-            event_type: header.to_string(),
+            event_type: event_type_name,
             event_symbol: symbol,
-            bid_price: number(2)?,
-            ask_price: number(3)?,
-            bid_size: number(4)?,
-            ask_size: number(5)?,
+            bid_price: row.double("bidPrice")?,
+            ask_price: row.double("askPrice")?,
+            bid_size: row.double("bidSize")?,
+            ask_size: row.double("askSize")?,
         }),
         EventType::Trade => MarketEvent::Trade(TradeEvent {
-            event_type: header.to_string(),
+            event_type: event_type_name,
             event_symbol: symbol,
-            price: number(2)?,
-            size: number(3)?,
-            day_volume: number(4)?,
+            price: row.double("price")?,
+            size: row.double("size")?,
+            day_volume: row.double("dayVolume")?,
         }),
         EventType::Greeks => MarketEvent::Greeks(GreeksEvent {
-            event_type: header.to_string(),
+            event_type: event_type_name,
             event_symbol: symbol,
-            delta: number(2)?,
-            gamma: number(3)?,
-            theta: number(4)?,
-            vega: number(5)?,
-            rho: number(6)?,
-            volatility: number(7)?,
+            delta: row.double("delta")?,
+            gamma: row.double("gamma")?,
+            theta: row.double("theta")?,
+            vega: row.double("vega")?,
+            rho: row.double("rho")?,
+            volatility: row.double("volatility")?,
         }),
-        EventType::Candle => {
-            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
-            MarketEvent::Candle(CandleEvent {
-                event_type: header.to_string(),
-                event_symbol: symbol,
-                event_time: int(2)?,
-                event_flags: int(3)?,
-                index: int(4)?,
-                time: int(5)?,
-                sequence: int(6)?,
-                count: int(7)?,
-                open: number(8)?,
-                high: number(9)?,
-                low: number(10)?,
-                close: number(11)?,
-                volume: number(12)?,
-                vwap: number(13)?,
-                bid_volume: number(14)?,
-                ask_volume: number(15)?,
-                imp_volatility: number(16)?,
-                open_interest: number(17)?,
-            })
-        }
-        EventType::Summary => {
-            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
-            let text = |index: usize| {
-                as_text(row_values, index, header, row, fields[index]).map(str::to_string)
-            };
-            MarketEvent::Summary(SummaryEvent {
-                event_type: header.to_string(),
-                event_symbol: symbol,
-                event_time: int(2)?,
-                day_id: int(3)?,
-                day_open_price: number(4)?,
-                day_high_price: number(5)?,
-                day_low_price: number(6)?,
-                day_close_price: number(7)?,
-                day_close_price_type: text(8)?,
-                prev_day_id: int(9)?,
-                prev_day_close_price: number(10)?,
-                prev_day_close_price_type: text(11)?,
-                prev_day_volume: number(12)?,
-                open_interest: number(13)?,
-            })
-        }
-        EventType::TimeAndSale => {
-            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
-            let text = |index: usize| {
-                as_text(row_values, index, header, row, fields[index]).map(str::to_string)
-            };
-            let flag = |index: usize| as_bool(row_values, index, header, row, fields[index]);
-            MarketEvent::TimeAndSale(TimeAndSaleEvent {
-                event_type: header.to_string(),
-                event_symbol: symbol,
-                event_time: int(2)?,
-                event_flags: int(3)?,
-                index: int(4)?,
-                time: int(5)?,
-                time_nano_part: int(6)?,
-                sequence: int(7)?,
-                exchange_code: text(8)?,
-                price: number(9)?,
-                size: number(10)?,
-                bid_price: number(11)?,
-                ask_price: number(12)?,
-                exchange_sale_conditions: text(13)?,
-                trade_through_exempt: text(14)?,
-                aggressor_side: text(15)?,
-                spread_leg: flag(16)?,
-                extended_trading_hours: flag(17)?,
-                valid_tick: flag(18)?,
-                sale_type: text(19)?,
-                buyer: text(20)?,
-                seller: text(21)?,
-            })
-        }
-        EventType::Profile => {
-            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
-            let text = |index: usize| {
-                as_text(row_values, index, header, row, fields[index]).map(str::to_string)
-            };
-            MarketEvent::Profile(ProfileEvent {
-                event_type: header.to_string(),
-                event_symbol: symbol,
-                event_time: int(2)?,
-                description: text(3)?,
-                short_sale_restriction: text(4)?,
-                trading_status: text(5)?,
-                status_reason: text(6)?,
-                halt_start_time: int(7)?,
-                halt_end_time: int(8)?,
-                high_limit_price: number(9)?,
-                low_limit_price: number(10)?,
-                high_52_week_price: number(11)?,
-                low_52_week_price: number(12)?,
-                beta: number(13)?,
-                earnings_per_share: number(14)?,
-                dividend_frequency: number(15)?,
-                ex_dividend_amount: number(16)?,
-                ex_dividend_day_id: int(17)?,
-                shares: number(18)?,
-                free_float: number(19)?,
-            })
-        }
-        EventType::Underlying => {
-            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
-            MarketEvent::Underlying(UnderlyingEvent {
-                event_type: header.to_string(),
-                event_symbol: symbol,
-                event_time: int(2)?,
-                event_flags: int(3)?,
-                index: int(4)?,
-                time: int(5)?,
-                sequence: int(6)?,
-                volatility: number(7)?,
-                front_volatility: number(8)?,
-                back_volatility: number(9)?,
-                call_volume: number(10)?,
-                put_volume: number(11)?,
-                put_call_ratio: number(12)?,
-            })
-        }
-        EventType::TheoPrice => {
-            let int = |index: usize| as_int(row_values, index, header, row, fields[index]);
-            MarketEvent::TheoPrice(TheoPriceEvent {
-                event_type: header.to_string(),
-                event_symbol: symbol,
-                event_time: int(2)?,
-                event_flags: int(3)?,
-                index: int(4)?,
-                time: int(5)?,
-                sequence: int(6)?,
-                price: number(7)?,
-                underlying_price: number(8)?,
-                delta: number(9)?,
-                gamma: number(10)?,
-                dividend: number(11)?,
-                interest: number(12)?,
-            })
-        }
+        EventType::Candle => MarketEvent::Candle(CandleEvent {
+            event_type: event_type_name,
+            event_symbol: symbol,
+            event_time: row.int("eventTime")?,
+            event_flags: row.int("eventFlags")?,
+            index: row.int("index")?,
+            time: row.int("time")?,
+            sequence: row.int("sequence")?,
+            count: row.int("count")?,
+            open: row.double("open")?,
+            high: row.double("high")?,
+            low: row.double("low")?,
+            close: row.double("close")?,
+            volume: row.double("volume")?,
+            vwap: row.double("VWAP")?,
+            bid_volume: row.double("bidVolume")?,
+            ask_volume: row.double("askVolume")?,
+            imp_volatility: row.double("impVolatility")?,
+            open_interest: row.double("openInterest")?,
+        }),
+        EventType::Summary => MarketEvent::Summary(SummaryEvent {
+            event_type: event_type_name,
+            event_symbol: symbol,
+            event_time: row.int("eventTime")?,
+            day_id: row.int("dayId")?,
+            day_open_price: row.double("dayOpenPrice")?,
+            day_high_price: row.double("dayHighPrice")?,
+            day_low_price: row.double("dayLowPrice")?,
+            day_close_price: row.double("dayClosePrice")?,
+            day_close_price_type: row.text("dayClosePriceType")?,
+            prev_day_id: row.int("prevDayId")?,
+            prev_day_close_price: row.double("prevDayClosePrice")?,
+            prev_day_close_price_type: row.text("prevDayClosePriceType")?,
+            prev_day_volume: row.double("prevDayVolume")?,
+            open_interest: row.double("openInterest")?,
+        }),
+        EventType::TimeAndSale => MarketEvent::TimeAndSale(TimeAndSaleEvent {
+            event_type: event_type_name,
+            event_symbol: symbol,
+            event_time: row.int("eventTime")?,
+            event_flags: row.int("eventFlags")?,
+            index: row.int("index")?,
+            time: row.int("time")?,
+            time_nano_part: row.int("timeNanoPart")?,
+            sequence: row.int("sequence")?,
+            exchange_code: row.text("exchangeCode")?,
+            price: row.double("price")?,
+            size: row.double("size")?,
+            bid_price: row.double("bidPrice")?,
+            ask_price: row.double("askPrice")?,
+            exchange_sale_conditions: row.text("exchangeSaleConditions")?,
+            trade_through_exempt: row.text("tradeThroughExempt")?,
+            aggressor_side: row.text("aggressorSide")?,
+            spread_leg: row.flag("spreadLeg")?,
+            extended_trading_hours: row.flag("extendedTradingHours")?,
+            valid_tick: row.flag("validTick")?,
+            sale_type: row.text("type")?,
+            buyer: row.text("buyer")?,
+            seller: row.text("seller")?,
+        }),
+        EventType::Profile => MarketEvent::Profile(ProfileEvent {
+            event_type: event_type_name,
+            event_symbol: symbol,
+            event_time: row.int("eventTime")?,
+            description: row.text("description")?,
+            short_sale_restriction: row.text("shortSaleRestriction")?,
+            trading_status: row.text("tradingStatus")?,
+            status_reason: row.text("statusReason")?,
+            halt_start_time: row.int("haltStartTime")?,
+            halt_end_time: row.int("haltEndTime")?,
+            high_limit_price: row.double("highLimitPrice")?,
+            low_limit_price: row.double("lowLimitPrice")?,
+            high_52_week_price: row.double("high52WeekPrice")?,
+            low_52_week_price: row.double("low52WeekPrice")?,
+            beta: row.double("beta")?,
+            earnings_per_share: row.double("earningsPerShare")?,
+            dividend_frequency: row.double("dividendFrequency")?,
+            ex_dividend_amount: row.double("exDividendAmount")?,
+            ex_dividend_day_id: row.int("exDividendDayId")?,
+            shares: row.double("shares")?,
+            free_float: row.double("freeFloat")?,
+        }),
+        EventType::Underlying => MarketEvent::Underlying(UnderlyingEvent {
+            event_type: event_type_name,
+            event_symbol: symbol,
+            event_time: row.int("eventTime")?,
+            event_flags: row.int("eventFlags")?,
+            index: row.int("index")?,
+            time: row.int("time")?,
+            sequence: row.int("sequence")?,
+            volatility: row.double("volatility")?,
+            front_volatility: row.double("frontVolatility")?,
+            back_volatility: row.double("backVolatility")?,
+            call_volume: row.double("callVolume")?,
+            put_volume: row.double("putVolume")?,
+            put_call_ratio: row.double("putCallRatio")?,
+        }),
+        EventType::TheoPrice => MarketEvent::TheoPrice(TheoPriceEvent {
+            event_type: event_type_name,
+            event_symbol: symbol,
+            event_time: row.int("eventTime")?,
+            event_flags: row.int("eventFlags")?,
+            index: row.int("index")?,
+            time: row.int("time")?,
+            sequence: row.int("sequence")?,
+            price: row.double("price")?,
+            underlying_price: row.double("underlyingPrice")?,
+            delta: row.double("delta")?,
+            gamma: row.double("gamma")?,
+            dividend: row.double("dividend")?,
+            interest: row.double("interest")?,
+        }),
         // compact_fields returned Some for this type, so a missing arm here is a
         // bug in this match rather than a protocol problem.
         other => {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -272,10 +272,23 @@ fn decode(
             );
         };
 
-        // The negotiated list wins; the requested one is the fallback.
-        let negotiated = layout.and_then(|layout| layout.get(header.as_str()));
-        let fields: Vec<&str> = match negotiated {
-            Some(fields) => fields.iter().map(String::as_str).collect(),
+        // The negotiated list wins. When a channel supplied one, a type missing
+        // from it is refused rather than falling back to what this client
+        // asked for: the fallback is the positional read that caused #63, and
+        // guessing here would decode against a layout nobody agreed to.
+        let fields: Vec<&str> = match layout {
+            Some(layout) => match layout.get(header.as_str()) {
+                Some(fields) => fields.iter().map(String::as_str).collect(),
+                None => {
+                    return (
+                        events,
+                        Some(DXLinkError::Protocol(format!(
+                            "event type `{header}` is not in the layout this channel \
+                             negotiated, so there is nothing to read its rows against"
+                        ))),
+                    );
+                }
+            },
             None => match event_type.compact_fields() {
                 Some(fields) => fields.to_vec(),
                 None => {

--- a/tests/integration/dxlink_real.rs
+++ b/tests/integration/dxlink_real.rs
@@ -26,11 +26,35 @@ use std::env;
 use std::time::Duration;
 use tokio::time::timeout;
 
-/// The demo endpoint that actually works.
+/// dxFeed's own public demo, which serves delayed data and needs no token.
 ///
-/// The older `wss://demo.dxfeed.com/dxlink-ws` answers HTTP 400 on upgrade, and
-/// that once got reported as a client bug.
-const DEMO_URL: &str = "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed";
+/// Note the `/market-data/` in the path. The shorter
+/// `wss://demo.dxfeed.com/dxlink-ws` answers HTTP 400 on upgrade, and that once
+/// got reported as a client bug.
+const PUBLIC_DEMO_URL: &str = "wss://demo.dxfeed.com/market-data/dxlink-ws";
+
+/// Where to point, and whether a token is needed.
+///
+/// Defaults to the public demo so these run with no credentials at all. Set
+/// `DXLINK_WS_URL` to aim them somewhere else — tastytrade's delayed endpoint is
+/// `wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed` and does require a token,
+/// which comes from tastytrade's `/api-quote-tokens`.
+fn endpoint() -> (String, String) {
+    let url = env::var("DXLINK_WS_URL").unwrap_or_else(|_| PUBLIC_DEMO_URL.to_string());
+    let token = env::var("DXLINK_API_TOKEN").unwrap_or_default();
+
+    // Only the public demo is anonymous. Anywhere else, a missing token shows up
+    // as UNAUTHORIZED from the server, which reads like a client bug rather than
+    // a missing credential.
+    assert!(
+        url == PUBLIC_DEMO_URL || !token.trim().is_empty(),
+        "DXLINK_WS_URL is set to {url} but DXLINK_API_TOKEN is empty. Only \
+         {PUBLIC_DEMO_URL} accepts an anonymous session; anything else rejects \
+         it at AUTH."
+    );
+
+    (url, token)
+}
 
 /// Liquid enough that something is usually moving.
 const EQUITY: &str = "AAPL";
@@ -54,6 +78,24 @@ const DECODED: &[EventType] = &[
     EventType::Underlying,
     EventType::TheoPrice,
 ];
+
+/// Turns on tracing when `RUST_LOG` asks for it.
+///
+/// Worth having on a network smoke specifically: when one of these fails the
+/// first question is always whether the client sent the wrong thing or the
+/// server answered oddly, and only the protocol log settles it.
+fn trace_the_wire() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        if env::var("RUST_LOG").is_ok() {
+            // The outbound log redacts credentials before it prints, so this is
+            // safe to enable with a real token in the environment.
+            let _ = tracing_subscriber::fmt()
+                .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+                .try_init();
+        }
+    });
+}
 
 fn subscription(event_type: &str, symbol: &str) -> FeedSubscription {
     FeedSubscription {
@@ -96,14 +138,34 @@ fn plausible_size(value: f64, field: &str, symbol: &str) {
     assert!(value >= 0.0, "{symbol}: {field} is negative ({value})");
 }
 
-/// An epoch millisecond in the range a live feed can produce. Catches a price
-/// that drifted into a time column, which is the same bug from the other side.
+/// An epoch millisecond in the range a live feed can produce, or zero.
+///
+/// Catches a price that drifted into a time column, which is the same bug as
+/// the other way round. Zero is allowed because the server genuinely sends it
+/// for a timestamp it did not populate — a real `Summary` from the demo feed
+/// arrives with `eventTime: 0`.
 fn plausible_time(value: i64, field: &str, symbol: &str) {
+    if value == 0 {
+        return;
+    }
     // 2001-09-09 to 2100-01-01. Wide on purpose: this is a shape check, not a
     // clock check, and a delayed feed replays older stamps.
     assert!(
         (1_000_000_000_000..4_102_444_800_000).contains(&value),
         "{symbol}: {field} is {value}, which is not an epoch millisecond"
+    );
+}
+
+/// A day identifier: **days since the Unix epoch**, not `yyyymmdd`.
+///
+/// This assertion started life as a `yyyymmdd` range, which is the natural
+/// guess and wrong. The real feed says 20665 for 2026-07-31, and that is
+/// exactly the kind of thing only a real server tells you.
+fn plausible_day_id(value: i64, field: &str, symbol: &str) {
+    // 1997-05-19 to 2079-09-28. A yyyymmdd would be far outside this.
+    assert!(
+        (10_000..40_000).contains(&value),
+        "{symbol}: {field} is {value}, which is not a day count since the epoch"
     );
 }
 
@@ -194,12 +256,8 @@ fn validate(event: &MarketEvent) -> &'static str {
                 "{symbol}: dayClosePriceType is {:?}, which is not a price type",
                 summary.day_close_price_type
             );
-            // Day identifiers are yyyymmdd, not epochs.
-            assert!(
-                (19000101..=21001231).contains(&summary.day_id),
-                "{symbol}: dayId is {}, which is not a day identifier",
-                summary.day_id
-            );
+            plausible_day_id(summary.day_id, "dayId", symbol);
+            plausible_day_id(summary.prev_day_id, "prevDayId", symbol);
             "Summary"
         }
         MarketEvent::TimeAndSale(print) => {
@@ -261,19 +319,13 @@ fn validate(event: &MarketEvent) -> &'static str {
 
 /// Connects and configures the channel for every decodable type.
 async fn open_session() -> (DXLinkClient, tokio::sync::mpsc::Receiver<MarketEvent>, u32) {
-    // Checked rather than defaulted. The demo feed answers an empty token with
-    // UNAUTHORIZED, and letting that surface as a bare connect failure reads
-    // like a client bug instead of a missing credential. Never printed: it goes
-    // straight into the client.
-    let token = env::var("DXLINK_API_TOKEN").unwrap_or_default();
-    assert!(
-        !token.trim().is_empty(),
-        "DXLINK_API_TOKEN is not set. These tests talk to the real dxFeed demo \
-         server, which rejects an empty token, so there is nothing to smoke \
-         without one. Set it in the environment and run again."
-    );
+    trace_the_wire();
 
-    let mut client = DXLinkClient::new(DEMO_URL, &token);
+    // The token is never printed: it goes straight into the client.
+    let (url, token) = endpoint();
+    println!("--- connecting to {url}");
+
+    let mut client = DXLinkClient::new(&url, &token);
     let stream = client
         .connect()
         .await
@@ -447,8 +499,10 @@ async fn test_real_server_replays_historical_candles() {
 
     assert!(
         !bars.is_empty(),
-        "no historical bars arrived for {CANDLE}; either fromTime was not \
-         honoured or the symbol has no history on this feed"
+        "no historical bars arrived for {CANDLE}. Known cause, issue #63: this \
+         server negotiates a Candle layout without VWAP, the decoder is \
+         compiled against one with it, so the channel is invalidated and every \
+         bar is dropped. Run with RUST_LOG=dxlink=debug to see them arriving."
     );
     for bar in &bars {
         assert_eq!(

--- a/tests/integration/dxlink_real.rs
+++ b/tests/integration/dxlink_real.rs
@@ -1,117 +1,515 @@
-use dxlink::{DXLinkClient, EventType, FeedSubscription};
+//! Smoke tests against the real dxFeed demo server.
+//!
+//! `#[ignore]`d because they need the network; run them with
+//! `cargo test --test tests -- --ignored --nocapture`.
+//!
+//! **These exist to catch what the offline suite structurally cannot.** Every
+//! other test in this directory drives a mock server written from our own
+//! reading of the protocol, so a misunderstanding of the wire format is baked
+//! into both sides of the exchange and passes. Only a real server can disagree
+//! with us.
+//!
+//! The specific failure they are here for is COMPACT column drift, which does
+//! not error: it puts plausible numbers in the wrong fields. So the assertions
+//! are about the *shape* of what arrives — a price that is a price, a symbol
+//! that is one of the symbols we asked for, a bar whose low is not above its
+//! high — rather than about market activity, which nobody controls.
+//!
+//! What they do **not** assert is that any particular event type arrives. The
+//! feed is delayed and demo entitlements vary, so requiring a `Trade` outside
+//! market hours would make a green test mean "the market is open". Coverage of
+//! what did arrive is printed instead, so a run is readable.
+
+use dxlink::{DXLinkClient, EventType, FeedSubscription, MarketEvent};
+use std::collections::BTreeSet;
 use std::env;
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
-use tokio::time::{sleep, timeout};
-use tracing::info;
+use tokio::time::timeout;
 
-#[tokio::test]
-#[ignore] // Requires network access to the external DXFeed demo server
-async fn test_integration_with_real_server() {
-    let token = env::var("DXLINK_API_TOKEN").unwrap_or_else(|_| String::new());
-    let url = "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed";
+/// The demo endpoint that actually works.
+///
+/// The older `wss://demo.dxfeed.com/dxlink-ws` answers HTTP 400 on upgrade, and
+/// that once got reported as a client bug.
+const DEMO_URL: &str = "wss://tasty-demo-dxlink-md-ws.dxfeed.com/delayed";
 
-    info!("Conectando al servidor demo de DXFeed: {}", url);
+/// Liquid enough that something is usually moving.
+const EQUITY: &str = "AAPL";
+const OTHER_EQUITY: &str = "MSFT";
+/// Five minute bars on the same underlying.
+const CANDLE: &str = "AAPL{=5m}";
 
-    let mut client = DXLinkClient::new(url, &token);
+/// How long to sit and collect before deciding what arrived.
+const COLLECT: Duration = Duration::from_secs(20);
 
-    let mut event_stream = client
+/// Every type this client can decode, which is what the channel is configured
+/// for: the server refusing one of these field lists is itself a finding.
+const DECODED: &[EventType] = &[
+    EventType::Quote,
+    EventType::Trade,
+    EventType::Greeks,
+    EventType::Candle,
+    EventType::Summary,
+    EventType::TimeAndSale,
+    EventType::Profile,
+    EventType::Underlying,
+    EventType::TheoPrice,
+];
+
+fn subscription(event_type: &str, symbol: &str) -> FeedSubscription {
+    FeedSubscription {
+        event_type: event_type.to_string(),
+        symbol: symbol.to_string(),
+        from_time: None,
+        source: None,
+    }
+}
+
+/// A number that could be a price. Catches a column holding a timestamp, a
+/// count, or a value shifted in from a neighbouring field.
+fn plausible_price(value: f64, field: &str, symbol: &str) {
+    assert!(
+        value.is_finite(),
+        "{symbol}: {field} is {value}, which is not a number a price can be"
+    );
+    assert!(
+        value > 0.0,
+        "{symbol}: {field} is {value}; a traded instrument has no zero or \
+         negative price, so this column is probably not the one we think"
+    );
+    assert!(
+        value < 1_000_000.0,
+        "{symbol}: {field} is {value}, which is more likely an epoch \
+         millisecond that drifted into a price column"
+    );
+}
+
+/// A number that could be a size or a volume: zero is legitimate, negative is
+/// not, and `NaN` means "not applicable" rather than a failure.
+fn plausible_size(value: f64, field: &str, symbol: &str) {
+    if value.is_nan() {
+        return;
+    }
+    assert!(
+        value.is_finite(),
+        "{symbol}: {field} is {value}, which is not a size"
+    );
+    assert!(value >= 0.0, "{symbol}: {field} is negative ({value})");
+}
+
+/// An epoch millisecond in the range a live feed can produce. Catches a price
+/// that drifted into a time column, which is the same bug from the other side.
+fn plausible_time(value: i64, field: &str, symbol: &str) {
+    // 2001-09-09 to 2100-01-01. Wide on purpose: this is a shape check, not a
+    // clock check, and a delayed feed replays older stamps.
+    assert!(
+        (1_000_000_000_000..4_102_444_800_000).contains(&value),
+        "{symbol}: {field} is {value}, which is not an epoch millisecond"
+    );
+}
+
+/// Checks one event against the layout it claims, and reports its type.
+///
+/// This is the whole point of the file. Every field named here is read at a
+/// fixed column offset, so a layout that disagrees with the server shows up as
+/// a value that fails one of these.
+fn validate(event: &MarketEvent) -> &'static str {
+    match event {
+        MarketEvent::Quote(quote) => {
+            let symbol = &quote.event_symbol;
+            plausible_price(quote.bid_price, "bidPrice", symbol);
+            plausible_price(quote.ask_price, "askPrice", symbol);
+            plausible_size(quote.bid_size, "bidSize", symbol);
+            plausible_size(quote.ask_size, "askSize", symbol);
+            "Quote"
+        }
+        MarketEvent::Trade(trade) => {
+            let symbol = &trade.event_symbol;
+            plausible_price(trade.price, "price", symbol);
+            plausible_size(trade.size, "size", symbol);
+            plausible_size(trade.day_volume, "dayVolume", symbol);
+            "Trade"
+        }
+        MarketEvent::Greeks(greeks) => {
+            let symbol = &greeks.event_symbol;
+            // Delta is bounded by definition, which makes it the single best
+            // column-drift detector in the protocol.
+            assert!(
+                greeks.delta.is_nan() || (-1.0..=1.0).contains(&greeks.delta),
+                "{symbol}: delta is {}, which is outside what a delta can be",
+                greeks.delta
+            );
+            assert!(
+                greeks.volatility.is_nan() || greeks.volatility >= 0.0,
+                "{symbol}: volatility is negative ({})",
+                greeks.volatility
+            );
+            "Greeks"
+        }
+        MarketEvent::Candle(candle) => {
+            let symbol = &candle.event_symbol;
+            plausible_time(candle.time, "time", symbol);
+            for (value, field) in [
+                (candle.open, "open"),
+                (candle.high, "high"),
+                (candle.low, "low"),
+                (candle.close, "close"),
+            ] {
+                plausible_price(value, field, symbol);
+            }
+            // The ordering is the assertion a shifted layout cannot satisfy.
+            assert!(
+                candle.high >= candle.low,
+                "{symbol}: high {} is below low {}",
+                candle.high,
+                candle.low
+            );
+            assert!(
+                candle.open <= candle.high && candle.open >= candle.low,
+                "{symbol}: open {} is outside [{}, {}]",
+                candle.open,
+                candle.low,
+                candle.high
+            );
+            assert!(
+                candle.close <= candle.high && candle.close >= candle.low,
+                "{symbol}: close {} is outside [{}, {}]",
+                candle.close,
+                candle.low,
+                candle.high
+            );
+            plausible_size(candle.volume, "volume", symbol);
+            "Candle"
+        }
+        MarketEvent::Summary(summary) => {
+            let symbol = &summary.event_symbol;
+            plausible_time(summary.event_time, "eventTime", symbol);
+            // A text column sitting between numeric ones: a shift in either
+            // direction lands a number here and fails the decode before this
+            // line, so reaching it already proves something.
+            assert!(
+                summary
+                    .day_close_price_type
+                    .chars()
+                    .all(|c| c.is_ascii_alphabetic()),
+                "{symbol}: dayClosePriceType is {:?}, which is not a price type",
+                summary.day_close_price_type
+            );
+            // Day identifiers are yyyymmdd, not epochs.
+            assert!(
+                (19000101..=21001231).contains(&summary.day_id),
+                "{symbol}: dayId is {}, which is not a day identifier",
+                summary.day_id
+            );
+            "Summary"
+        }
+        MarketEvent::TimeAndSale(print) => {
+            let symbol = &print.event_symbol;
+            plausible_time(print.time, "time", symbol);
+            plausible_price(print.price, "price", symbol);
+            plausible_size(print.size, "size", symbol);
+            assert!(
+                print.exchange_code.len() <= 4,
+                "{symbol}: exchangeCode is {:?}, so the text columns may be shifted",
+                print.exchange_code
+            );
+            "TimeAndSale"
+        }
+        MarketEvent::Profile(profile) => {
+            let symbol = &profile.event_symbol;
+            assert!(
+                !profile.description.is_empty(),
+                "{symbol}: description is empty, so the text columns may be shifted"
+            );
+            assert!(
+                profile.high_52_week_price.is_nan()
+                    || profile.low_52_week_price.is_nan()
+                    || profile.high_52_week_price >= profile.low_52_week_price,
+                "{symbol}: 52 week high {} is below the low {}",
+                profile.high_52_week_price,
+                profile.low_52_week_price
+            );
+            "Profile"
+        }
+        MarketEvent::Underlying(surface) => {
+            let symbol = &surface.event_symbol;
+            for (value, field) in [
+                (surface.volatility, "volatility"),
+                (surface.front_volatility, "frontVolatility"),
+                (surface.back_volatility, "backVolatility"),
+            ] {
+                assert!(
+                    value.is_nan() || (0.0..10.0).contains(&value),
+                    "{symbol}: {field} is {value}, which is not a volatility"
+                );
+            }
+            plausible_size(surface.call_volume, "callVolume", symbol);
+            plausible_size(surface.put_volume, "putVolume", symbol);
+            "Underlying"
+        }
+        MarketEvent::TheoPrice(theo) => {
+            let symbol = &theo.event_symbol;
+            plausible_time(theo.time, "time", symbol);
+            assert!(
+                theo.delta.is_nan() || (-1.0..=1.0).contains(&theo.delta),
+                "{symbol}: delta is {}",
+                theo.delta
+            );
+            "TheoPrice"
+        }
+    }
+}
+
+/// Connects and configures the channel for every decodable type.
+async fn open_session() -> (DXLinkClient, tokio::sync::mpsc::Receiver<MarketEvent>, u32) {
+    // Checked rather than defaulted. The demo feed answers an empty token with
+    // UNAUTHORIZED, and letting that surface as a bare connect failure reads
+    // like a client bug instead of a missing credential. Never printed: it goes
+    // straight into the client.
+    let token = env::var("DXLINK_API_TOKEN").unwrap_or_default();
+    assert!(
+        !token.trim().is_empty(),
+        "DXLINK_API_TOKEN is not set. These tests talk to the real dxFeed demo \
+         server, which rejects an empty token, so there is nothing to smoke \
+         without one. Set it in the environment and run again."
+    );
+
+    let mut client = DXLinkClient::new(DEMO_URL, &token);
+    let stream = client
         .connect()
         .await
-        .expect("Fallo al conectar al servidor");
+        .expect("failed to connect to the demo server");
 
     let channel_id = client
         .create_feed_channel("AUTO")
         .await
-        .expect("Fallo al crear canal de feed");
-    info!("Canal de feed creado: {}", channel_id);
+        .expect("failed to create a feed channel");
 
+    // Every type at once, deliberately. `setup_feed` validates the FEED_CONFIG
+    // reply against what we asked for, so a server that disagrees with any of
+    // these field lists fails here rather than silently later.
     client
-        .setup_feed(
-            channel_id,
-            &[
-                EventType::Quote,
-                EventType::Trade,
-                EventType::Greeks,
-                EventType::TimeAndSale,
-            ],
-        )
+        .setup_feed(channel_id, DECODED)
         .await
-        .expect("Fallo al configurar feed");
+        .expect("the server rejected a field list this client requests");
 
-    let event_counter = Arc::new(Mutex::new(0));
-    let event_counter_clone = event_counter.clone();
+    (client, stream, channel_id)
+}
 
-    let stream_task = tokio::spawn(async move {
-        info!("Iniciando procesamiento de stream de eventos");
-        let mut local_counter = 0;
+/// Collects for `COLLECT`, validating everything, and reports which types
+/// arrived and how many events in total.
+async fn collect_and_validate(
+    stream: &mut tokio::sync::mpsc::Receiver<MarketEvent>,
+) -> (BTreeSet<&'static str>, usize) {
+    let mut seen = BTreeSet::new();
+    let mut total = 0usize;
+    let deadline = tokio::time::Instant::now() + COLLECT;
 
-        while local_counter < 5 {
-            match timeout(Duration::from_secs(3), event_stream.recv()).await {
-                Ok(Some(event)) => {
-                    local_counter += 1;
-                    info!("Evento recibido: {:?}", event);
-                    let mut counter = event_counter_clone.lock().unwrap();
-                    *counter += 1;
-                }
-                Ok(None) => {
-                    info!("Stream de eventos cerrado");
-                    break;
-                }
-                Err(_) => {
-                    info!("Timeout esperando evento");
-                    break;
-                }
-            }
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
         }
+        match timeout(remaining, stream.recv()).await {
+            Ok(Some(event)) => {
+                if total < 5 {
+                    // A handful in full, so a failing run shows what the wire
+                    // actually looked like and not just an assertion.
+                    println!("sample: {event:?}");
+                }
+                seen.insert(validate(&event));
+                total += 1;
+            }
+            Ok(None) => panic!("the stream closed mid-session, which is a session failure"),
+            Err(_) => break,
+        }
+    }
 
-        info!(
-            "Procesamiento de eventos completado. Eventos recibidos: {}",
-            local_counter
-        );
-        local_counter
-    });
+    (seen, total)
+}
 
-    let subscriptions = vec![
-        FeedSubscription {
-            event_type: "Quote".to_string(),
-            symbol: "AAPL".to_string(),
-            from_time: None,
-            source: None,
-        },
-        FeedSubscription {
-            event_type: "Trade".to_string(),
-            symbol: "AAPL".to_string(),
-            from_time: None,
-            source: None,
-        },
-        FeedSubscription {
-            event_type: "Quote".to_string(),
-            symbol: "MSFT".to_string(),
-            from_time: None,
-            source: None,
-        },
-        FeedSubscription {
-            event_type: "Quote".to_string(),
-            symbol: "BTC/USD:GDAX".to_string(),
-            from_time: None,
-            source: None,
-        },
-    ];
+/// The main smoke: everything this client can decode, against the real server,
+/// with every arriving event checked for shape.
+#[tokio::test]
+#[ignore = "needs network access to the dxFeed demo server"]
+async fn test_real_server_delivers_well_formed_events() {
+    let (mut client, mut stream, channel_id) = open_session().await;
+
+    let mut subscriptions = Vec::new();
+    for event_type in [
+        "Quote",
+        "Trade",
+        "Summary",
+        "Profile",
+        "TimeAndSale",
+        "Underlying",
+    ] {
+        subscriptions.push(subscription(event_type, EQUITY));
+    }
+    // A second symbol, because a stride error usually shows up as the second
+    // row of a batch carrying the first row's symbol.
+    subscriptions.push(subscription("Quote", OTHER_EQUITY));
+    subscriptions.push(subscription("Trade", OTHER_EQUITY));
+    subscriptions.push(subscription("Candle", CANDLE));
 
     client
         .subscribe(channel_id, subscriptions)
         .await
-        .expect("Fallo al suscribirse");
+        .expect("failed to subscribe");
 
-    let wait_duration = Duration::from_secs(15);
-    info!("Esperando {} segundos", wait_duration.as_secs());
-    sleep(wait_duration).await;
+    let (seen, total) = collect_and_validate(&mut stream).await;
 
-    stream_task.abort();
-    client.disconnect().await.expect("Fallo al desconectar");
+    println!("--- decoded {total} event(s) in {COLLECT:?}");
+    for event_type in DECODED {
+        let name = event_type.to_string();
+        let mark = if seen.contains(name.as_str()) {
+            "yes"
+        } else {
+            "none"
+        };
+        println!("    {name:<12} {mark}");
+    }
 
-    let event_count = *event_counter.lock().unwrap();
-    info!("Total de eventos recibidos: {}", event_count);
-    info!("Test completado exitosamente");
+    // Not "every type arrived": entitlements and market hours decide that, and a
+    // test that depends on them reports the wrong thing when it fails. What must
+    // hold is that the session produced data and none of it was malformed.
+    assert!(
+        total > 0,
+        "no events at all in {COLLECT:?}. Either the feed is closed, the token \
+         has no entitlements, or the subscription never took"
+    );
+    assert!(
+        client.disconnect_reason().is_none(),
+        "the session died during collection: {:?}",
+        client.disconnect_reason()
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// Historical candles are the indexed path: a `fromTime` subscription replays a
+/// snapshot, a different code path from a live update and the one most likely
+/// to expose a wrong `eventFlags` or `index` column.
+#[tokio::test]
+#[ignore = "needs network access to the dxFeed demo server"]
+async fn test_real_server_replays_historical_candles() {
+    let (mut client, mut stream, channel_id) = open_session().await;
+
+    // Fixed and well in the past, so there is something to replay whatever day
+    // this runs on.
+    let from_time = 1_700_000_000_000i64;
+
+    client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Candle".to_string(),
+                symbol: CANDLE.to_string(),
+                from_time: Some(from_time),
+                source: None,
+            }],
+        )
+        .await
+        .expect("failed to subscribe to historical candles");
+
+    let mut bars = Vec::new();
+    let deadline = tokio::time::Instant::now() + COLLECT;
+    while bars.len() < 10 {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match timeout(remaining, stream.recv()).await {
+            Ok(Some(event)) => {
+                validate(&event);
+                if let MarketEvent::Candle(candle) = event {
+                    bars.push(candle);
+                }
+            }
+            Ok(None) => panic!("the stream closed during the replay"),
+            Err(_) => break,
+        }
+    }
+
+    println!("--- replayed {} bar(s)", bars.len());
+    for bar in bars.iter().take(3) {
+        println!(
+            "    t={} o={} h={} l={} c={} v={} flags={} idx={}",
+            bar.time,
+            bar.open,
+            bar.high,
+            bar.low,
+            bar.close,
+            bar.volume,
+            bar.event_flags,
+            bar.index
+        );
+    }
+
+    assert!(
+        !bars.is_empty(),
+        "no historical bars arrived for {CANDLE}; either fromTime was not \
+         honoured or the symbol has no history on this feed"
+    );
+    for bar in &bars {
+        assert_eq!(
+            bar.event_symbol, CANDLE,
+            "a bar came back for another symbol"
+        );
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// The keepalive interval is derived from the server's own `SETUP`, and getting
+/// it wrong means the server hangs up mid-session. Only a real server enforces
+/// that deadline, so this sits idle across one and checks nothing died.
+#[tokio::test]
+#[ignore = "needs network access to the dxFeed demo server"]
+async fn test_real_server_session_survives_an_idle_keepalive_cycle() {
+    let (mut client, mut stream, channel_id) = open_session().await;
+
+    client
+        .subscribe(channel_id, vec![subscription("Quote", EQUITY)])
+        .await
+        .expect("failed to subscribe");
+
+    // Longer than any interval this client derives, so at least one maintenance
+    // beat has to have gone out and been accepted.
+    let idle = Duration::from_secs(75);
+    println!("--- sitting idle for {idle:?} to cross a keepalive cycle");
+
+    let deadline = tokio::time::Instant::now() + idle;
+    loop {
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match timeout(remaining, stream.recv()).await {
+            // Drained rather than ignored: a full queue would drop events and
+            // muddy what this is measuring.
+            Ok(Some(event)) => {
+                validate(&event);
+            }
+            Ok(None) => panic!(
+                "the session died while idle, which is what a wrong keepalive \
+                 looks like: {:?}",
+                client.disconnect_reason()
+            ),
+            Err(_) => break,
+        }
+    }
+
+    assert!(
+        client.disconnect_reason().is_none(),
+        "the session ended during the idle period: {:?}",
+        client.disconnect_reason()
+    );
+
+    // And it is still usable afterwards, not merely un-dead.
+    client
+        .subscribe(channel_id, vec![subscription("Quote", OTHER_EQUITY)])
+        .await
+        .expect("the connection was not usable after sitting idle");
+
+    client.disconnect().await.expect("failed to disconnect");
 }

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -1054,3 +1054,53 @@ async fn test_a_late_config_is_adopted_rather_than_fatal() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+/// A mid-session layout this client cannot read has to **stop** the channel,
+/// not be quietly ignored.
+///
+/// Ignoring it leaves the old layout installed while the server sends rows in
+/// the new one. When the two happen to have the same column count — which is
+/// exactly the case constructed here — that decodes into wrong values instead
+/// of into an error, which is the failure mode this whole area exists to
+/// prevent.
+#[tokio::test]
+async fn test_an_unreadable_reconfiguration_stops_the_channel() {
+    let server = MockServer::start(Behaviour::UnusableConfigMidSession).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut stream = client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("the setup itself is fine");
+
+    client
+        .subscribe(channel_id, vec![quote_subscription("AAPL")])
+        .await
+        .expect("failed to subscribe");
+
+    // Nothing may be delivered.
+    let delivered = tokio::time::timeout(Duration::from_secs(2), stream.recv()).await;
+    assert!(
+        delivered.is_err(),
+        "a layout this client cannot read must stop delivery, got {delivered:?}"
+    );
+
+    // And the channel is stopped, not merely producing an error per batch. This
+    // is the part that distinguishes failing closed from ignoring the config:
+    // with the layout gone, the refusal comes before anything is sent rather
+    // than after every row that arrives.
+    assert!(
+        client
+            .subscribe(channel_id, vec![quote_subscription("MSFT")])
+            .await
+            .is_err(),
+        "a channel whose layout the server moved past must stop accepting work"
+    );
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -3,8 +3,8 @@
 //!
 //! Event delivery is covered in `dxlink_flow.rs`.
 
-use crate::fixture::{Behaviour, MockServer, is_type, is_type_on_channel};
-use dxlink::{DXLinkClient, DXLinkError, EventType, FeedSubscription};
+use crate::fixture::{Behaviour, MockServer, expected, is_type, is_type_on_channel};
+use dxlink::{DXLinkClient, DXLinkError, EventType, FeedSubscription, MarketEvent};
 use std::time::Duration;
 
 #[tokio::test]
@@ -552,30 +552,63 @@ async fn test_a_client_can_reconnect_after_disconnecting() {
     client.disconnect().await.expect("failed to disconnect");
 }
 
+/// A plain Quote subscription, for the layout tests below.
+fn quote_subscription(symbol: &str) -> FeedSubscription {
+    FeedSubscription {
+        event_type: "Quote".to_string(),
+        symbol: symbol.to_string(),
+        from_time: None,
+        source: None,
+    }
+}
+
 // --- FEED_CONFIG validation (issue #12) ------------------------------------
 
-/// A server that reorders the field list must be rejected. Accepting it meant
-/// the decoder kept reading the requested order and attached every value to the
-/// wrong field, with no error anywhere.
+/// A server that reorders the field list is **decoded against that order**,
+/// not refused.
+///
+/// This used to be a rejection, which was the right answer while the decoder
+/// read by position. It reads by name now, so the order the server picks is
+/// simply the order it is read in, and refusing would be turning a
+/// non-problem into a dead channel.
 #[tokio::test]
-async fn test_setup_feed_rejects_a_reordered_field_layout() {
+async fn test_setup_feed_adopts_a_reordered_field_layout() {
     let server = MockServer::start(Behaviour::ReorderedFeedConfig).await;
     let mut client = DXLinkClient::new(&server.url(), "test-token");
-    client.connect().await.expect("failed to connect");
+    let mut stream = client.connect().await.expect("failed to connect");
     let channel_id = client
         .create_feed_channel("AUTO")
         .await
         .expect("failed to create feed channel");
 
-    match client.setup_feed(channel_id, &[EventType::Quote]).await {
-        Err(DXLinkError::Protocol(msg)) => {
-            assert!(msg.contains("Quote"), "which event type is unclear: {msg}");
-            assert!(
-                msg.contains("eventSymbol") && msg.contains("eventType"),
-                "the error should show both layouts: {msg}"
-            );
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("a reordered layout is decodable, so it must be accepted");
+
+    client
+        .subscribe(channel_id, vec![quote_subscription("AAPL")])
+        .await
+        .expect("failed to subscribe");
+
+    let event = tokio::time::timeout(Duration::from_secs(5), stream.recv())
+        .await
+        .expect("no event arrived")
+        .expect("the stream closed");
+
+    // The whole point: the values land in the right fields even though the
+    // server put the columns somewhere else. Reading by position would have
+    // put the symbol in event_type here.
+    match event {
+        MarketEvent::Quote(quote) => {
+            assert_eq!(quote.event_type, "Quote");
+            assert_eq!(quote.event_symbol, "AAPL");
+            assert_eq!(quote.bid_price, expected::BID_PRICE);
+            assert_eq!(quote.ask_price, expected::ASK_PRICE);
+            assert_eq!(quote.bid_size, expected::BID_SIZE);
+            assert_eq!(quote.ask_size, expected::ASK_SIZE);
         }
-        other => panic!("a reordered layout must be rejected, got: {other:?}"),
+        other => panic!("expected a quote, got {other:?}"),
     }
 
     client.disconnect().await.expect("failed to disconnect");
@@ -606,12 +639,9 @@ async fn test_setup_feed_rejects_a_format_it_cannot_decode() {
     client.disconnect().await.expect("failed to disconnect");
 }
 
-/// A reconfiguration that fails validation must not leave the previous layout
-/// installed. It used to: the error returned before replacing the entry, and
-/// because the reply went to the waiter the unsolicited-config path never saw
-/// it, so the channel kept decoding against a contract the server had changed.
+/// A reconfiguration mid-session is adopted, and the channel keeps working.
 #[tokio::test]
-async fn test_a_rejected_reconfiguration_invalidates_the_channel() {
+async fn test_a_reconfiguration_is_adopted_and_the_channel_keeps_working() {
     let server = MockServer::start(Behaviour::ReorderedFeedConfigOnSecondSetup).await;
     let mut client = DXLinkClient::new(&server.url(), "test-token");
     let mut stream = client.connect().await.expect("failed to connect");
@@ -620,41 +650,38 @@ async fn test_a_rejected_reconfiguration_invalidates_the_channel() {
         .await
         .expect("failed to create feed channel");
 
-    // First setup is honoured.
     client
         .setup_feed(channel_id, &[EventType::Quote])
         .await
         .expect("the first setup should succeed");
 
-    // Second one comes back reordered and must be refused.
-    assert!(
-        client
-            .setup_feed(channel_id, &[EventType::Quote])
-            .await
-            .is_err(),
-        "a reordered reconfiguration must be refused"
-    );
+    // The second reply comes back with the columns in a different order, and
+    // that is now something to follow rather than refuse.
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("a reconfiguration this client can decode must be accepted");
 
-    // And the channel is no longer usable at all: with its layout gone there is
-    // nothing to decode against, so the refusal comes before anything is sent
-    // rather than after data arrives.
-    let result = client
-        .subscribe(
-            channel_id,
-            vec![FeedSubscription {
-                event_type: "Quote".to_string(),
-                symbol: "AAPL".to_string(),
-                from_time: None,
-                source: None,
-            }],
-        )
-        .await;
-    assert!(
-        result.is_err(),
-        "a channel whose reconfiguration was refused must not accept subscriptions"
-    );
+    client
+        .subscribe(channel_id, vec![quote_subscription("AAPL")])
+        .await
+        .expect("the channel should still be usable after a reconfiguration");
 
-    let _ = &mut stream;
+    let event = tokio::time::timeout(Duration::from_secs(5), stream.recv())
+        .await
+        .expect("no event arrived after the reconfiguration")
+        .expect("the stream closed");
+
+    match event {
+        MarketEvent::Quote(quote) => {
+            // Decoded against the *new* layout: the old one would have swapped
+            // these two.
+            assert_eq!(quote.event_type, "Quote");
+            assert_eq!(quote.event_symbol, "AAPL");
+            assert_eq!(quote.bid_price, expected::BID_PRICE);
+        }
+        other => panic!("expected a quote, got {other:?}"),
+    }
 
     client.disconnect().await.expect("failed to disconnect");
 }
@@ -917,6 +944,113 @@ async fn test_setup_feed_refuses_an_empty_event_type_list() {
         0,
         "a refused setup still went out"
     );
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// Issue #63, reproduced offline: the server serves **fewer** fields than were
+/// asked for.
+///
+/// The dxFeed demo drops `VWAP` from `Candle`. Reading by position against the
+/// requested 18 columns meant the 17 that arrived were not a whole number of
+/// rows, so the whole batch was discarded and `Candle` delivered nothing at
+/// all. Reading by name, the bar decodes and the missing field reads as `NaN`.
+#[tokio::test]
+async fn test_a_trimmed_layout_still_decodes() {
+    let server = MockServer::start(Behaviour::TrimsCandleVwap).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut stream = client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+
+    client
+        .setup_feed(channel_id, &[EventType::Candle])
+        .await
+        .expect("a server serving a subset is still decodable");
+
+    client
+        .subscribe(
+            channel_id,
+            vec![FeedSubscription {
+                event_type: "Candle".to_string(),
+                symbol: "AAPL{=5m}".to_string(),
+                from_time: None,
+                source: None,
+            }],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    let event = tokio::time::timeout(Duration::from_secs(5), stream.recv())
+        .await
+        .expect("no bar arrived, which is exactly the bug")
+        .expect("the stream closed");
+
+    match event {
+        MarketEvent::Candle(candle) => {
+            // Everything after the missing column still lands correctly, which
+            // is what a positional read could not do.
+            assert_eq!(candle.event_symbol, "AAPL{=5m}");
+            assert_eq!(candle.volume, expected::VOLUME);
+            assert_eq!(candle.bid_volume, expected::BID_VOLUME);
+            assert_eq!(candle.ask_volume, expected::ASK_VOLUME);
+            assert_eq!(candle.imp_volatility, expected::IMP_VOLATILITY);
+            assert_eq!(candle.open_interest, expected::OPEN_INTEREST);
+            // And the one the server does not serve is absent, not wrong.
+            assert!(
+                candle.vwap.is_nan(),
+                "a field the server did not send must not come back as a number: {}",
+                candle.vwap
+            );
+        }
+        other => panic!("expected a candle, got {other:?}"),
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}
+
+/// The other half of issue #63: the real layout arrives **after** the
+/// subscription, not as the reply to `FEED_SETUP`.
+///
+/// The demo server acknowledges the setup with no field list at all, then
+/// reports what it will really serve once there is something to serve. That
+/// second config used to invalidate the channel, so every row that followed was
+/// dropped. It is adopted now.
+#[tokio::test]
+async fn test_a_late_config_is_adopted_rather_than_fatal() {
+    let server = MockServer::start(Behaviour::LateFeedConfig).await;
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut stream = client.connect().await.expect("failed to connect");
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+
+    client
+        .setup_feed(channel_id, &[EventType::Quote])
+        .await
+        .expect("an acknowledgement with no field list is agreement, not a refusal");
+
+    client
+        .subscribe(channel_id, vec![quote_subscription("AAPL")])
+        .await
+        .expect("failed to subscribe");
+
+    let event = tokio::time::timeout(Duration::from_secs(5), stream.recv())
+        .await
+        .expect("no event arrived after the late config")
+        .expect("the stream closed");
+
+    match event {
+        MarketEvent::Quote(quote) => {
+            assert_eq!(quote.event_symbol, "AAPL");
+            assert_eq!(quote.bid_price, expected::BID_PRICE);
+            assert_eq!(quote.ask_price, expected::ASK_PRICE);
+        }
+        other => panic!("expected a quote, got {other:?}"),
+    }
 
     client.disconnect().await.expect("failed to disconnect");
 }

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -71,6 +71,12 @@ pub enum Behaviour {
     NonCompactFeedConfig,
     /// Honour the first FEED_SETUP and reorder the reply to every one after it.
     ReorderedFeedConfigOnSecondSetup,
+    /// Serve `Candle` without `VWAP`, reporting and sending the trimmed layout.
+    /// This is what the dxFeed demo does, and issue #63 is about it.
+    TrimsCandleVwap,
+    /// Acknowledge FEED_SETUP with no field list, then report the real layout
+    /// only once a subscription exists. Also what the dxFeed demo does.
+    LateFeedConfig,
     /// Serve one full session, hang up once the feed is subscribed, then serve
     /// every later connection normally. Drives a reconnect that succeeds.
     DropFirstSession,
@@ -286,29 +292,6 @@ impl MockServer {
                             "service": value["service"].as_str().unwrap_or("FEED"),
                             "parameters": {}
                         })),
-                        "FEED_SETUP"
-                            if behaviour == Behaviour::ReorderedFeedConfig
-                                || (behaviour == Behaviour::ReorderedFeedConfigOnSecondSetup
-                                    && {
-                                        feed_setups_seen += 1;
-                                        feed_setups_seen > 1
-                                    }) =>
-                        {
-                            let mut reordered = value["acceptEventFields"]["Quote"]
-                                .as_array()
-                                .cloned()
-                                .unwrap_or_default();
-                            // Guard: a fixture panic would mask the behaviour under
-                            // test rather than reporting it.
-                            if reordered.len() >= 2 {
-                                reordered.swap(0, 1);
-                            }
-                            responses.push(json!({
-                                "channel": channel, "type": "FEED_CONFIG",
-                                "aggregationPeriod": 0.1, "dataFormat": "COMPACT",
-                                "eventFields": { "Quote": reordered }
-                            }));
-                        }
                         "FEED_SETUP" if behaviour == Behaviour::NonCompactFeedConfig => {
                             responses.push(json!({
                                 "channel": channel, "type": "FEED_CONFIG",
@@ -316,11 +299,17 @@ impl MockServer {
                             }));
                         }
                         "FEED_SETUP" => {
-                            // Remember exactly which fields the client asked for, in
-                            // order: that is the wire layout it will decode against.
+                            feed_setups_seen += 1;
+
+                            // The layout this server will actually serve. A real
+                            // one does not always agree with the request, so the
+                            // fixture has to be able to disagree too — and it
+                            // reports and serves the *same* list, which is the
+                            // property that makes these tests mean anything.
+                            let mut effective: Vec<(String, Vec<String>)> = Vec::new();
                             if let Some(fields) = value["acceptEventFields"].as_object() {
                                 for (event_type, list) in fields {
-                                    let order: Vec<String> = list
+                                    let mut order: Vec<String> = list
                                         .as_array()
                                         .map(|a| {
                                             a.iter()
@@ -328,16 +317,50 @@ impl MockServer {
                                                 .collect()
                                         })
                                         .unwrap_or_default();
-                                    event_fields.insert((channel, event_type.clone()), order);
+
+                                    let reorders = behaviour == Behaviour::ReorderedFeedConfig
+                                        || (behaviour
+                                            == Behaviour::ReorderedFeedConfigOnSecondSetup
+                                            && feed_setups_seen > 1);
+                                    if reorders && event_type == "Quote" && order.len() >= 2 {
+                                        // Guard on the length: a fixture panic would
+                                        // mask the behaviour under test.
+                                        order.swap(0, 1);
+                                    }
+                                    if behaviour == Behaviour::TrimsCandleVwap {
+                                        order.retain(|field| field != "VWAP");
+                                    }
+
+                                    effective.push((event_type.clone(), order));
                                 }
                             }
-                            responses.push(json!({
-                                "channel": channel,
-                                "type": "FEED_CONFIG",
-                                "aggregationPeriod": 0.1,
-                                "dataFormat": "COMPACT",
-                                "eventFields": value["acceptEventFields"].clone()
-                            }));
+
+                            for (event_type, order) in &effective {
+                                event_fields.insert((channel, event_type.clone()), order.clone());
+                            }
+
+                            let reported: serde_json::Map<String, Value> = effective
+                                .iter()
+                                .map(|(event_type, order)| (event_type.clone(), json!(order)))
+                                .collect();
+
+                            if behaviour == Behaviour::LateFeedConfig {
+                                // What the dxFeed demo does: acknowledge with no
+                                // field list at all, and report the real one only
+                                // once there is a subscription.
+                                responses.push(json!({
+                                    "channel": channel, "type": "FEED_CONFIG",
+                                    "aggregationPeriod": 0.1, "dataFormat": "COMPACT"
+                                }));
+                            } else {
+                                responses.push(json!({
+                                    "channel": channel,
+                                    "type": "FEED_CONFIG",
+                                    "aggregationPeriod": 0.1,
+                                    "dataFormat": "COMPACT",
+                                    "eventFields": reported
+                                }));
+                            }
                         }
                         "FEED_SUBSCRIPTION" => {
                             if let Some(add) = value.get("add").and_then(|a| a.as_array()) {
@@ -349,6 +372,16 @@ impl MockServer {
                                     else {
                                         continue;
                                     };
+                                    if behaviour == Behaviour::LateFeedConfig {
+                                        // The real layout, announced now rather
+                                        // than at setup, and immediately before
+                                        // the data that uses it.
+                                        responses.push(json!({
+                                            "channel": channel, "type": "FEED_CONFIG",
+                                            "aggregationPeriod": 0.1, "dataFormat": "COMPACT",
+                                            "eventFields": { event_type: order.clone() }
+                                        }));
+                                    }
                                     let row: Vec<Value> = order
                                         .iter()
                                         .map(|field| field_value(field, event_type, symbol))

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -525,10 +525,10 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "dayHighPrice" => json!(152.0),
         "dayLowPrice" => json!(148.0),
         "prevDayClosePrice" => json!(147.75),
-        "dayId" => json!(20240119i64),
+        "dayId" => json!(20100i64),
         "dayClosePrice" => json!(150.75),
         "dayClosePriceType" => json!("Final"),
-        "prevDayId" => json!(20240118i64),
+        "prevDayId" => json!(20099i64),
         "prevDayClosePriceType" => json!("Final"),
         "prevDayVolume" => json!(58_000_000.0),
         "openInterest" => json!(4_200.0),
@@ -560,7 +560,7 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "earningsPerShare" => json!(6.13),
         "dividendFrequency" => json!(4.0),
         "exDividendAmount" => json!(0.24),
-        "exDividendDayId" => json!(20240209i64),
+        "exDividendDayId" => json!(20050i64),
         "shares" => json!(15_552_800_000.0),
         "freeFloat" => json!(15_461_900_000.0),
         // Underlying (volatility is shared with Greeks)
@@ -621,13 +621,13 @@ pub mod expected {
     pub const ASK_VOLUME: f64 = 634_000.0;
     pub const IMP_VOLATILITY: f64 = 0.31;
     pub const OPEN_INTEREST: f64 = 4_200.0;
-    pub const DAY_ID: i64 = 20240119;
+    pub const DAY_ID: i64 = 20100;
     pub const DAY_OPEN_PRICE: f64 = 149.5;
     pub const DAY_HIGH_PRICE: f64 = 152.0;
     pub const DAY_LOW_PRICE: f64 = 148.0;
     pub const DAY_CLOSE_PRICE: f64 = 150.75;
     pub const DAY_CLOSE_PRICE_TYPE: &str = "Final";
-    pub const PREV_DAY_ID: i64 = 20240118;
+    pub const PREV_DAY_ID: i64 = 20099;
     pub const PREV_DAY_CLOSE_PRICE: f64 = 147.75;
     pub const PREV_DAY_CLOSE_PRICE_TYPE: &str = "Final";
     pub const PREV_DAY_VOLUME: f64 = 58_000_000.0;
@@ -656,7 +656,7 @@ pub mod expected {
     pub const EARNINGS_PER_SHARE: f64 = 6.13;
     pub const DIVIDEND_FREQUENCY: f64 = 4.0;
     pub const EX_DIVIDEND_AMOUNT: f64 = 0.24;
-    pub const EX_DIVIDEND_DAY_ID: i64 = 20240209;
+    pub const EX_DIVIDEND_DAY_ID: i64 = 20050;
     pub const SHARES: f64 = 15_552_800_000.0;
     pub const FREE_FLOAT: f64 = 15_461_900_000.0;
     pub const FRONT_VOLATILITY: f64 = 0.28;

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -77,6 +77,11 @@ pub enum Behaviour {
     /// Acknowledge FEED_SETUP with no field list, then report the real layout
     /// only once a subscription exists. Also what the dxFeed demo does.
     LateFeedConfig,
+    /// Honour FEED_SETUP, then announce a mid-session layout with no
+    /// `eventSymbol` — one this client cannot identify rows with — while
+    /// keeping the column count the same, so a client that ignored it would
+    /// decode the rows into the wrong fields instead of erroring.
+    UnusableConfigMidSession,
     /// Serve one full session, hang up once the feed is subscribed, then serve
     /// every later connection normally. Drives a reconnect that succeeds.
     DropFirstSession,
@@ -372,6 +377,26 @@ impl MockServer {
                                     else {
                                         continue;
                                     };
+                                    if behaviour == Behaviour::UnusableConfigMidSession {
+                                        // Same width, no eventSymbol: the shape
+                                        // that decodes silently if it is not
+                                        // refused.
+                                        let unusable: Vec<String> = order
+                                            .iter()
+                                            .map(|field| {
+                                                if field == "eventSymbol" {
+                                                    "someFieldWeDoNotKnow".to_string()
+                                                } else {
+                                                    field.clone()
+                                                }
+                                            })
+                                            .collect();
+                                        responses.push(json!({
+                                            "channel": channel, "type": "FEED_CONFIG",
+                                            "aggregationPeriod": 0.1, "dataFormat": "COMPACT",
+                                            "eventFields": { event_type: unusable }
+                                        }));
+                                    }
                                     if behaviour == Behaviour::LateFeedConfig {
                                         // The real layout, announced now rather
                                         // than at setup, and immediately before


### PR DESCRIPTION
## Summary

`Candle` delivered **nothing at all** against the real dxFeed server. Not slowly, not wrongly — zero events, while bars were arriving the whole time.

Stacked on #62, whose smoke tests found this.

## What was happening

The server serves 17 `Candle` columns; it will not serve `VWAP`. The decoder read 18 by position, so the arithmetic did not divide, every batch was discarded, and the second `FEED_CONFIG` was read as "the server reconfigured this channel" and invalidated it.

`VWAP` is spelled correctly — the AsyncAPI spec has it at line 1524. The server simply does not serve it on this feed.

The root assumption, from the era when `compact_fields()` became the single source of truth, was:

> the server returns the fields we asked for, in the order we asked for them

The **order** part holds. The **set** does not.

## The fix

**Columns are read by name.** A field the server leaves out reads as not provided — `NaN` for a double, `0` for an integer, empty for text, `false` for a flag — rather than as whatever sat next to it. `eventType` and `eventSymbol` must still be present, because without them a row cannot be identified at all.

Three consequences, all deliberate:

- **A reordered list is now adopted, not refused.** Refusing was right while the decode was positional; it is now turning a harmless difference into a dead channel. `test_setup_feed_rejects_a_reordered_field_layout` becomes `..._adopts_...` and asserts the values land in the right fields, which is a stronger claim than the rejection it replaces.
- **A mid-session `FEED_CONFIG` is adopted**, not treated as grounds for invalidation. The demo server acknowledges `FEED_SETUP` with no field list at all, then reports the real one once a subscription exists — the exact sequence that killed the channel.
- **What still invalidates**: a non-COMPACT format, an unreadable `FEED_CONFIG`, and a layout with no `eventType`/`eventSymbol`. Those are genuinely undecodable rather than merely different.

The safety property that mattered is intact: 17 columns are never read as 18. It is just no longer the case that the only alternative is delivering nothing.

## Public API impact

None. `parse_compact_data` and `try_parse_compact_data` keep their signatures and still decode against `compact_fields()`, which is the right default with no channel in play. The client uses a crate-internal entry point that takes the negotiated layout.

`setup_feed` no longer returns an error for a reordered layout. That is a behaviour change, and a deliberate one.

## Testing

**Against the real server**: the historical candle smoke went from `replayed 0 bar(s)` to `replayed 10 bar(s)`, with OHLC in the right fields and `vwap` as `NaN`.

**Offline**, the mock can now negotiate a layout different from the one requested — it reports and serves the *same* list, which is the property that makes any of this meaningful. Two new behaviours reproduce the real server:

- `TrimsCandleVwap` — serves 17 columns. The test asserts every field after the gap still lands correctly and that `vwap` is `NaN` rather than a number.
- `LateFeedConfig` — acknowledges with no field list, reports the real layout after the subscription.

Both fail without the fix; the trimmed one fails with "no bar arrived, which is exactly the bug".

Also in this branch, as its own commit: the `basic` example defaulted to tastytrade's delayed endpoint, which rejects an empty token, so cloning the repo and running the example produced an `UNAUTHORIZED` that looked like a broken client. It points at the anonymous demo now.

- [x] `make check` and `cargo build --workspace --all-features` clean (exit codes checked explicitly)

Closes #63
