### PR TITLE
Decode TradeETH events end to end (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ to DXLink servers, subscribing to market events, and processing real-time market
   believes is live.
 - Automatic keepalives while the connection is open.
 - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-  `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`, `Underlying` and
-  `TheoPrice`**, each with the full field set the dxFeed schema defines for it.
+  `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`, `Underlying`,
+  `TheoPrice` and `TradeETH`**, each with the full field set the dxFeed
+  schema defines for it.
 - Both delivery styles: a per-symbol callback and a single event stream.
 - Historical data via `from_time` on a `Candle` subscription, decoded into
   OHLC bars.
@@ -48,7 +49,7 @@ to DXLink servers, subscribing to market events, and processing real-time market
 
 - [`EventType`] declares more variants than the library can decode. Only
   `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`,
-  `Underlying` and `TheoPrice` produce a [`MarketEvent`], and
+  `Underlying`, `TheoPrice` and `TradeETH` produce a [`MarketEvent`], and
   configuring or subscribing to any other type is **refused** rather than
   accepted into a stream that can never produce.
 
@@ -219,6 +220,7 @@ are decoded into a [`MarketEvent`] and delivered:
 | `Profile` | the full 20-column layout: description, trading status and halt window, price limits, 52-week range and the fundamentals |
 | `Underlying` | the full 13-column layout: implied volatility with its term structure, call and put volume and their ratio |
 | `TheoPrice` | the full 13-column layout: the theoretical price with the underlying price, delta, gamma, dividend and interest it came from |
+| `TradeETH` | the full 15-column layout: the extended-hours print, its session volume and turnover, tick direction and the extended-hours flag |
 
 Configuring or subscribing to any other variant (`Order`, `Series`,
 …) is **refused**, rather than accepted into a stream that can

--- a/src/client.rs
+++ b/src/client.rs
@@ -1538,6 +1538,7 @@ fn symbol_of(event: &MarketEvent) -> &str {
         MarketEvent::Profile(e) => &e.event_symbol,
         MarketEvent::Underlying(e) => &e.event_symbol,
         MarketEvent::TheoPrice(e) => &e.event_symbol,
+        MarketEvent::TradeETH(e) => &e.event_symbol,
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -946,7 +946,9 @@ pub struct TradeETHEvent {
     pub day_turnover: f64,
 
     /// Which way the price moved against the previous print: `UP`, `DOWN`,
-    /// `ZERO_UP`, `ZERO_DOWN` or `UNDEFINED`.
+    /// `ZERO`, `ZERO_UP`, `ZERO_DOWN` or `UNDEFINED`.
+    ///
+    /// A delayed feed sends `UNDEFINED` for most prints.
     #[serde(rename = "tickDirection")]
     pub tick_direction: String,
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -259,6 +259,23 @@ impl EventType {
                 "shares",
                 "freeFloat",
             ]),
+            EventType::TradeETH => Some(&[
+                "eventType",
+                "eventSymbol",
+                "eventTime",
+                "time",
+                "timeNanoPart",
+                "sequence",
+                "exchangeCode",
+                "price",
+                "change",
+                "size",
+                "dayId",
+                "dayVolume",
+                "dayTurnover",
+                "tickDirection",
+                "extendedTradingHours",
+            ]),
             EventType::TimeAndSale => Some(&[
                 "eventType",
                 "eventSymbol",
@@ -325,7 +342,6 @@ impl EventType {
             ]),
             // Declared by the protocol, not decoded here.
             EventType::Order
-            | EventType::TradeETH
             | EventType::SpreadOrder
             | EventType::Series
             | EventType::Configuration
@@ -865,6 +881,83 @@ pub struct TimeAndSaleEvent {
     pub seller: String,
 }
 
+/// One extended-hours print: the last trade of the pre- or post-market session.
+///
+/// The counterpart to [`TradeEvent`], and not a curiosity on a US feed: between
+/// 04:00 and 09:30 and again from 16:00 to 20:00 ET, `Trade` is silent and this
+/// is the only print there is.
+///
+/// Every field the dxFeed AsyncAPI schema defines for it, confirmed against the
+/// `FEED_CONFIG` the server actually returns rather than copied from `Trade`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TradeETHEvent {
+    /// The type of the event, `TradeETH`.
+    #[serde(rename = "eventType")]
+    pub event_type: String,
+
+    /// The symbol that traded.
+    #[serde(rename = "eventSymbol")]
+    pub event_symbol: String,
+
+    /// When the server emitted the event, as epoch milliseconds.
+    ///
+    /// A live feed sends `0` here when it did not populate it.
+    #[serde(rename = "eventTime")]
+    pub event_time: i64,
+
+    /// When the print happened, as epoch milliseconds.
+    pub time: i64,
+
+    /// Sub-millisecond part of `time`, in nanoseconds.
+    #[serde(rename = "timeNanoPart")]
+    pub time_nano_part: i64,
+
+    /// Sequence number, separating prints that share a millisecond.
+    pub sequence: i64,
+
+    /// Exchange the print came from, as its single-character code.
+    #[serde(rename = "exchangeCode")]
+    pub exchange_code: String,
+
+    /// Execution price.
+    #[serde(with = "json_double")]
+    pub price: f64,
+
+    /// Change against the previous close, `NaN` when the venue does not compute
+    /// it — which on a delayed feed is the usual answer.
+    #[serde(with = "json_double")]
+    pub change: f64,
+
+    /// Executed size.
+    #[serde(with = "json_double")]
+    pub size: f64,
+
+    /// The trading day this print belongs to, as **days since the Unix epoch**
+    /// rather than `yyyymmdd`.
+    #[serde(rename = "dayId")]
+    pub day_id: i64,
+
+    /// Cumulative volume for the day, extended hours included.
+    #[serde(rename = "dayVolume", with = "json_double")]
+    pub day_volume: f64,
+
+    /// Cumulative turnover for the day, price times size summed.
+    #[serde(rename = "dayTurnover", with = "json_double")]
+    pub day_turnover: f64,
+
+    /// Which way the price moved against the previous print: `UP`, `DOWN`,
+    /// `ZERO_UP`, `ZERO_DOWN` or `UNDEFINED`.
+    #[serde(rename = "tickDirection")]
+    pub tick_direction: String,
+
+    /// Whether the print happened outside regular trading hours.
+    ///
+    /// The reason this event type exists, and `true` on every row a real
+    /// extended-hours session produces.
+    #[serde(rename = "extendedTradingHours")]
+    pub extended_trading_hours: bool,
+}
+
 /// The option surface over an underlying: implied volatility and the call/put
 /// balance.
 ///
@@ -1043,6 +1136,16 @@ pub enum MarketEvent {
     /// which contains details about a specific quote event, including the type of event,
     /// the symbol it relates to, and the bid and ask prices and sizes.
     Quote(QuoteEvent),
+    /// One extended-hours print: the last trade of the pre- or post-market
+    /// session.
+    ///
+    /// **Ahead of `Trade` on purpose, against the usual rule of appending.**
+    /// Every field `TradeEvent` declares is also in this one, so an untagged
+    /// match tries `Trade` first and succeeds, and a `TradeETH` payload comes
+    /// back as a `Trade` with its extended-hours flag and session volume
+    /// silently gone. The more specific variant has to be tried first.
+    /// `test_each_new_type_round_trips_as_its_own_variant` fails if this moves.
+    TradeETH(TradeETHEvent),
     /// Represents a Trade event. This is typically a market trade that has occurred.
     Trade(TradeEvent),
     /// Represents a Greeks event, containing Greek values (delta, gamma, theta, vega, rho)
@@ -1060,11 +1163,20 @@ pub enum MarketEvent {
     Underlying(UnderlyingEvent),
     /// A theoretical option price with the inputs it was computed from.
     ///
-    /// New variants go last on purpose: `MarketEvent` is `#[serde(untagged)]`,
-    /// so serde tries them in declaration order and keeps the first that
-    /// deserializes. Appending leaves every variant already in the list
-    /// matching exactly as it did. Each type has a round-trip test that would
-    /// catch one variant stealing another's payload.
+    /// `MarketEvent` is `#[serde(untagged)]`, so serde tries the variants in
+    /// declaration order and keeps the first that deserializes — and it
+    /// deserializes as long as every field *that variant* declares is present,
+    /// ignoring any extras.
+    ///
+    /// So the rule is **most specific first**, not simply "append". Appending
+    /// is right whenever the new type is not a superset of an existing one,
+    /// which is the common case. When it is a superset, the existing variant
+    /// matches first and quietly drops the extra fields: see `TradeETH`, which
+    /// contains all of `Trade` and therefore sits ahead of it.
+    ///
+    /// Each type has a round-trip test, and
+    /// `test_each_new_type_round_trips_as_its_own_variant` is what catches a
+    /// variant stealing another's payload.
     TheoPrice(TheoPriceEvent),
 }
 
@@ -1803,6 +1915,32 @@ mod event_serde_tests {
         }
     }
 
+    /// Values from a real row the demo server sent for AAPL.
+    fn trade_eth() -> TradeETHEvent {
+        TradeETHEvent {
+            event_type: "TradeETH".to_string(),
+            event_symbol: "AAPL".to_string(),
+            event_time: 0,
+            time: 1_785_542_396_498,
+            time_nano_part: 0,
+            sequence: 3_009_441,
+            exchange_code: "D".to_string(),
+            price: 307.3554,
+            change: f64::NAN,
+            size: 600.0,
+            day_id: 20665,
+            day_volume: 11_085_372.061_196,
+            day_turnover: 3_417_052_245.055_67,
+            tick_direction: "UNDEFINED".to_string(),
+            extended_trading_hours: true,
+        }
+    }
+
+    #[test]
+    fn test_trade_eth_serde_names_match_its_layout() {
+        assert_wire_contract(&trade_eth(), EventType::TradeETH);
+    }
+
     #[test]
     fn test_theo_price_serde_names_match_its_layout() {
         assert_wire_contract(&theo_price(), EventType::TheoPrice);
@@ -1871,6 +2009,7 @@ mod event_serde_tests {
             MarketEvent::Profile(profile()),
             MarketEvent::Underlying(underlying()),
             MarketEvent::TheoPrice(theo_price()),
+            MarketEvent::TradeETH(trade_eth()),
         ] {
             let serialized = to_string(&event).expect("serialize");
             let back: MarketEvent = from_str(&serialized).expect("round trip");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,8 +15,9 @@
 //!   believes is live.
 //! - Automatic keepalives while the connection is open.
 //! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
-//!   `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`, `Underlying` and
-//!   `TheoPrice`**, each with the full field set the dxFeed schema defines for it.
+//!   `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`, `Underlying`,
+//!   `TheoPrice` and `TradeETH`**, each with the full field set the dxFeed
+//!   schema defines for it.
 //! - Both delivery styles: a per-symbol callback and a single event stream.
 //! - Historical data via `from_time` on a `Candle` subscription, decoded into
 //!   OHLC bars.
@@ -46,7 +47,7 @@
 //!
 //! - [`EventType`] declares more variants than the library can decode. Only
 //!   `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`,
-//!   `Underlying` and `TheoPrice` produce a [`MarketEvent`], and
+//!   `Underlying`, `TheoPrice` and `TradeETH` produce a [`MarketEvent`], and
 //!   configuring or subscribing to any other type is **refused** rather than
 //!   accepted into a stream that can never produce.
 //!
@@ -217,6 +218,7 @@
 //! | `Profile` | the full 20-column layout: description, trading status and halt window, price limits, 52-week range and the fundamentals |
 //! | `Underlying` | the full 13-column layout: implied volatility with its term structure, call and put volume and their ratio |
 //! | `TheoPrice` | the full 13-column layout: the theoretical price with the underlying price, delta, gamma, dividend and interest it came from |
+//! | `TradeETH` | the full 15-column layout: the extended-hours print, its session volume and turnover, tick direction and the extended-hours flag |
 //!
 //! Configuring or subscribing to any other variant (`Order`, `Series`,
 //! …) is **refused**, rather than accepted into a stream that can

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use crate::MarketEvent;
 use crate::error::{DXLinkError, DXLinkResult};
 use crate::events::{
     CandleEvent, CompactData, EventType, GreeksEvent, ProfileEvent, QuoteEvent, SummaryEvent,
-    TheoPriceEvent, TimeAndSaleEvent, TradeEvent, UnderlyingEvent,
+    TheoPriceEvent, TimeAndSaleEvent, TradeETHEvent, TradeEvent, UnderlyingEvent,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -518,6 +518,23 @@ fn build_event(event_type: EventType, row: &Row<'_>) -> DXLinkResult<MarketEvent
             gamma: row.double("gamma")?,
             dividend: row.double("dividend")?,
             interest: row.double("interest")?,
+        }),
+        EventType::TradeETH => MarketEvent::TradeETH(TradeETHEvent {
+            event_type: event_type_name,
+            event_symbol: symbol,
+            event_time: row.int("eventTime")?,
+            time: row.int("time")?,
+            time_nano_part: row.int("timeNanoPart")?,
+            sequence: row.int("sequence")?,
+            exchange_code: row.text("exchangeCode")?,
+            price: row.double("price")?,
+            change: row.double("change")?,
+            size: row.double("size")?,
+            day_id: row.int("dayId")?,
+            day_volume: row.double("dayVolume")?,
+            day_turnover: row.double("dayTurnover")?,
+            tick_direction: row.text("tickDirection")?,
+            extended_trading_hours: row.flag("extendedTradingHours")?,
         }),
         // compact_fields returned Some for this type, so a missing arm here is a
         // bug in this match rather than a protocol problem.
@@ -1883,5 +1900,146 @@ mod theo_price_tests {
             matches!(back, MarketEvent::TheoPrice(_)),
             "an untagged round trip picked the wrong variant: {back:?}"
         );
+    }
+}
+
+#[cfg(test)]
+mod trade_eth_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// A row exactly as the demo server sent it for AAPL, values included.
+    /// Copied from a capture rather than invented, because the point of this
+    /// type is that its layout was confirmed rather than inferred from `Trade`.
+    fn print_row(symbol: &str) -> Vec<Value> {
+        vec![
+            json!("TradeETH"),           // 0 eventType
+            json!(symbol),               // 1 eventSymbol
+            json!(0i64),                 // 2 eventTime, sent as 0 by a live feed
+            json!(1_785_542_396_498i64), // 3 time
+            json!(0i64),                 // 4 timeNanoPart
+            json!(3_009_441i64),         // 5 sequence
+            json!("D"),                  // 6 exchangeCode
+            json!(307.3554),             // 7 price
+            json!("NaN"),                // 8 change
+            json!(600.0),                // 9 size
+            json!(20665i64),             // 10 dayId
+            json!(11_085_372.061_196),   // 11 dayVolume
+            json!(3_417_052_245.055_67), // 12 dayTurnover
+            json!("UNDEFINED"),          // 13 tickDirection
+            json!(true),                 // 14 extendedTradingHours
+        ]
+    }
+
+    fn batch(values: Vec<Value>) -> Vec<CompactData> {
+        vec![
+            CompactData::EventType("TradeETH".to_string()),
+            CompactData::Values(values),
+        ]
+    }
+
+    #[test]
+    fn test_the_field_list_matches_the_decoder_stride() {
+        let fields = EventType::TradeETH
+            .compact_fields()
+            .expect("TradeETH has a decoder");
+        assert_eq!(fields.len(), 15, "the layout the server confirmed is 15");
+        assert_eq!(fields.len(), print_row("AAPL").len());
+    }
+
+    #[test]
+    fn test_a_real_row_decodes_field_for_field() {
+        let events = try_parse_compact_data(&batch(print_row("AAPL"))).expect("well formed");
+        match &events[0] {
+            MarketEvent::TradeETH(print) => {
+                assert_eq!(print.event_symbol, "AAPL");
+                assert_eq!(print.event_time, 0);
+                assert_eq!(print.time, 1_785_542_396_498);
+                assert_eq!(print.time_nano_part, 0);
+                assert_eq!(print.sequence, 3_009_441);
+                assert_eq!(print.exchange_code, "D");
+                assert_eq!(print.price, 307.3554);
+                assert!(print.change.is_nan(), "the venue sends NaN here");
+                assert_eq!(print.size, 600.0);
+                assert_eq!(print.day_id, 20665);
+                assert_eq!(print.day_volume, 11_085_372.061_196);
+                assert_eq!(print.day_turnover, 3_417_052_245.055_67);
+                assert_eq!(print.tick_direction, "UNDEFINED");
+                // The whole reason the type exists.
+                assert!(print.extended_trading_hours);
+            }
+            other => panic!("expected an extended-hours print, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_two_prints_decode_with_the_right_stride() {
+        let mut values = print_row("AAPL");
+        values.extend(print_row("MSFT"));
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        assert_eq!(events.len(), 2);
+        match (&events[0], &events[1]) {
+            (MarketEvent::TradeETH(first), MarketEvent::TradeETH(second)) => {
+                assert_eq!(first.event_symbol, "AAPL");
+                assert_eq!(second.event_symbol, "MSFT");
+            }
+            other => panic!("expected two prints, got {other:?}"),
+        }
+    }
+
+    /// The point of issue #66: an undecodable type does not merely go missing,
+    /// it abandons the rest of the batch it appears in.
+    #[test]
+    fn test_a_batch_mixing_trade_and_trade_eth_decodes_whole() {
+        let mut data = batch(print_row("AAPL"));
+        data.push(CompactData::EventType("Trade".to_string()));
+        data.push(CompactData::Values(vec![
+            json!("Trade"),
+            json!("MSFT"),
+            json!(464.72),
+            json!(100.0),
+            json!(60_845_971.0),
+        ]));
+
+        let events = try_parse_compact_data(&data).expect("both types decode now");
+        assert_eq!(
+            events.len(),
+            2,
+            "a TradeETH row used to abort the batch and take the Trade with it"
+        );
+        assert!(matches!(events[0], MarketEvent::TradeETH(_)));
+        assert!(matches!(events[1], MarketEvent::Trade(_)));
+    }
+
+    #[test]
+    fn test_a_numeric_tick_direction_is_rejected() {
+        let mut values = print_row("AAPL");
+        values[13] = json!(1.0);
+
+        let error = try_parse_compact_data(&batch(values)).expect_err("the column is text");
+        assert!(
+            error.to_string().contains("tickDirection"),
+            "the field is missing: {error}"
+        );
+    }
+
+    #[test]
+    fn test_a_regular_hours_print_is_distinguishable() {
+        let mut values = print_row("AAPL");
+        values[14] = json!(false);
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        match &events[0] {
+            MarketEvent::TradeETH(print) => assert!(!print.extended_trading_hours),
+            other => panic!("expected a print, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_truncated_print_row_is_rejected() {
+        let mut values = print_row("AAPL");
+        values.pop();
+        assert!(try_parse_compact_data(&batch(values)).is_err());
     }
 }

--- a/tests/integration/dxlink_flow.rs
+++ b/tests/integration/dxlink_flow.rs
@@ -1047,3 +1047,91 @@ async fn test_theo_prices_reach_the_stream_and_the_callback() {
 
     client.disconnect().await.expect("failed to disconnect");
 }
+
+/// Issue #66: extended-hours prints reach both delivery paths.
+#[tokio::test]
+async fn test_extended_hours_prints_reach_the_stream_and_the_callback() {
+    let server = MockServer::start(Behaviour::Normal).await;
+
+    let mut client = DXLinkClient::new(&server.url(), "test-token");
+    let mut event_stream = client.connect().await.expect("failed to connect");
+
+    let channel_id = client
+        .create_feed_channel("AUTO")
+        .await
+        .expect("failed to create feed channel");
+    client
+        .setup_feed(channel_id, &[EventType::TradeETH])
+        .await
+        .expect("failed to set up feed");
+
+    let delivered = Arc::new(Mutex::new(Vec::new()));
+    let sink = delivered.clone();
+    client.on_event("AAPL", move |event| {
+        sink.lock().expect("callback lock poisoned").push(event);
+    });
+
+    client
+        .subscribe(
+            channel_id,
+            vec![
+                FeedSubscription {
+                    event_type: "TradeETH".to_string(),
+                    symbol: "AAPL".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+                FeedSubscription {
+                    event_type: "TradeETH".to_string(),
+                    symbol: "MSFT".to_string(),
+                    from_time: None,
+                    source: None,
+                },
+            ],
+        )
+        .await
+        .expect("failed to subscribe");
+
+    let events = collect_events(&mut event_stream, 2).await;
+    assert_eq!(events.len(), 2, "expected two prints, got {events:?}");
+
+    let print = events
+        .iter()
+        .find_map(|event| match event {
+            MarketEvent::TradeETH(print) if print.event_symbol == "AAPL" => Some(print),
+            _ => None,
+        })
+        .expect("no TradeETH for AAPL reached the stream");
+
+    assert_eq!(print.event_type, "TradeETH");
+    assert_eq!(print.time, expected::TIME);
+    assert_eq!(print.exchange_code, expected::EXCHANGE_CODE);
+    assert_eq!(print.price, expected::PRICE);
+    assert_eq!(print.change, expected::CHANGE);
+    assert_eq!(print.size, expected::SIZE);
+    assert_eq!(print.day_id, expected::DAY_ID);
+    assert_eq!(print.day_volume, expected::DAY_VOLUME);
+    assert_eq!(print.day_turnover, expected::DAY_TURNOVER);
+    assert_eq!(print.tick_direction, expected::TICK_DIRECTION);
+    assert_eq!(
+        print.extended_trading_hours,
+        expected::EXTENDED_TRADING_HOURS
+    );
+
+    // The callback routes through symbol_of, which needed a new arm.
+    let seen: Vec<MarketEvent> = {
+        let events = delivered.lock().expect("callback lock poisoned");
+        events.clone()
+    };
+    match seen.as_slice() {
+        [MarketEvent::TradeETH(print)] => {
+            assert_eq!(print.event_symbol, "AAPL");
+            // A consumer acting on an extended-hours last price reads this
+            // before it moves anything.
+            assert!(print.extended_trading_hours);
+        }
+        other => panic!("the callback for AAPL should have received one print, got {other:?}"),
+    }
+
+    client.disconnect().await.expect("failed to disconnect");
+}

--- a/tests/integration/dxlink_real.rs
+++ b/tests/integration/dxlink_real.rs
@@ -77,6 +77,7 @@ const DECODED: &[EventType] = &[
     EventType::Profile,
     EventType::Underlying,
     EventType::TheoPrice,
+    EventType::TradeETH,
 ];
 
 /// Turns on tracing when `RUST_LOG` asks for it.
@@ -304,6 +305,29 @@ fn validate(event: &MarketEvent) -> &'static str {
             plausible_size(surface.put_volume, "putVolume", symbol);
             "Underlying"
         }
+        MarketEvent::TradeETH(print) => {
+            let symbol = &print.event_symbol;
+            plausible_time(print.time, "time", symbol);
+            plausible_price(print.price, "price", symbol);
+            plausible_size(print.size, "size", symbol);
+            plausible_size(print.day_volume, "dayVolume", symbol);
+            plausible_day_id(print.day_id, "dayId", symbol);
+            assert!(
+                print.exchange_code.len() <= 4,
+                "{symbol}: exchangeCode is {:?}, so the text columns may be shifted",
+                print.exchange_code
+            );
+            // Bounded set, so a shifted column lands outside it.
+            assert!(
+                matches!(
+                    print.tick_direction.as_str(),
+                    "UP" | "DOWN" | "ZERO" | "ZERO_UP" | "ZERO_DOWN" | "UNDEFINED"
+                ),
+                "{symbol}: tickDirection is {:?}, which is not one of the venue's values",
+                print.tick_direction
+            );
+            "TradeETH"
+        }
         MarketEvent::TheoPrice(theo) => {
             let symbol = &theo.event_symbol;
             plausible_time(theo.time, "time", symbol);
@@ -394,6 +418,7 @@ async fn test_real_server_delivers_well_formed_events() {
         "Profile",
         "TimeAndSale",
         "Underlying",
+        "TradeETH",
     ] {
         subscriptions.push(subscription(event_type, EQUITY));
     }

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -631,6 +631,11 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "underlyingPrice" => json!(152.4),
         "dividend" => json!(0.55),
         "interest" => json!(4.75),
+        // TradeETH (time, price, size, dayVolume, exchangeCode, dayId and
+        // extendedTradingHours are shared with the events above)
+        "change" => json!(-1.25),
+        "dayTurnover" => json!(3_417_052_245.055_67),
+        "tickDirection" => json!("UP"),
         // Greeks
         "delta" => json!(0.65),
         "gamma" => json!(0.05),
@@ -725,6 +730,9 @@ pub mod expected {
     pub const UNDERLYING_PRICE: f64 = 152.4;
     pub const DIVIDEND: f64 = 0.55;
     pub const INTEREST: f64 = 4.75;
+    pub const CHANGE: f64 = -1.25;
+    pub const DAY_TURNOVER: f64 = 3_417_052_245.055_67;
+    pub const TICK_DIRECTION: &str = "UP";
 }
 
 /// Convenience predicates for `wait_for`.


### PR DESCRIPTION
## Summary

`TradeETH` decodes. It is the extended-hours counterpart to `Trade`, and during the pre- and post-market sessions it is the only print there is.

## The layout was confirmed, not inferred

Both the issue and the acceptance criteria insist on this, so: I opened a channel on the real demo server, sent a `FEED_SETUP` asking for the spec's full list, and read back what it agreed to.

The server accepts all **15** columns with no trimming:

```
eventType, eventSymbol, eventTime, time, timeNanoPart, sequence, exchangeCode,
price, change, size, dayId, dayVolume, dayTurnover, tickDirection,
extendedTradingHours
```

Worth noting these are **not** `Trade`'s five plus extras — `dayTurnover`, `tickDirection` and the `extendedTradingHours` flag have no counterpart in `Trade` at all. Copying `Trade` would have produced something that decoded and was wrong.

A captured row, used verbatim in the tests:

```
["TradeETH","AAPL",0,1785542396498,0,3009441,"D",307.3554,"NaN",600.0,20665,
 1.1085372061196E7,3.41705224505567E9,"UNDEFINED",true]
```

`change` arrives as the string `"NaN"`, which the JSONDouble path already handles, and `dayId` is 20665 — days since the epoch, 2026-07-31 — the same convention as `Summary`.

## The variant is *not* appended last

This is the one place I did not follow the issue's instructions, and the reason is worth stating.

Every field `TradeEvent` declares is also in `TradeETHEvent`. `MarketEvent` is `#[serde(untagged)]`, so serde tries variants in declaration order and accepts the first whose *own* fields are all present, ignoring extras. Appending therefore means a `TradeETH` payload deserializes as a `Trade` — with its session volume, tick direction and extended-hours flag silently dropped.

I implemented it appended first and let `test_each_new_type_round_trips_as_its_own_variant` catch it, which it did, reporting the wrong discriminant. The variant now sits ahead of `Trade`, and the doc comment on the enum states the actual rule — **most specific first**, of which "append" is the common case rather than the law.

## Public API impact

`TradeETHEvent` and `MarketEvent::TradeETH` are additive types, but the new variant **breaks any downstream exhaustive match** on `MarketEvent`. A 0.x minor bump, so 0.4.0. The compiler demonstrated this immediately by failing the smoke test's own `match`.

## Testing

- The field list length is pinned against the decoder's row width.
- A real captured row decodes field for field, including `change` as `NaN` and the extended-hours flag.
- **A batch mixing `Trade` and `TradeETH` decodes whole.** This is the issue's real point: an undecodable type did not merely go missing, it returned `Protocol` and abandoned everything after it in the frame.
- Two rows prove the stride; a numeric `tickDirection` is rejected; a truncated row is rejected; a regular-hours print is distinguishable.
- End to end against the mock, both the stream and a per-symbol callback.
- The real-server smoke now configures and validates `TradeETH` too, including a `tickDirection` drawn from the venue's bounded set — and it decoded live: `extended_trading_hours: true` on a real AAPL print.

- [x] `make check`, `cargo build --workspace --all-features` and `cargo doc` with `-D warnings` clean (exit codes checked explicitly)

Closes #66
