### PR TITLE
Decode Series events end to end (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
 - Automatic keepalives while the connection is open.
 - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
   `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`, `Underlying`,
-  `TheoPrice` and `TradeETH`**, each with the full field set the dxFeed
-  schema defines for it.
+  `TheoPrice`, `TradeETH` and `Series`**, each with the full field set the
+  dxFeed schema defines for it.
 - Both delivery styles: a per-symbol callback and a single event stream.
 - Historical data via `from_time` on a `Candle` subscription, decoded into
   OHLC bars.
@@ -49,7 +49,8 @@ to DXLink servers, subscribing to market events, and processing real-time market
 
 - [`EventType`] declares more variants than the library can decode. Only
   `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`,
-  `Underlying`, `TheoPrice` and `TradeETH` produce a [`MarketEvent`], and
+  `Underlying`, `TheoPrice`, `TradeETH` and `Series` produce a
+  [`MarketEvent`], and
   configuring or subscribing to any other type is **refused** rather than
   accepted into a stream that can never produce.
 
@@ -221,8 +222,9 @@ are decoded into a [`MarketEvent`] and delivered:
 | `Underlying` | the full 13-column layout: implied volatility with its term structure, call and put volume and their ratio |
 | `TheoPrice` | the full 13-column layout: the theoretical price with the underlying price, delta, gamma, dividend and interest it came from |
 | `TradeETH` | the full 15-column layout: the extended-hours print, its session volume and turnover, tick direction and the extended-hours flag |
+| `Series` | the full 15-column layout: per-expiration implied volatility, call and put volume, forward price and the dividend and interest inputs |
 
-Configuring or subscribing to any other variant (`Order`, `Series`,
+Configuring or subscribing to any other variant (`Order`, `SpreadOrder`,
 …) is **refused**, rather than accepted into a stream that can
 never produce.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -1539,6 +1539,7 @@ fn symbol_of(event: &MarketEvent) -> &str {
         MarketEvent::Underlying(e) => &e.event_symbol,
         MarketEvent::TheoPrice(e) => &e.event_symbol,
         MarketEvent::TradeETH(e) => &e.event_symbol,
+        MarketEvent::Series(e) => &e.event_symbol,
     }
 }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -259,6 +259,23 @@ impl EventType {
                 "shares",
                 "freeFloat",
             ]),
+            EventType::Series => Some(&[
+                "eventType",
+                "eventSymbol",
+                "eventTime",
+                "eventFlags",
+                "index",
+                "time",
+                "sequence",
+                "expiration",
+                "volatility",
+                "callVolume",
+                "putVolume",
+                "putCallRatio",
+                "forwardPrice",
+                "dividend",
+                "interest",
+            ]),
             EventType::TradeETH => Some(&[
                 "eventType",
                 "eventSymbol",
@@ -343,7 +360,6 @@ impl EventType {
             // Declared by the protocol, not decoded here.
             EventType::Order
             | EventType::SpreadOrder
-            | EventType::Series
             | EventType::Configuration
             | EventType::Message => None,
         }
@@ -881,6 +897,88 @@ pub struct TimeAndSaleEvent {
     pub seller: String,
 }
 
+/// One option expiration's computed values for an underlying.
+///
+/// The streaming counterpart to polling a REST option chain: a subscription
+/// replays one of these per expiration as a snapshot, delimited by
+/// `event_flags`, and updates them as the surface moves.
+///
+/// Every field the dxFeed AsyncAPI schema defines for it, confirmed against the
+/// `FEED_CONFIG` the server returns and against a captured row, rather than
+/// extrapolated from [`UnderlyingEvent`] or [`TheoPriceEvent`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SeriesEvent {
+    /// The type of the event, `Series`.
+    #[serde(rename = "eventType")]
+    pub event_type: String,
+
+    /// The underlying the expiration belongs to.
+    #[serde(rename = "eventSymbol")]
+    pub event_symbol: String,
+
+    /// When the server emitted the event, as epoch milliseconds.
+    ///
+    /// A live feed sends `0` here when it did not populate it.
+    #[serde(rename = "eventTime")]
+    pub event_time: i64,
+
+    /// Transactional and snapshot bits.
+    ///
+    /// A subscription replays every expiration as one snapshot, and these
+    /// delimit it. **The last row of that snapshot is a marker, not an
+    /// expiration**: a real feed ends a 24-row AAPL chain with `event_flags`
+    /// 10 and `index`, `expiration`, `volatility` and `forward_price` all
+    /// zeroed or `NaN`. A consumer that reads it as data gets a phantom
+    /// expiration 0. The first row carries 4.
+    ///
+    /// Filter on this being non-zero before treating a row as an expiration.
+    #[serde(rename = "eventFlags")]
+    pub event_flags: i64,
+
+    /// Unique index of the record, ordering it within the stream.
+    pub index: i64,
+
+    /// When the values were computed, as epoch milliseconds.
+    pub time: i64,
+
+    /// Sequence number, separating records that share a millisecond.
+    pub sequence: i64,
+
+    /// The expiration this record is for, as **days since the Unix epoch**
+    /// rather than `yyyymmdd`. A real feed sends 21533 for 2028-12-15.
+    ///
+    /// Zero on the snapshot marker row — see [`event_flags`](Self::event_flags).
+    pub expiration: i64,
+
+    /// Implied volatility for this expiration, as a fraction.
+    #[serde(with = "json_double")]
+    pub volatility: f64,
+
+    /// Call option volume for the day, at this expiration.
+    #[serde(rename = "callVolume", with = "json_double")]
+    pub call_volume: f64,
+
+    /// Put option volume for the day, at this expiration.
+    #[serde(rename = "putVolume", with = "json_double")]
+    pub put_volume: f64,
+
+    /// Put volume over call volume.
+    #[serde(rename = "putCallRatio", with = "json_double")]
+    pub put_call_ratio: f64,
+
+    /// Implied forward price of the underlying at this expiration.
+    #[serde(rename = "forwardPrice", with = "json_double")]
+    pub forward_price: f64,
+
+    /// Dividend rate used as an input.
+    #[serde(with = "json_double")]
+    pub dividend: f64,
+
+    /// Interest rate used as an input.
+    #[serde(with = "json_double")]
+    pub interest: f64,
+}
+
 /// One extended-hours print: the last trade of the pre- or post-market session.
 ///
 /// The counterpart to [`TradeEvent`], and not a curiosity on a US feed: between
@@ -1163,6 +1261,13 @@ pub enum MarketEvent {
     Profile(ProfileEvent),
     /// The option surface over an underlying: implied volatility and volumes.
     Underlying(UnderlyingEvent),
+    /// One option expiration's computed values for an underlying.
+    ///
+    /// Appended, which is the ordinary case: no existing variant's fields are
+    /// a subset of this one, so nothing already in the list can claim a
+    /// `Series` payload. `UnderlyingEvent` comes closest and still needs
+    /// `frontVolatility`, which is not here.
+    Series(SeriesEvent),
     /// A theoretical option price with the inputs it was computed from.
     ///
     /// `MarketEvent` is `#[serde(untagged)]`, so serde tries the variants in
@@ -1938,6 +2043,32 @@ mod event_serde_tests {
         }
     }
 
+    /// Values from a real row the demo server sent for AAPL.
+    fn series() -> SeriesEvent {
+        SeriesEvent {
+            event_type: "Series".to_string(),
+            event_symbol: "AAPL".to_string(),
+            event_time: 0,
+            event_flags: 4,
+            index: 23,
+            time: 1_785_542_361_974,
+            sequence: 0,
+            expiration: 21533,
+            volatility: 0.3188,
+            call_volume: 8526.0,
+            put_volume: 1899.0,
+            put_call_ratio: 0.222_730_471_498_944_4,
+            forward_price: 335.174_395_879_884,
+            dividend: 0.0,
+            interest: 0.0,
+        }
+    }
+
+    #[test]
+    fn test_series_serde_names_match_its_layout() {
+        assert_wire_contract(&series(), EventType::Series);
+    }
+
     #[test]
     fn test_trade_eth_serde_names_match_its_layout() {
         assert_wire_contract(&trade_eth(), EventType::TradeETH);
@@ -2012,6 +2143,7 @@ mod event_serde_tests {
             MarketEvent::Underlying(underlying()),
             MarketEvent::TheoPrice(theo_price()),
             MarketEvent::TradeETH(trade_eth()),
+            MarketEvent::Series(series()),
         ] {
             let serialized = to_string(&event).expect("serialize");
             let back: MarketEvent = from_str(&serialized).expect("round trip");

--- a/src/events.rs
+++ b/src/events.rs
@@ -931,7 +931,11 @@ pub struct SeriesEvent {
     /// zeroed or `NaN`. A consumer that reads it as data gets a phantom
     /// expiration 0. The first row carries 4.
     ///
-    /// Filter on this being non-zero before treating a row as an expiration.
+    /// **Non-zero flags do not mean "marker"** — that first row has them and is
+    /// real data, so filtering on them drops an expiration. What identifies the
+    /// marker is [`expiration`](Self::expiration) being zero, which only ever
+    /// happens with flags set. The spec does not document what the individual
+    /// bits mean, so this describes what a real feed was observed to send.
     #[serde(rename = "eventFlags")]
     pub event_flags: i64,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,8 +16,8 @@
 //! - Automatic keepalives while the connection is open.
 //! - Market events decoded from the `COMPACT` wire format: **`Quote`, `Trade`,
 //!   `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`, `Underlying`,
-//!   `TheoPrice` and `TradeETH`**, each with the full field set the dxFeed
-//!   schema defines for it.
+//!   `TheoPrice`, `TradeETH` and `Series`**, each with the full field set the
+//!   dxFeed schema defines for it.
 //! - Both delivery styles: a per-symbol callback and a single event stream.
 //! - Historical data via `from_time` on a `Candle` subscription, decoded into
 //!   OHLC bars.
@@ -47,7 +47,8 @@
 //!
 //! - [`EventType`] declares more variants than the library can decode. Only
 //!   `Quote`, `Trade`, `Greeks`, `Candle`, `Summary`, `TimeAndSale`, `Profile`,
-//!   `Underlying`, `TheoPrice` and `TradeETH` produce a [`MarketEvent`], and
+//!   `Underlying`, `TheoPrice`, `TradeETH` and `Series` produce a
+//!   [`MarketEvent`], and
 //!   configuring or subscribing to any other type is **refused** rather than
 //!   accepted into a stream that can never produce.
 //!
@@ -219,8 +220,9 @@
 //! | `Underlying` | the full 13-column layout: implied volatility with its term structure, call and put volume and their ratio |
 //! | `TheoPrice` | the full 13-column layout: the theoretical price with the underlying price, delta, gamma, dividend and interest it came from |
 //! | `TradeETH` | the full 15-column layout: the extended-hours print, its session volume and turnover, tick direction and the extended-hours flag |
+//! | `Series` | the full 15-column layout: per-expiration implied volatility, call and put volume, forward price and the dividend and interest inputs |
 //!
-//! Configuring or subscribing to any other variant (`Order`, `Series`,
+//! Configuring or subscribing to any other variant (`Order`, `SpreadOrder`,
 //! …) is **refused**, rather than accepted into a stream that can
 //! never produce.
 //!

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,8 +6,8 @@
 use crate::MarketEvent;
 use crate::error::{DXLinkError, DXLinkResult};
 use crate::events::{
-    CandleEvent, CompactData, EventType, GreeksEvent, ProfileEvent, QuoteEvent, SummaryEvent,
-    TheoPriceEvent, TimeAndSaleEvent, TradeETHEvent, TradeEvent, UnderlyingEvent,
+    CandleEvent, CompactData, EventType, GreeksEvent, ProfileEvent, QuoteEvent, SeriesEvent,
+    SummaryEvent, TheoPriceEvent, TimeAndSaleEvent, TradeETHEvent, TradeEvent, UnderlyingEvent,
 };
 use serde_json::Value;
 use std::collections::HashMap;
@@ -519,6 +519,23 @@ fn build_event(event_type: EventType, row: &Row<'_>) -> DXLinkResult<MarketEvent
             dividend: row.double("dividend")?,
             interest: row.double("interest")?,
         }),
+        EventType::Series => MarketEvent::Series(SeriesEvent {
+            event_type: event_type_name,
+            event_symbol: symbol,
+            event_time: row.int("eventTime")?,
+            event_flags: row.int("eventFlags")?,
+            index: row.int("index")?,
+            time: row.int("time")?,
+            sequence: row.int("sequence")?,
+            expiration: row.int("expiration")?,
+            volatility: row.double("volatility")?,
+            call_volume: row.double("callVolume")?,
+            put_volume: row.double("putVolume")?,
+            put_call_ratio: row.double("putCallRatio")?,
+            forward_price: row.double("forwardPrice")?,
+            dividend: row.double("dividend")?,
+            interest: row.double("interest")?,
+        }),
         EventType::TradeETH => MarketEvent::TradeETH(TradeETHEvent {
             event_type: event_type_name,
             event_symbol: symbol,
@@ -840,11 +857,21 @@ mod strict_tests {
 
     #[test]
     fn test_an_undecodable_event_type_is_reported() {
-        // Series is deliberately chosen: it is not on the roadmap of types
-        // gaining decoders, so this test stops needing an edit each time one
-        // does.
-        let error = try_parse_compact_data(&batch("Series", vec![json!("Series"), json!("AAPL")]))
-            .expect_err("Series has no decoder");
+        // Whichever type still has no decoder, rather than a name hardcoded
+        // here. The previous version named Series and had to be edited the day
+        // Series gained one, which is the wrong thing to spend an edit on.
+        let Some(undecodable) = crate::events::ALL_EVENT_TYPES
+            .iter()
+            .find(|event_type| event_type.compact_fields().is_none())
+        else {
+            // Every declared type decodes. Nothing left to report, and this
+            // test has nothing to say until the protocol adds one.
+            return;
+        };
+
+        let name = undecodable.to_string();
+        let error = try_parse_compact_data(&batch(&name, vec![json!(name.clone())]))
+            .expect_err("a type with no decoder must be reported, not skipped");
         assert!(error.to_string().contains("no decoder"), "{error}");
     }
 
@@ -2041,5 +2068,215 @@ mod trade_eth_tests {
         let mut values = print_row("AAPL");
         values.pop();
         assert!(try_parse_compact_data(&batch(values)).is_err());
+    }
+}
+
+#[cfg(test)]
+mod series_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// One expiration exactly as the demo server sent it for AAPL. Captured
+    /// rather than invented: the issue asks for the layout to be confirmed
+    /// against a real row, not extrapolated from Underlying or TheoPrice.
+    fn series_row(symbol: &str, expiration: i64) -> Vec<Value> {
+        vec![
+            json!("Series"),                // 0 eventType
+            json!(symbol),                  // 1 eventSymbol
+            json!(0i64),                    // 2 eventTime, sent as 0 by a live feed
+            json!(4i64),                    // 3 eventFlags, the snapshot bit
+            json!(23i64),                   // 4 index
+            json!(1_785_542_361_974i64),    // 5 time
+            json!(0i64),                    // 6 sequence
+            json!(expiration),              // 7 expiration
+            json!(0.3188),                  // 8 volatility
+            json!(8526.0),                  // 9 callVolume
+            json!(1899.0),                  // 10 putVolume
+            json!(0.222_730_471_498_944_4), // 11 putCallRatio
+            json!(335.174_395_879_884),     // 12 forwardPrice
+            json!(0.0),                     // 13 dividend
+            json!(0.0),                     // 14 interest
+        ]
+    }
+
+    fn batch(values: Vec<Value>) -> Vec<CompactData> {
+        vec![
+            CompactData::EventType("Series".to_string()),
+            CompactData::Values(values),
+        ]
+    }
+
+    #[test]
+    fn test_the_field_list_matches_the_decoder_stride() {
+        let fields = EventType::Series
+            .compact_fields()
+            .expect("Series has a decoder");
+        assert_eq!(fields.len(), 15, "the layout the server confirmed is 15");
+        assert_eq!(fields.len(), series_row("AAPL", 21533).len());
+    }
+
+    #[test]
+    fn test_a_real_row_decodes_field_for_field() {
+        let events =
+            try_parse_compact_data(&batch(series_row("AAPL", 21533))).expect("well formed");
+        match &events[0] {
+            MarketEvent::Series(series) => {
+                assert_eq!(series.event_symbol, "AAPL");
+                assert_eq!(series.event_time, 0);
+                assert_eq!(series.event_flags, 4);
+                assert_eq!(series.index, 23);
+                assert_eq!(series.time, 1_785_542_361_974);
+                assert_eq!(series.sequence, 0);
+                // Days since the epoch, 2028-12-15. Not yyyymmdd.
+                assert_eq!(series.expiration, 21533);
+                assert_eq!(series.volatility, 0.3188);
+                assert_eq!(series.call_volume, 8526.0);
+                assert_eq!(series.put_volume, 1899.0);
+                assert_eq!(series.put_call_ratio, 0.222_730_471_498_944_4);
+                assert_eq!(series.forward_price, 335.174_395_879_884);
+                assert_eq!(series.dividend, 0.0);
+                assert_eq!(series.interest, 0.0);
+            }
+            other => panic!("expected a series, got {other:?}"),
+        }
+    }
+
+    /// A subscription replays the whole chain in one batch, one row per
+    /// expiration, which is how the real server sends it.
+    #[test]
+    fn test_a_whole_chain_decodes_expiration_by_expiration() {
+        let mut values = series_row("AAPL", 21533);
+        values.extend(series_row("AAPL", 21260));
+        values.extend(series_row("AAPL", 21204));
+
+        let events = try_parse_compact_data(&batch(values)).expect("well formed");
+        assert_eq!(events.len(), 3);
+
+        let expirations: Vec<i64> = events
+            .iter()
+            .map(|event| match event {
+                MarketEvent::Series(series) => series.expiration,
+                other => panic!("expected a series, got {other:?}"),
+            })
+            .collect();
+        // The stride of fifteen is what keeps these distinct.
+        assert_eq!(expirations, [21533, 21260, 21204]);
+    }
+
+    /// The point of issue #67: an undecodable type does not merely go missing,
+    /// it abandons the rest of the batch it appears in.
+    #[test]
+    fn test_a_batch_mixing_series_and_quote_decodes_whole() {
+        let mut data = batch(series_row("AAPL", 21533));
+        data.push(CompactData::EventType("Quote".to_string()));
+        data.push(CompactData::Values(vec![
+            json!("Quote"),
+            json!("AAPL"),
+            json!(307.33),
+            json!(307.35),
+            json!(2160.0),
+            json!(80.0),
+        ]));
+
+        let events = try_parse_compact_data(&data).expect("both types decode now");
+        assert_eq!(
+            events.len(),
+            2,
+            "a Series row used to abort the batch and take the Quote with it"
+        );
+        assert!(matches!(events[0], MarketEvent::Series(_)));
+        assert!(matches!(events[1], MarketEvent::Quote(_)));
+    }
+
+    #[test]
+    fn test_an_expiration_with_no_options_traded_decodes() {
+        // No volume on either side leaves the ratio undefined, and the protocol
+        // sends NaN rather than omitting the column.
+        let mut values = series_row("AAPL", 21533);
+        values[9] = json!(0.0);
+        values[10] = json!(0.0);
+        values[11] = json!("NaN");
+
+        let events = try_parse_compact_data(&batch(values)).expect("NaN is a value");
+        match &events[0] {
+            MarketEvent::Series(series) => {
+                assert_eq!(series.call_volume, 0.0);
+                assert!(series.put_call_ratio.is_nan());
+            }
+            other => panic!("expected a series, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_a_fractional_expiration_is_rejected() {
+        let mut values = series_row("AAPL", 21533);
+        values[7] = json!(21533.5);
+
+        let error =
+            try_parse_compact_data(&batch(values)).expect_err("a day count is a whole number");
+        assert!(
+            error.to_string().contains("expiration"),
+            "the field is missing: {error}"
+        );
+    }
+
+    #[test]
+    fn test_a_truncated_series_row_is_rejected() {
+        let mut values = series_row("AAPL", 21533);
+        values.pop();
+        assert!(try_parse_compact_data(&batch(values)).is_err());
+    }
+}
+
+#[cfg(test)]
+mod series_snapshot_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The row a real feed ends a Series snapshot with: flags set, everything
+    /// else zeroed or NaN. Captured from the demo server, which closes a
+    /// 24-row AAPL chain exactly like this.
+    fn marker_row() -> Vec<Value> {
+        vec![
+            json!("Series"),
+            json!("AAPL"),
+            json!(0i64),
+            json!(10i64), // eventFlags: the snapshot terminator
+            json!(0i64),
+            json!(1_785_542_361_974i64),
+            json!(0i64),
+            json!(0i64), // expiration: not an expiration at all
+            json!("NaN"),
+            json!("NaN"),
+            json!("NaN"),
+            json!("NaN"),
+            json!("NaN"),
+            json!("NaN"),
+            json!("NaN"),
+        ]
+    }
+
+    #[test]
+    fn test_the_snapshot_marker_decodes_and_is_distinguishable() {
+        let events = try_parse_compact_data(&[
+            CompactData::EventType("Series".to_string()),
+            CompactData::Values(marker_row()),
+        ])
+        .expect("the marker is a well formed row and must not error");
+
+        match &events[0] {
+            MarketEvent::Series(series) => {
+                // It has to decode, because erroring here would abandon the
+                // rest of the batch it closes.
+                assert_eq!(series.expiration, 0);
+                assert!(series.volatility.is_nan());
+                // And a consumer has to be able to tell it apart from data.
+                assert_ne!(
+                    series.event_flags, 0,
+                    "the marker is only distinguishable by its flags"
+                );
+            }
+            other => panic!("expected a series, got {other:?}"),
+        }
     }
 }

--- a/tests/integration/dxlink_real.rs
+++ b/tests/integration/dxlink_real.rs
@@ -78,6 +78,7 @@ const DECODED: &[EventType] = &[
     EventType::Underlying,
     EventType::TheoPrice,
     EventType::TradeETH,
+    EventType::Series,
 ];
 
 /// Turns on tracing when `RUST_LOG` asks for it.
@@ -305,6 +306,35 @@ fn validate(event: &MarketEvent) -> &'static str {
             plausible_size(surface.put_volume, "putVolume", symbol);
             "Underlying"
         }
+        MarketEvent::Series(series) => {
+            let symbol = &series.event_symbol;
+            plausible_time(series.time, "time", symbol);
+            // A snapshot ends with a marker row rather than an expiration: the
+            // real feed sends eventFlags 10 with index, expiration and every
+            // value zeroed or NaN. Requiring a day id unconditionally fails on
+            // it, so the assertion is that a zero expiration only ever comes
+            // with flags set — which still catches a genuinely shifted column.
+            if series.expiration == 0 {
+                assert_ne!(
+                    series.event_flags, 0,
+                    "{symbol}: expiration 0 on a row with no flags is a shifted column, \
+                     not a snapshot marker"
+                );
+            } else {
+                plausible_day_id(series.expiration, "expiration", symbol);
+            }
+            assert!(
+                series.volatility.is_nan() || (0.0..10.0).contains(&series.volatility),
+                "{symbol}: volatility is {}, which is not a volatility",
+                series.volatility
+            );
+            plausible_size(series.call_volume, "callVolume", symbol);
+            plausible_size(series.put_volume, "putVolume", symbol);
+            if series.event_flags == 0 {
+                plausible_price(series.forward_price, "forwardPrice", symbol);
+            }
+            "Series"
+        }
         MarketEvent::TradeETH(print) => {
             let symbol = &print.event_symbol;
             plausible_time(print.time, "time", symbol);
@@ -419,6 +449,7 @@ async fn test_real_server_delivers_well_formed_events() {
         "TimeAndSale",
         "Underlying",
         "TradeETH",
+        "Series",
     ] {
         subscriptions.push(subscription(event_type, EQUITY));
     }

--- a/tests/integration/dxlink_test.rs
+++ b/tests/integration/dxlink_test.rs
@@ -796,9 +796,9 @@ async fn test_setup_feed_refuses_a_type_it_cannot_decode() {
         .await
         .expect("failed to create feed channel");
 
-    match client.setup_feed(channel_id, &[EventType::Series]).await {
+    match client.setup_feed(channel_id, &[EventType::Order]).await {
         Err(DXLinkError::Protocol(msg)) => {
-            assert!(msg.contains("Series"), "the type is missing: {msg}");
+            assert!(msg.contains("Order"), "the type is missing: {msg}");
             // The error has to say what does work, or it is a dead end.
             assert!(msg.contains("Quote"), "the usable types are missing: {msg}");
         }
@@ -839,7 +839,7 @@ async fn test_subscribe_refuses_a_type_it_cannot_decode() {
         .subscribe(
             channel_id,
             vec![FeedSubscription {
-                event_type: "Series".to_string(),
+                event_type: "Order".to_string(),
                 symbol: "AAPL".to_string(),
                 from_time: None,
                 source: None,
@@ -849,7 +849,7 @@ async fn test_subscribe_refuses_a_type_it_cannot_decode() {
 
     match result {
         Err(DXLinkError::Protocol(msg)) => {
-            assert!(msg.contains("Series"), "the type is missing: {msg}");
+            assert!(msg.contains("Order"), "the type is missing: {msg}");
             assert!(msg.contains("AAPL"), "the symbol is missing: {msg}");
         }
         other => panic!("an undecodable subscription must be refused, got: {other:?}"),

--- a/tests/integration/fixture.rs
+++ b/tests/integration/fixture.rs
@@ -636,6 +636,10 @@ fn field_value(field: &str, event_type: &str, symbol: &str) -> Value {
         "change" => json!(-1.25),
         "dayTurnover" => json!(3_417_052_245.055_67),
         "tickDirection" => json!("UP"),
+        // Series (volatility, callVolume, putVolume and putCallRatio are shared
+        // with Underlying; dividend and interest with TheoPrice)
+        "expiration" => json!(21533i64),
+        "forwardPrice" => json!(335.174_395_879_884),
         // Greeks
         "delta" => json!(0.65),
         "gamma" => json!(0.05),
@@ -733,6 +737,8 @@ pub mod expected {
     pub const CHANGE: f64 = -1.25;
     pub const DAY_TURNOVER: f64 = 3_417_052_245.055_67;
     pub const TICK_DIRECTION: &str = "UP";
+    pub const EXPIRATION: i64 = 21533;
+    pub const FORWARD_PRICE: f64 = 335.174_395_879_884;
 }
 
 /// Convenience predicates for `wait_for`.


### PR DESCRIPTION
## Summary

`Series` decodes. The issue's open question — whether the venue publishes it at the entitlement in use — is answered: **it does, richly.** A subscription for AAPL replays the whole option chain as a 24-row snapshot, one row per expiration.

Stacked on #68.

## The layout was confirmed, not extrapolated

I opened a channel on the real demo server, asked for the spec's full list, and read back what it agreed to. All **15** columns, no trimming:

```
eventType, eventSymbol, eventTime, eventFlags, index, time, sequence, expiration,
volatility, callVolume, putVolume, putCallRatio, forwardPrice, dividend, interest
```

## Two things only a real row could have taught

**`expiration` is days since the Unix epoch**, not `yyyymmdd`. The feed sends 21533 for 2028-12-15 — the same convention as `dayId`, and the same trap.

**The snapshot ends with a marker, not an expiration.** The 24th row of that AAPL chain arrives with `eventFlags` 10 and `index`, `expiration`, `volatility` and `forwardPrice` all zeroed or `NaN`. A consumer reading it as data gets a phantom expiration 0 with no volatility.

It has to *decode* rather than error — erroring would abandon the rest of the batch it closes, which is the exact failure this issue is about. So it decodes, it is documented on `event_flags`, and a test asserts both that it survives and that it stays distinguishable by its flags.

The spec does not document what the `eventFlags` bits mean, so the docs state what was observed rather than naming bits I could not verify.

That also caught a bad assertion in the real-server smoke: it demanded a plausible day id unconditionally and failed on the marker. It now asserts that a zero `expiration` only ever comes with flags set, which still catches a genuinely shifted column but does not misread the protocol.

## Ordering

Appended, which is the ordinary case here. No existing variant's fields are a subset of this one — `UnderlyingEvent` comes closest and still needs `frontVolatility`, which `Series` does not carry. So nothing already in the list can claim a `Series` payload, unlike the `TradeETH` case in #68.

## Public API impact

`SeriesEvent` and `MarketEvent::Series` are additive, but the new variant **breaks any downstream exhaustive match**. A 0.x minor bump.

## Housekeeping

Two tests used `Series` as their stand-in for "a type with no decoder", one of them with a comment explaining that Series was chosen because it would never gain one. That reasoning just expired. The unit test now picks whichever type still has no decoder at runtime, so it stops needing an edit each time one lands; the integration test names `Order`.

## Testing

- The field list length is pinned against the decoder's row width.
- A real captured row decodes field for field.
- A whole chain decodes expiration by expiration — three rows, three distinct expirations, which is what the stride of 15 buys.
- **A batch mixing `Series` and `Quote` decodes whole**, which is the issue's actual point.
- The snapshot marker decodes and is distinguishable.
- An expiration with no options traded decodes with `NaN`; a fractional expiration and a truncated row are rejected.
- Live against the real server: 31 events decoded, `Series` among them.

- [x] `make check`, `cargo build --workspace --all-features` and `cargo doc` with `-D warnings` clean (exit codes checked explicitly)

Closes #67
