### PR TITLE
Bump to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dxlink"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2024"
 # Measured, not guessed: 1.87 rejects the let-chains this crate uses.
 # Raising this is a compatibility break for consumers and belongs in release notes.


### PR DESCRIPTION
Version bump for the 0.3.1 release.

**Breaking change shipping as a patch, by explicit decision.** `MarketEvent::TradeETH` (#66) and `MarketEvent::Series` (#67) break exhaustive matches on `MarketEvent`. Verified: a consumer written against 0.3.0 fails with `E0004: non-exhaustive patterns`.

`0.3.1` satisfies `^0.3.0`, so a `cargo update` picks it up and can break a downstream build that changed nothing. Semver would put this in 0.4.0. Recorded here and in the release notes so anyone hitting the failure finds the reason.

- [x] `make check` and `cargo build --workspace --all-features` clean